### PR TITLE
Add migration to ensure mindmap_id column

### DIFF
--- a/migrations/014_ensure_mindmap_id.sql
+++ b/migrations/014_ensure_mindmap_id.sql
@@ -1,0 +1,9 @@
+-- Ensure mindmap_id column exists in core tables
+ALTER TABLE IF EXISTS nodes
+  ADD COLUMN IF NOT EXISTS mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
+
+ALTER TABLE IF EXISTS todos
+  ADD COLUMN IF NOT EXISTS mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes(mindmap_id);
+CREATE INDEX IF NOT EXISTS idx_todos_mindmap_id ON todos(mindmap_id);


### PR DESCRIPTION
## Summary
- ensure `mindmap_id` column exists for `nodes` and `todos`

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions')*

------
https://chatgpt.com/codex/tasks/task_e_68786a69ced48327a044ca97aa40c46b