### PR TITLE
Add idempotent column setup for nodes migrations

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -24,6 +24,13 @@ export async function runMigrations(): Promise<void> {
         run_on TIMESTAMPTZ NOT NULL DEFAULT NOW()
       );
     `)
+
+    // Ensure columns used in later indexes exist before index creation
+    await client.query(`
+      ALTER TABLE nodes
+      ADD COLUMN IF NOT EXISTS mindmap_id UUID NOT NULL
+        REFERENCES mindmaps(id)
+    `)
     const files = fs.readdirSync(migrationsDir)
       .filter((file: string) => file.endsWith('.sql'))
       .sort((a: string, b: string) => {


### PR DESCRIPTION
## Summary
- ensure `mindmap_id` column exists on `nodes` before applying migrations

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions')*

------
https://chatgpt.com/codex/tasks/task_e_687849be2e0c83278a74ab88188382b9