### PR TITLE
Fix non-idempotent migration scripts

### DIFF
--- a/migrations/002_add_orders_table.sql
+++ b/migrations/002_add_orders_table.sql
@@ -19,7 +19,7 @@ BEGIN
 END
 $$;
 
-CREATE TABLE orders (
+CREATE TABLE IF NOT EXISTS orders (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   stripe_session_id TEXT UNIQUE NOT NULL,
   customer_email CITEXT NOT NULL CHECK (

--- a/migrations/002_create_maps.sql
+++ b/migrations/002_create_maps.sql
@@ -1,4 +1,4 @@
-CREATE TABLE maps (
+CREATE TABLE IF NOT EXISTS maps (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
@@ -20,4 +20,4 @@ CREATE TRIGGER set_maps_updated_at
 BEFORE UPDATE ON maps
 FOR EACH ROW EXECUTE PROCEDURE trigger_set_updated_at();
 
-CREATE INDEX idx_maps_user_id ON maps(user_id);
+CREATE INDEX IF NOT EXISTS idx_maps_user_id ON maps(user_id);

--- a/migrations/003_create_nodes.sql
+++ b/migrations/003_create_nodes.sql
@@ -2,7 +2,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 BEGIN;
 
-CREATE TABLE nodes (
+CREATE TABLE IF NOT EXISTS nodes (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   mind_map_id UUID NOT NULL REFERENCES mind_maps(id) ON DELETE CASCADE,
   parent_id UUID REFERENCES nodes(id) ON DELETE SET NULL,
@@ -12,8 +12,12 @@ CREATE TABLE nodes (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX idx_nodes_mind_map_id ON nodes (mind_map_id);
-CREATE INDEX idx_nodes_parent_id ON nodes (parent_id);
+ALTER TABLE nodes
+  ADD COLUMN IF NOT EXISTS mind_map_id UUID NOT NULL
+    REFERENCES mind_maps(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_nodes_mind_map_id ON nodes (mind_map_id);
+CREATE INDEX IF NOT EXISTS idx_nodes_parent_id ON nodes (parent_id);
 
 CREATE OR REPLACE FUNCTION nodes_update_updated_at()
 RETURNS TRIGGER AS $$


### PR DESCRIPTION
## Summary
- ensure `mind_map_id` exists before indexing in `nodes`
- make the `nodes` and `maps` index creation safe
- guard orders table creation with `IF NOT EXISTS`

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions')*
- `npm run compile:functions` *(fails to find module '@netlify/functions' and others)*

------
https://chatgpt.com/codex/tasks/task_e_6878439a2dd083279d154e7a7d3e2a2d