### PR TITLE
Switch to png placeholders

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -233,6 +233,11 @@ export default function DashboardPage(): JSX.Element {
   return (
     <div className="dashboard-page">
       <h1 className="dashboard-title">Dashboard</h1>
+      <img
+        src="./assets/dashboard.png"
+        alt="Dashboard banner"
+        className="dashboard-banner mb-4"
+      />
       {summaryLoading ? (
         <LoadingSkeleton count={3} />
       ) : summaryError ? (

--- a/header.tsx
+++ b/header.tsx
@@ -72,7 +72,7 @@ const Header = (): JSX.Element => {
         <div className="header__logo">
           <Link to="/" aria-label="Home">
             <img
-              src="./assets/placeholder.svg"
+              src="./assets/placeholder.png"
               alt="Mindxdo logo"
               className="header__logo-img"
             />

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -3,40 +3,40 @@ const features = [
     title: 'Mind Mapping',
     description:
       'Visualize your ideas with dynamic, draggable mind maps that expand as you think.',
-    icon: './assets/placeholder.svg',
+    icon: './assets/placeholder.png',
   },
   {
     title: 'Integrated To-Do Lists',
     description:
       'Link tasks to your mind map nodes and track progress effortlessly in one place.',
-    icon: './assets/placeholder.svg',
+    icon: './assets/placeholder.png',
   },
   {
     title: 'Real-Time Collaboration',
     description:
       'Work together with your team on interactive maps and task lists in real time.',
-    icon: './assets/placeholder.svg',
+    icon: './assets/placeholder.png',
   },
   {
     title: 'Cross-Platform Sync',
     description:
       'Access your projects on any device with instant syncing and offline support.',
-    icon: './assets/placeholder.svg',
+    icon: './assets/placeholder.png',
   },
   {
     title: 'AI Automation',
     description:
       'Let Mindxdo suggest tasks and connections so you can focus on the experience.',
-    icon: './assets/placeholder.svg',
+    icon: './assets/placeholder.png',
   },
 ]
 
 const Homepage: React.FC = (): JSX.Element => {
   const [loading, setLoading] = useState(false)
   const heroImages = [
-    './assets/placeholder.svg',
-    './assets/placeholder.svg',
-    './assets/placeholder.svg',
+    './assets/placeholder.png',
+    './assets/placeholder.png',
+    './assets/placeholder.png',
   ]
   const [currentHero, setCurrentHero] = useState(0)
 
@@ -148,7 +148,7 @@ const Homepage: React.FC = (): JSX.Element => {
           Map your ideas visually while keeping tasks in focus.
         </div>
         <img
-          src="./assets/placeholder.svg"
+          src="./assets/placeholder.png"
           alt="Two column placeholder"
           className="banner-image"
         />
@@ -175,7 +175,7 @@ const Homepage: React.FC = (): JSX.Element => {
           Mindxdo helps you execute ambitious plans with ease.
         </p>
         <img
-          src="./assets/placeholder.svg"
+          src="./assets/placeholder.png"
           alt="AI showcase"
           className="banner-image"
         />

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <!-- Open Graph -->
   <meta property="og:title" content="Mindxdo" />
   <meta property="og:description" content="Combine mindmaps and todos with AI for an unmatched experience" />
-  <meta property="og:image" content="./assets/placeholder.svg" />
+  <meta property="og:image" content="./assets/placeholder.png" />
   <meta property="og:url" content="https://example.com" />
   <meta property="og:type" content="website" />
 
@@ -17,10 +17,10 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Mindxdo" />
   <meta name="twitter:description" content="Combine mindmaps and todos with AI for an unmatched experience" />
-  <meta name="twitter:image" content="./assets/placeholder.svg" />
+  <meta name="twitter:image" content="./assets/placeholder.png" />
   <meta name="twitter:site" content="@yourtwitterhandle" />
 
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="/favicon.png" type="image/png" />
   <title>Mindxdo</title>
 </head>
 <body>

--- a/login.tsx
+++ b/login.tsx
@@ -93,6 +93,11 @@ const LoginPage = (): JSX.Element => {
 
   return (
     <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded shadow">
+      <img
+        src="./assets/login.png"
+        alt="Login"
+        className="w-24 mx-auto mb-4"
+      />
       <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
       {submitError && (
         <div role="alert" aria-live="assertive" className="text-red-600 mb-4">

--- a/profile.tsx
+++ b/profile.tsx
@@ -57,6 +57,11 @@ export default function ProfilePage(): JSX.Element {
   return (
     <div className="profile-page container mx-auto p-6 max-w-lg">
       <h1 className="text-2xl font-semibold mb-4">Update Profile</h1>
+      <img
+        src="./assets/profile.png"
+        alt="Profile header"
+        className="profile-image w-32 mx-auto mb-4"
+      />
       {error && <div className="text-red-600 mb-4">{error}</div>}
       {success && <div className="text-green-600 mb-4">Profile updated!</div>}
       <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary
- switch images to use relative .png paths
- include placeholder image references in dashboard, login and profile pages
- update meta tags and logo usage to png

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876980fc71c83279142d0c51b1f93ef