### PR TITLE
Fix migration by ensuring todos mindmap column

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -56,6 +56,12 @@ export async function runMigrations(): Promise<void> {
       ADD COLUMN IF NOT EXISTS mindmap_id UUID NOT NULL
         REFERENCES mindmaps(id)
     `)
+
+    await client.query(`
+      ALTER TABLE IF EXISTS todos
+      ADD COLUMN IF NOT EXISTS mindmap_id UUID
+        REFERENCES mindmaps(id) ON DELETE CASCADE
+    `)
     const files = fs.readdirSync(migrationsDir)
       .filter((file: string) => file.endsWith('.sql'))
       .sort((a: string, b: string) => {


### PR DESCRIPTION
## Summary
- update `runmigrations.ts` so `mindmap_id` column is created on existing `todos` table

## Testing
- `node --test tests` *(fails: cannot find module 'pg' and missing jest globals)*

------
https://chatgpt.com/codex/tasks/task_e_68786c6b12fc8327bb6e100bdbc7cbe1