### PR TITLE
Add marketing placeholders with new layouts

### DIFF
--- a/aboutus.tsx
+++ b/aboutus.tsx
@@ -31,6 +31,11 @@ export function AboutUs(): JSX.Element {
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-6'
       }`}
     >
+      <img
+        src="/images/about-banner.png"
+        alt="About us banner"
+        className="about-banner mb-6"
+      />
       <h2 className="text-3xl sm:text-4xl font-extrabold text-gray-900 mb-4 text-center">
         About Mindmap ? Todo
       </h2>
@@ -46,6 +51,23 @@ export function AboutUs(): JSX.Element {
         Join thousands of users who have transformed their ideas into actionable plans
         with Mindmap ? Todo.
       </p>
+
+      <section className="two-column">
+        <div className="bold-marketing-text">
+          Seamlessly bridge brainstorming and execution with our intuitive tools.
+        </div>
+        <img
+          src="/images/about-section.png"
+          alt="Product screenshot"
+          className="banner-image"
+        />
+      </section>
+
+      <section className="three-column">
+        <div className="bold-marketing-text">Collaborate</div>
+        <div className="bold-marketing-text">Organize</div>
+        <div className="bold-marketing-text">Succeed</div>
+      </section>
       <div className="mt-8 flex flex-col sm:flex-row justify-center gap-4">
         <a
           href="#features"

--- a/global.scss
+++ b/global.scss
@@ -319,3 +319,39 @@ hr {
     padding: var(--spacing-md);
   }
 }
+
+.header__logo-img {
+  height: 40px;
+}
+
+.banner-slider {
+  position: relative;
+  overflow: hidden;
+}
+
+.banner-image {
+  width: 100%;
+  display: block;
+  height: auto;
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-lg);
+  align-items: center;
+  margin: var(--spacing-2xl) 0;
+}
+
+.three-column {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-lg);
+  margin: var(--spacing-2xl) 0;
+  text-align: center;
+}
+
+.bold-marketing-text {
+  font-size: 1.5rem;
+  font-weight: 700;
+}

--- a/header.tsx
+++ b/header.tsx
@@ -70,7 +70,13 @@ const Header = (): JSX.Element => {
     <header className="header">
       <div className="header__container">
         <div className="header__logo">
-          <Link to="/">PlanScaler</Link>
+          <Link to="/" aria-label="Home">
+            <img
+              src="/images/logo-placeholder.png"
+              alt="PlanScaler logo"
+              className="header__logo-img"
+            />
+          </Link>
         </div>
         <button
           ref={toggleRef}

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -3,30 +3,43 @@ const features = [
     title: 'Mind Mapping',
     description:
       'Visualize your ideas with dynamic, draggable mind maps that expand as you think.',
-    icon: '/icons/mindmap.svg',
+    icon: '/images/icon-mindmap.png',
   },
   {
     title: 'Integrated To-Do Lists',
     description:
       'Link tasks to your mind map nodes and track progress effortlessly in one place.',
-    icon: '/icons/todo.svg',
+    icon: '/images/icon-todo.png',
   },
   {
     title: 'Real-Time Collaboration',
     description:
       'Work together with your team on interactive maps and task lists in real time.',
-    icon: '/icons/collaboration.svg',
+    icon: '/images/icon-collaboration.png',
   },
   {
     title: 'Cross-Platform Sync',
     description:
       'Access your projects on any device with instant syncing and offline support.',
-    icon: '/icons/sync.svg',
+    icon: '/images/icon-sync.png',
   },
 ]
 
 const Homepage: React.FC = (): JSX.Element => {
   const [loading, setLoading] = useState(false)
+  const heroImages = [
+    '/images/banner1.png',
+    '/images/banner2.png',
+    '/images/banner3.png',
+  ]
+  const [currentHero, setCurrentHero] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCurrentHero(i => (i + 1) % heroImages.length)
+    }, 4000)
+    return () => clearInterval(id)
+  }, [])
 
   const handleCheckout = async () => {
     if (loading) return
@@ -76,14 +89,20 @@ const Homepage: React.FC = (): JSX.Element => {
             {loading ? 'Processing...' : 'Get Started'}
           </button>
         </motion.div>
-        <motion.img
-          src="/images/hero-mockup.png"
-          alt="App mockup"
-          className="hero-image"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.4, duration: 0.8 }}
-        />
+        <div className="banner-slider">
+          <AnimatePresence mode="wait">
+            <motion.img
+              key={currentHero}
+              src={heroImages[currentHero]}
+              alt="Hero banner"
+              className="banner-image"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.8 }}
+            />
+          </AnimatePresence>
+        </div>
       </section>
 
       <section className="features">
@@ -112,6 +131,23 @@ const Homepage: React.FC = (): JSX.Element => {
         <h2>Try It Live</h2>
         <p>Interactive demo of Mindmap ? Todo?no signup required.</p>
         <Demo />
+      </section>
+
+      <section className="two-column">
+        <div className="bold-marketing-text">
+          Map your ideas visually while keeping tasks in focus.
+        </div>
+        <img
+          src="/images/marketing-two-col.png"
+          alt="Two column placeholder"
+          className="banner-image"
+        />
+      </section>
+
+      <section className="three-column">
+        <div className="bold-marketing-text">Plan</div>
+        <div className="bold-marketing-text">Track</div>
+        <div className="bold-marketing-text">Launch</div>
       </section>
 
       <section className="pricing">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <!-- Open Graph -->
   <meta property="og:title" content="PlanScaler Mindmap Tools" />
   <meta property="og:description" content="Infinite-zoom, pan-enabled workspace for visual ideation" />
-  <meta property="og:image" content="https://example.com/og-image.png" />
+  <meta property="og:image" content="/images/og-image.png" />
   <meta property="og:url" content="https://example.com" />
   <meta property="og:type" content="website" />
 
@@ -17,7 +17,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="PlanScaler Mindmap Tools" />
   <meta name="twitter:description" content="Infinite-zoom, pan-enabled workspace for visual ideation" />
-  <meta name="twitter:image" content="https://example.com/og-image.png" />
+  <meta name="twitter:image" content="/images/og-image.png" />
   <meta name="twitter:site" content="@yourtwitterhandle" />
 
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />


### PR DESCRIPTION
## Summary
- add header logo placeholder
- update OG image paths
- add hero slider and marketing sections
- add placeholder banner and columns on about page
- style marketing elements in global stylesheet

## Testing
- `npm run build` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875965828548327b1e6726cc12350f6