### PR TITLE
Update vercel-postgres version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "openai": "^4.5.0",
     "@netlify/functions": "^3.0.0",
     "zod": "^3.21.0",
-    "@vercel/postgres": "^1.0.0"
+    "@vercel/postgres": "^0.8.0"
   },
   "devDependencies": {
     "typescript": "^5.1.0",


### PR DESCRIPTION
## Summary
- use a published version of `@vercel/postgres`

## Testing
- `node --test tests/db-client.test.js` *(fails: Cannot find package '@netlify/neon')*

------
https://chatgpt.com/codex/tasks/task_e_6877079fe2708327abcd8f3c53582c4d