### PR TITLE
Add __dirname polyfill to runmigrations.ts

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -1,6 +1,12 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// define __dirname in ESM
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
 import { pool } from './netlify/functions/db-client.js'
 import fs from 'fs'
-import path from 'path'
 
 function splitSql(sql: string): string[] {
   return sql


### PR DESCRIPTION
## Summary
- add Node ESM-compatible `__dirname` polyfill before all code in `runmigrations.ts`

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions' and 'node')*
- `npx tsc runmigrations.ts --outDir dist --module nodenext --target ES2020 --esModuleInterop --skipLibCheck` *(fails: Cannot find type declarations for Node modules)*

------
https://chatgpt.com/codex/tasks/task_e_68783c0894088327acba97f7ba457e64