### PR TITLE
Add homepage and sticky menu

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -12,6 +12,9 @@ const queryClient = new QueryClient({
 const MindmapCanvas = lazy(() => import('./mindmapcanvas'))
 const TodoDashboard = lazy(() => import('./tododashboard'))
 const AboutModulePage = lazy(() => import('./aboutmodulepage'))
+const Homepage = lazy(() => import('./homepage'))
+const PaymentPage = lazy(() => import('./paymentpage'))
+const LoginPage = lazy(() => import('./login'))
 
 function ErrorFallback({ error, resetErrorBoundary }) {
   return (
@@ -42,11 +45,13 @@ function App() {
           <Layout>
             <Suspense fallback={<LoadingSpinner />}>
               <Routes>
-                <Route path="/" element={<Navigate to="/mindmap" replace />} />
+                <Route path="/" element={<Homepage />} />
                 <Route path="/mindmap" element={<MindmapCanvas />} />
                 <Route path="/todos" element={<TodoDashboard />} />
+                <Route path="/payment" element={<PaymentPage />} />
+                <Route path="/login" element={<LoginPage />} />
                 <Route path="/about-module" element={<AboutModulePage />} />
-                <Route path="*" element={<Navigate to="/mindmap" replace />} />
+                <Route path="*" element={<Navigate to="/" replace />} />
               </Routes>
             </Suspense>
           </Layout>

--- a/global.scss
+++ b/global.scss
@@ -270,3 +270,52 @@ hr {
   border-top: 1px solid var(--color-border);
   margin: var(--spacing-lg) 0;
 }
+
+.layout-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--color-bg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.layout-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md);
+}
+
+.layout-nav {
+  display: flex;
+  gap: var(--spacing-lg);
+}
+
+.layout-menu-button {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .layout-menu-button {
+    display: block;
+  }
+  .layout-nav {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 100%;
+    flex-direction: column;
+    background-color: var(--color-bg);
+    transform: translateY(-200%);
+    transition: transform var(--transition-duration) var(--transition-ease);
+  }
+  .layout-nav.layout-nav-open {
+    transform: translateY(0);
+  }
+  .layout-nav-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+  }
+}

--- a/layout.tsx
+++ b/layout.tsx
@@ -50,25 +50,35 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
           >
             <ul className="layout-nav-list">
               <li>
-                <NavLink to="/" className="layout-nav-link" onClick={handleLinkClick}>
-                  Home
-                </NavLink>
-              </li>
-              <li>
-                <NavLink to="/mindmaps" className="layout-nav-link" onClick={handleLinkClick}>
-                  Mindmaps
-                </NavLink>
-              </li>
-              <li>
-                <NavLink to="/todos" className="layout-nav-link" onClick={handleLinkClick}>
-                  Todos
-                </NavLink>
-              </li>
-              <li>
-                <NavLink to="/admin" className="layout-nav-link" onClick={handleLinkClick}>
-                  Admin
-                </NavLink>
-              </li>
+              <NavLink to="/" className="layout-nav-link" onClick={handleLinkClick}>
+                Home
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/mindmap" className="layout-nav-link" onClick={handleLinkClick}>
+                Mindmap
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/todos" className="layout-nav-link" onClick={handleLinkClick}>
+                Todos
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/admin" className="layout-nav-link" onClick={handleLinkClick}>
+                Admin
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/payment" className="layout-nav-link" onClick={handleLinkClick}>
+                Upgrade
+              </NavLink>
+            </li>
+            <li>
+              <NavLink to="/login" className="layout-nav-link" onClick={handleLinkClick}>
+                Login
+              </NavLink>
+            </li>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
## Summary
- add lazy loaded marketing pages
- update navigation links
- make the header sticky and responsive

## Testing
- `npm run build` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_687467812f8c8327bbf7b3c855907079