### PR TITLE
Fix Postgres runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "openai": "^4.5.0",
     "@netlify/functions": "^3.0.0",
     "zod": "^3.21.0",
-    "@vercel/postgres": "^0.10.0"
+    "@vercel/postgres": "^0.10.0",
+    "pg": "^8.10.0"
   },
   "devDependencies": {
     "typescript": "^5.1.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+    "@types/pg": "^8.6.6"
   }
 }


### PR DESCRIPTION
## Summary
- ensure `pg` is installed in production dependencies
- add types for `pg` to devDependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687740d5be348327a7c164c487f97075