### PR TITLE
Fix Netlify build without lockfile

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   command = """
-    npm ci &&
+    npm install &&
     npm run compile:migrations &&
     npm run migrate &&
     npm run build


### PR DESCRIPTION
## Summary
- replace `npm ci` with `npm install` in `netlify.toml`

## Testing
- `npx jest` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6876c5778828832798a18385681817ea