### PR TITLE
Fix Node type configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": ["node"]
   },
   "include": [
     "stubs-node.d.ts",


### PR DESCRIPTION
## Summary
- ensure TypeScript only loads Node typings by default

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6877307f4e808327bddf4e0e72548552