### PR TITLE
Fix todos mind_map_id migration

### DIFF
--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -25,6 +25,10 @@ CREATE TABLE IF NOT EXISTS todos (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+ALTER TABLE todos
+  ADD COLUMN IF NOT EXISTS mind_map_id UUID NOT NULL
+    REFERENCES mind_maps(id) ON DELETE CASCADE;
+
 CREATE INDEX IF NOT EXISTS idx_todos_user_id ON todos(user_id);
 CREATE INDEX IF NOT EXISTS idx_todos_mind_map_id ON todos(mind_map_id);
 CREATE INDEX IF NOT EXISTS idx_todos_node_id ON todos(node_id);


### PR DESCRIPTION
## Summary
- ensure `mind_map_id` column exists before indexing in `todos` migration

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions' and 'node')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68784526c74c83279af79237c86db362