### PR TITLE
Unify mindmaps table name

### DIFF
--- a/migrations/002_create_maps.sql
+++ b/migrations/002_create_maps.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS maps (
+CREATE TABLE IF NOT EXISTS mindmaps (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   title TEXT NOT NULL,
@@ -16,8 +16,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER set_maps_updated_at
-BEFORE UPDATE ON maps
+CREATE TRIGGER set_mindmaps_updated_at
+BEFORE UPDATE ON mindmaps
 FOR EACH ROW EXECUTE PROCEDURE trigger_set_updated_at();
 
-CREATE INDEX IF NOT EXISTS idx_maps_user_id ON maps(user_id);
+CREATE INDEX IF NOT EXISTS idx_mindmaps_user_id ON mindmaps(user_id);

--- a/migrations/003_create_nodes.sql
+++ b/migrations/003_create_nodes.sql
@@ -4,7 +4,7 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS nodes (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  mind_map_id UUID NOT NULL REFERENCES mind_maps(id) ON DELETE CASCADE,
+  mindmap_id UUID NOT NULL REFERENCES mindmaps(id) ON DELETE CASCADE,
   parent_id UUID REFERENCES nodes(id) ON DELETE SET NULL,
   data JSONB NOT NULL DEFAULT '{}'::jsonb,
   order_index INT NOT NULL DEFAULT 0,
@@ -13,10 +13,10 @@ CREATE TABLE IF NOT EXISTS nodes (
 );
 
 ALTER TABLE nodes
-  ADD COLUMN IF NOT EXISTS mind_map_id UUID NOT NULL
-    REFERENCES mind_maps(id) ON DELETE CASCADE;
+  ADD COLUMN IF NOT EXISTS mindmap_id UUID NOT NULL
+    REFERENCES mindmaps(id) ON DELETE CASCADE;
 
-CREATE INDEX IF NOT EXISTS idx_nodes_mind_map_id ON nodes (mind_map_id);
+CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes (mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_nodes_parent_id ON nodes (parent_id);
 
 CREATE OR REPLACE FUNCTION nodes_update_updated_at()

--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -10,7 +10,7 @@ CREATE TYPE IF NOT EXISTS todo_ai_status AS ENUM (
 CREATE TABLE IF NOT EXISTS todos (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  mind_map_id UUID NOT NULL REFERENCES mind_maps(id) ON DELETE CASCADE,
+  mindmap_id UUID NOT NULL REFERENCES mindmaps(id) ON DELETE CASCADE,
   node_id UUID REFERENCES nodes(id) ON DELETE SET NULL,
   title TEXT NOT NULL,
   description TEXT,
@@ -26,11 +26,11 @@ CREATE TABLE IF NOT EXISTS todos (
 );
 
 ALTER TABLE todos
-  ADD COLUMN IF NOT EXISTS mind_map_id UUID NOT NULL
-    REFERENCES mind_maps(id) ON DELETE CASCADE;
+  ADD COLUMN IF NOT EXISTS mindmap_id UUID NOT NULL
+    REFERENCES mindmaps(id) ON DELETE CASCADE;
 
 CREATE INDEX IF NOT EXISTS idx_todos_user_id ON todos(user_id);
-CREATE INDEX IF NOT EXISTS idx_todos_mind_map_id ON todos(mind_map_id);
+CREATE INDEX IF NOT EXISTS idx_todos_mindmap_id ON todos(mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_todos_node_id ON todos(node_id);
 CREATE INDEX IF NOT EXISTS idx_todos_due_at ON todos(due_at);
 CREATE INDEX IF NOT EXISTS idx_todos_user_id_status ON todos(user_id, status);

--- a/migrations/009_create_products.sql
+++ b/migrations/009_create_products.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS products (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name          TEXT NOT NULL,
+  description   TEXT,
+  price         NUMERIC(10,2) NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/010_create_order_items.sql
+++ b/migrations/010_create_order_items.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS order_items (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id      UUID NOT NULL REFERENCES orders(id),
+  product_id    UUID NOT NULL REFERENCES products(id),
+  quantity      INTEGER NOT NULL,
+  unit_price    NUMERIC(10,2) NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/011_create_password_reset_tokens.sql
+++ b/migrations/011_create_password_reset_tokens.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  token         TEXT PRIMARY KEY,
+  user_id       UUID NOT NULL REFERENCES users(id),
+  expires_at    TIMESTAMPTZ NOT NULL,
+  used          BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/012_create_password_resets.sql
+++ b/migrations/012_create_password_resets.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS password_resets (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users(id),
+  reset_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/migrations/013_create_stripe_events.sql
+++ b/migrations/013_create_stripe_events.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS stripe_events (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id      TEXT NOT NULL UNIQUE,
+  payload       JSONB NOT NULL,
+  received_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/netlify/functions/ai-create-mindmap.ts
+++ b/netlify/functions/ai-create-mindmap.ts
@@ -20,7 +20,7 @@ export const handler: Handler = async (event) => {
   try {
     await client.query('BEGIN')
     const res = await client.query(
-      `INSERT INTO mind_maps(id, user_id, title, description, created_at)
+      `INSERT INTO mindmaps(id, user_id, title, description, created_at)
        VALUES ($1, $2, $3, $4, NOW()) RETURNING id`,
       [randomUUID(), data.userId ?? null, title.trim(), description.trim() || null]
     )
@@ -48,7 +48,7 @@ export const handler: Handler = async (event) => {
           const items: string[] = JSON.parse(text)
           for (const t of items) {
             await client.query(
-              `INSERT INTO nodes(id, mind_map_id, parent_id, data) VALUES ($1,$2,NULL,$3)`,
+              `INSERT INTO nodes(id, mindmap_id, parent_id, data) VALUES ($1,$2,NULL,$3)`,
               [randomUUID(), mapId, JSON.stringify({ content: String(t) })]
             )
           }

--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -56,7 +56,7 @@ export const handler: Handler = async (
     const client = await getClient()
     try {
       const ownershipResult = await client.query(
-        'SELECT 1 FROM mind_maps WHERE id = $1 AND user_id = $2',
+        'SELECT 1 FROM mindmaps WHERE id = $1 AND user_id = $2',
         [data.mindMapId, userId]
       )
       if (ownershipResult.rowCount === 0) {
@@ -114,12 +114,12 @@ export const handler: Handler = async (
       for (const item of validTodos) {
         const id = uuidv4()
         const result = await client.query(
-          `INSERT INTO todos (id, user_id, mind_map_id, node_id, title, description, created_at)
+          `INSERT INTO todos (id, user_id, mindmap_id, node_id, title, description, created_at)
            VALUES ($1, $2, $3, $4, $5, $6, NOW())
            RETURNING
              id AS "id",
              user_id AS "userId",
-             mind_map_id AS "mindMapId",
+             mindmap_id AS "mindMapId",
              node_id AS "nodeId",
              title,
              description,

--- a/netlify/functions/analytics.ts
+++ b/netlify/functions/analytics.ts
@@ -70,14 +70,14 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
     const { rows } = await pool.query(`
       SELECT
         (SELECT COUNT(*) FROM users)        AS total_users,
-        (SELECT COUNT(*) FROM mind_maps)    AS total_mind_maps,
+        (SELECT COUNT(*) FROM mindmaps)    AS total_mindmaps,
         (SELECT COUNT(*) FROM nodes)        AS total_nodes,
         (SELECT COUNT(*) FROM todos)        AS total_todos
     `)
     const row = rows[0]
     const data = {
       totalUsers:    Number(row.total_users),
-      totalMindMaps: Number(row.total_mind_maps),
+      totalMindMaps: Number(row.total_mindmaps),
       totalNodes:    Number(row.total_nodes),
       totalTodos:    Number(row.total_todos)
     }

--- a/netlify/functions/create.ts
+++ b/netlify/functions/create.ts
@@ -93,7 +93,7 @@ export const handler: Handler = async (event) => {
   try {
     const result = await db.query(
       `
-        INSERT INTO mind_maps (user_id, title, description, created_at)
+        INSERT INTO mindmaps (user_id, title, description, created_at)
         VALUES ($1, $2, $3, NOW())
         RETURNING id, user_id, title, description, created_at
       `,

--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -34,7 +34,7 @@ async function getUserId(headers: { [key: string]: string }): Promise<string> {
 async function getMaps(userId: string) {
   const result = await pool.query(
     `SELECT id, user_id AS "userId", data, created_at AS "createdAt", updated_at AS "updatedAt"
-     FROM maps
+     FROM mindmaps
      WHERE user_id = $1
         OR user_id IN (SELECT user_id FROM team_members WHERE member_id = $1)
      ORDER BY created_at DESC`,
@@ -45,7 +45,7 @@ async function getMaps(userId: string) {
 
 async function createMap(userId: string, data: unknown) {
   const result = await pool.query(
-    `INSERT INTO maps (user_id, data)
+    `INSERT INTO mindmaps (user_id, data)
      VALUES ($1, $2)
      RETURNING id, user_id AS "userId", data, created_at AS "createdAt", updated_at AS "updatedAt"`,
     [userId, data]

--- a/netlify/functions/mapid.ts
+++ b/netlify/functions/mapid.ts
@@ -69,7 +69,7 @@ export const handler: Handler = async event => {
 
 async function getMap(mapId: string): Promise<{ id: string; data: MapData; created_at: string; updated_at: string | null } | null> {
   const client = await getClient()
-  const res = await client.query('SELECT id, data, created_at, updated_at FROM maps WHERE id = $1', [mapId])
+  const res = await client.query('SELECT id, data, created_at, updated_at FROM mindmaps WHERE id = $1', [mapId])
   client.release()
   return res.rowCount > 0 ? res.rows[0] : null
 }
@@ -77,7 +77,7 @@ async function getMap(mapId: string): Promise<{ id: string; data: MapData; creat
 async function updateMap(mapId: string, data: MapData): Promise<{ id: string; data: MapData; created_at: string; updated_at: string | null } | null> {
   const client = await getClient()
   const res = await client.query(
-    'UPDATE maps SET data = $2, updated_at = NOW() WHERE id = $1 RETURNING id, data, created_at, updated_at',
+    'UPDATE mindmaps SET data = $2, updated_at = NOW() WHERE id = $1 RETURNING id, data, created_at, updated_at',
     [mapId, data]
   )
   client.release()
@@ -86,7 +86,7 @@ async function updateMap(mapId: string, data: MapData): Promise<{ id: string; da
 
 async function deleteMap(mapId: string): Promise<number> {
   const client = await getClient()
-  const res = await client.query('DELETE FROM maps WHERE id = $1', [mapId])
+  const res = await client.query('DELETE FROM mindmaps WHERE id = $1', [mapId])
   client.release()
   return res.rowCount
 }

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -1,10 +1,6 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
 
-// define __dirname in ESM
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
 import { pool } from './netlify/functions/db-client.js'
 import fs from 'fs'
 
@@ -12,7 +8,7 @@ import fs from 'fs'
 // blocks (e.g. in PL/pgSQL functions) are not split incorrectly.
 
 export async function runMigrations(): Promise<void> {
-  const migrationsDir = path.resolve(__dirname, '../migrations')
+  const migrationsDir = fileURLToPath(new URL('../migrations', import.meta.url))
   const client = await pool.connect()
   const LOCK_KEY = 1234567890
   try {


### PR DESCRIPTION
## Summary
- rename map tables to `mindmaps` in migrations and functions
- normalize FK columns and update queries
- add new migrations for products, order_items, password reset tables, and stripe events
- simplify `runmigrations` path logic

## Testing
- `npm test` *(fails: Missing script)*
- `npm run compile:functions` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687863e35ca883279f0138a89a81e0ca