### PR TITLE
Fix migration runner setup

### DIFF
--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg'
 
-const conn = process.env.NETLIFY_DATABASE_URL
-if (!conn) throw new Error('Missing NETLIFY_DATABASE_URL')
+const conn = process.env.NETLIFY_DATABASE_URL_UNPOOLED
+if (!conn) throw new Error('Missing NETLIFY_DATABASE_URL_UNPOOLED')
 
 export const pool = new Pool({
   connectionString: conn,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:web": "vite",
     "dev:api": "netlify functions:serve --port=8888",
     "dev": "concurrently \"npm run dev:web\" \"npm run dev:api\"",
-    "build": "npm run compile:migrations && node dist/runmigrations.js && vite build",
+    "build": "npm run compile:migrations && npm run migrate && vite build",
     "preview": "vite preview",
     "compile:migrations": "tsc -p tsconfig.migrations.json",
     "migrate": "node dist/runmigrations.js",

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { pool } from './netlify/functions/db-client.js'
+import { pool } from '../netlify/functions/db-client.js'
 
 function splitSql(sql: string): string[] {
   return sql
@@ -10,7 +10,7 @@ function splitSql(sql: string): string[] {
 }
 
 export async function runMigrations(): Promise<void> {
-  const migrationsDir = path.resolve(process.cwd(), 'migrations')
+  const migrationsDir = path.resolve(__dirname, '../migrations')
   const client = await pool.connect()
   const LOCK_KEY = 1234567890
   try {

--- a/tsconfig.migrations.json
+++ b/tsconfig.migrations.json
@@ -1,7 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "include": [
-    "runmigrations.ts",
-    "netlify/functions/db-client.ts"
-  ]
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2020",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["runmigrations.ts", "migrations/**/*.sql"]
 }


### PR DESCRIPTION
## Summary
- set db-client to use NETLIFY_DATABASE_URL_UNPOOLED
- adjust migration runner paths
- refine tsconfig for migrations
- update build script

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68774a3a6bd883278bb933830010dea8