### PR TITLE
Fix tsconfig module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "node16",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "outDir": "dist",
     "rootDir": ".",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- update `module` and `moduleResolution` to `Node16`

## Testing
- `npx jest` *(fails: 403 when attempting to fetch Jest)*

------
https://chatgpt.com/codex/tasks/task_e_6876d02f1dd8832793000be831cf95d6