### PR TITLE
Fix migrations tsconfig

### DIFF
--- a/tsconfig.migrations.json
+++ b/tsconfig.migrations.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["runmigrations.ts"],
-  "exclude": ["netlify/functions", "node_modules"]
+  "include": ["runmigrations.ts", "netlify/functions/db-client.ts"]
 }


### PR DESCRIPTION
## Summary
- compile db client when building migrations so runmigrations can load it

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68773a1cf70c8327aca3d9e58334e73f