### PR TITLE
Add AI generation support for mindmaps and todos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-key
+OPENAI_DEFAULT_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ This project uses Netlify Functions and a Neon database. SQL migration files are
    ```
 
 Pushing changes to the `main` branch triggers a Netlify production build that deploys the `dist` directory and the functions in `netlify/functions`.
+
+## OpenAI Configuration
+
+Set the following variables in your Netlify environment to enable AI powered features:
+
+```
+OPENAI_API_KEY=your-openai-key
+OPENAI_DEFAULT_MODEL=gpt-4o-mini
+```
+
+These are used by serverless functions to generate mind maps and todo lists.

--- a/global.scss
+++ b/global.scss
@@ -355,3 +355,17 @@ hr {
   font-size: 1.5rem;
   font-weight: 700;
 }
+
+.ai-button {
+  background: linear-gradient(90deg, #10b981, #a855f7);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.ai-button::after {
+  content: '✨';
+}

--- a/netlify/functions/ai-create-mindmap.ts
+++ b/netlify/functions/ai-create-mindmap.ts
@@ -1,0 +1,66 @@
+import type { Handler } from "@netlify/functions"
+import { Configuration, OpenAIApi } from 'openai'
+import { randomUUID } from 'crypto'
+import { getClient } from './db-client.js'
+
+const db = getClient()
+const openaiKey = process.env.OPENAI_API_KEY
+if (!openaiKey) throw new Error('Missing OPENAI_API_KEY')
+const openai = new OpenAIApi(new Configuration({ apiKey: openaiKey }))
+const MODEL = process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-4o-mini'
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' }
+  }
+  if (!event.body) return { statusCode: 400, body: 'Missing body' }
+  let data: any
+  try { data = JSON.parse(event.body) } catch { return { statusCode: 400, body: 'Invalid JSON' } }
+  const { title, description = '', prompt } = data
+  if (typeof title !== 'string' || !title.trim()) return { statusCode: 400, body: 'Invalid title' }
+  const client = await db.connect()
+  try {
+    await client.query('BEGIN')
+    const res = await client.query(
+      `INSERT INTO mind_maps(id, user_id, title, description, created_at)
+       VALUES ($1, $2, $3, $4, NOW()) RETURNING id`,
+      [randomUUID(), data.userId ?? null, title.trim(), description.trim() || null]
+    )
+    const mapId = res.rows[0].id
+    if (prompt && typeof prompt === 'string' && prompt.trim()) {
+      const completion = await openai.createChatCompletion({
+        model: MODEL,
+        messages: [
+          {
+            role: 'system',
+            content: 'Generate a JSON array of mind map node titles based on the user prompt.'
+          },
+          { role: 'user', content: prompt }
+        ],
+        max_tokens: 200
+      })
+      const text = completion.data.choices?.[0]?.message?.content
+      if (text) {
+        try {
+          const items: string[] = JSON.parse(text)
+          for (const t of items) {
+            await client.query(
+              `INSERT INTO nodes(id, mind_map_id, parent_id, data) VALUES ($1,$2,NULL,$3)`,
+              [randomUUID(), mapId, JSON.stringify({ content: String(t) })]
+            )
+          }
+        } catch {
+          // ignore parse errors
+        }
+      }
+    }
+    await client.query('COMMIT')
+    return { statusCode: 201, body: JSON.stringify({ id: mapId }) }
+  } catch (err) {
+    await client.query('ROLLBACK')
+    console.error(err)
+    return { statusCode: 500, body: 'Internal Server Error' }
+  } finally {
+    client.release()
+  }
+}

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -1,0 +1,40 @@
+import type { Handler } from '@netlify/functions'
+import { Configuration, OpenAIApi } from 'openai'
+
+const openaiKey = process.env.OPENAI_API_KEY
+if (!openaiKey) throw new Error('Missing OPENAI_API_KEY')
+const openai = new OpenAIApi(new Configuration({ apiKey: openaiKey }))
+const MODEL = process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-4o-mini'
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' }
+  }
+  if (!event.body) return { statusCode: 400, body: 'Missing body' }
+  let data: any
+  try { data = JSON.parse(event.body) } catch { return { statusCode: 400, body: 'Invalid JSON' } }
+  const { prompt } = data
+  if (!prompt || typeof prompt !== 'string') return { statusCode: 400, body: 'Invalid prompt' }
+  try {
+    const completion = await openai.createChatCompletion({
+      model: MODEL,
+      messages: [
+        { role: 'system', content: 'Generate a JSON array of todo items with title and optional description.' },
+        { role: 'user', content: prompt }
+      ],
+      max_tokens: 200
+    })
+    const text = completion.data.choices?.[0]?.message?.content
+    if (!text) return { statusCode: 500, body: 'No AI content' }
+    let todos
+    try { todos = JSON.parse(text) } catch { todos = [] }
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ todos })
+    }
+  } catch (err) {
+    console.error(err)
+    return { statusCode: 500, body: 'Internal Server Error' }
+  }
+}

--- a/openaiclient.ts
+++ b/openaiclient.ts
@@ -1,4 +1,6 @@
-const DEFAULT_MODEL = process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-3.5-turbo'
+import { Configuration, OpenAIApi, type CreateChatCompletionRequest } from 'openai'
+
+const DEFAULT_MODEL = process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-4o-mini'
 const DEFAULT_TEMPERATURE = parseFloat(process.env.OPENAI_DEFAULT_TEMPERATURE ?? '0.7')
 const DEFAULT_MAX_TOKENS = parseInt(process.env.OPENAI_DEFAULT_MAX_TOKENS ?? '256', 10)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.4.0",
-    "dotenv": "^16.0.3"
+    "dotenv": "^16.0.3",
+    "openai": "^4.5.0"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## Summary
- add OpenAI-powered mindmap and todo generation functions
- update OpenAI client defaults and add dependency
- allow prompts when creating maps or todos
- style AI actions with gradient buttons
- document OpenAI environment variables

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f68faecc8327b03a867657b33559