### PR TITLE
Fix build by updating vercel-postgres version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "openai": "^4.5.0",
     "@netlify/functions": "^3.0.0",
     "zod": "^3.21.0",
-    "@vercel/postgres": "^0.8.0"
+    "@vercel/postgres": "^1.0.1"
   },
   "devDependencies": {
     "typescript": "^5.1.0",


### PR DESCRIPTION
## Summary
- update the `@vercel/postgres` dependency to a valid version

## Testing
- `npm test` *(fails: Missing script)*
- `node tests/db-client.test.js` *(fails: cannot find module @netlify/neon)*

------
https://chatgpt.com/codex/tasks/task_e_68770c07b90083278f1415c8aa541507