### PR TITLE
Update migrate script and remove test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "dev": "concurrently \"npm run dev:web\" \"npm run dev:api\"",
     "build": "npm run migrate && vite build",
     "preview": "vite preview",
-    "migrate": "node --loader ts-node/esm runmigrations.ts",
-    "start": "npm run dev",
-    "test": "jest"
+    "migrate": "ts-node runmigrations.ts",
+    "start": "npm run dev"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.1",


### PR DESCRIPTION
## Summary
- simplify the migrate script
- drop the test npm script

## Testing
- `npx jest` *(fails: unable to download packages)*
- `npm run migrate` *(fails: ts-node not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b742d7708327a019882d030abab6