### PR TITLE
Fix handler spread args

### DIFF
--- a/netlify/functions/forgotpassword.ts
+++ b/netlify/functions/forgotpassword.ts
@@ -11,10 +11,6 @@ if (!DATABASE_URL) throw new Error('Missing DATABASE_URL')
 if (!FRONTEND_URL) throw new Error('Missing FRONTEND_URL')
 if (!RESET_TOKEN_SECRET) throw new Error('Missing RESET_TOKEN_SECRET')
 
-const pool = {
-  query: async (...args: any[]) => (await getClient()).query(...args)
-}
-
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 function generateResetToken(): string {

--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -3,7 +3,10 @@ import { getClient } from './db-client.js'
 import { verify, JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { z, ZodError } from 'zod'
 const pool = {
-  query: async (...args: any[]) => (await getClient()).query(...args)
+  async query(text: string, params?: any[]) {
+    const client = await getClient()
+    return client.query(text, params)
+  }
 }
 
 const mapInputSchema = z.object({

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -9,7 +9,10 @@ if (!DATABASE_URL || !JWT_SECRET) {
   throw new Error('Missing required environment variables')
 }
 const pool = {
-  query: async (...args: any[]) => (await getClient()).query(...args)
+  async query(text: string, params?: any[]) {
+    const client = await getClient()
+    return client.query(text, params)
+  }
 }
 
 const loginSchema = z.object({

--- a/netlify/functions/payme.ts
+++ b/netlify/functions/payme.ts
@@ -2,7 +2,10 @@ import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
 import Stripe from 'stripe'
 import { getClient } from './db-client.js'
 const db = {
-  query: async (...args: any[]) => (await getClient()).query(...args)
+  async query(text: string, params?: any[]) {
+    const client = await getClient()
+    return client.query(text, params)
+  }
 }
 const stripeSecret = process.env.STRIPE_SECRET_KEY
 const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET


### PR DESCRIPTION
## Summary
- remove unused pool from forgotpassword handler
- use explicit query parameters in index handler
- do the same for login and payme handlers

## Testing
- `npm run compile:functions` *(fails: Cannot find module '@netlify/functions', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687823f0283883278cdc26f8d4ba3d76