### PR TITLE
Ensure triggers recreate safely

### DIFF
--- a/migrations/001_create_schema.sql
+++ b/migrations/001_create_schema.sql
@@ -27,10 +27,12 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+DROP TRIGGER IF EXISTS update_users_updated_at ON users;
 CREATE TRIGGER update_users_updated_at
 BEFORE UPDATE ON users
 FOR EACH ROW
 EXECUTE PROCEDURE trigger_update_timestamp();
+DROP TRIGGER IF EXISTS update_todos_updated_at ON todos;
 CREATE TRIGGER update_todos_updated_at
 BEFORE UPDATE ON todos
 FOR EACH ROW

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS users (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+DROP TRIGGER IF EXISTS set_users_updated_at ON users;
 CREATE TRIGGER set_users_updated_at BEFORE UPDATE ON users
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
@@ -34,6 +35,7 @@ CREATE TABLE IF NOT EXISTS mindmaps (
   UNIQUE (id, user_id)
 );
 CREATE INDEX IF NOT EXISTS idx_mindmaps_user_id ON mindmaps(user_id);
+DROP TRIGGER IF EXISTS set_mindmaps_updated_at ON mindmaps;
 CREATE TRIGGER set_mindmaps_updated_at BEFORE UPDATE ON mindmaps
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
@@ -51,6 +53,7 @@ CREATE TABLE IF NOT EXISTS todos (
 );
 CREATE INDEX IF NOT EXISTS idx_todos_mindmap_id ON todos(mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_todos_user_id ON todos(user_id);
+DROP TRIGGER IF EXISTS set_todos_updated_at ON todos;
 CREATE TRIGGER set_todos_updated_at BEFORE UPDATE ON todos
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
@@ -67,6 +70,7 @@ CREATE TABLE IF NOT EXISTS payments (
   UNIQUE (payment_provider, provider_payment_id)
 );
 CREATE INDEX IF NOT EXISTS idx_payments_user_id ON payments(user_id);
+DROP TRIGGER IF EXISTS set_payments_updated_at ON payments;
 CREATE TRIGGER set_payments_updated_at BEFORE UPDATE ON payments
   FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+DROP TRIGGER IF EXISTS trg_users_updated_at ON users;
 CREATE TRIGGER trg_users_updated_at
 BEFORE UPDATE ON users
 FOR EACH ROW EXECUTE FUNCTION set_updated_at();
@@ -34,6 +35,7 @@ CREATE TABLE IF NOT EXISTS mindmaps (
 
 CREATE INDEX IF NOT EXISTS idx_mindmaps_owner_id ON mindmaps(owner_id);
 
+DROP TRIGGER IF EXISTS trg_mindmaps_updated_at ON mindmaps;
 CREATE TRIGGER trg_mindmaps_updated_at
 BEFORE UPDATE ON mindmaps
 FOR EACH ROW EXECUTE FUNCTION set_updated_at();
@@ -58,6 +60,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_nodes_mindmap_id_id ON nodes(mindmap_id, id
 CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes(mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_nodes_parent_id ON nodes(parent_id);
 
+DROP TRIGGER IF EXISTS trg_nodes_updated_at ON nodes;
 CREATE TRIGGER trg_nodes_updated_at
 BEFORE UPDATE ON nodes
 FOR EACH ROW EXECUTE FUNCTION set_updated_at();
@@ -80,6 +83,7 @@ CREATE INDEX IF NOT EXISTS idx_edges_mindmap_id ON edges(mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_edges_source_node_id ON edges(source_node_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target_node_id ON edges(target_node_id);
 
+DROP TRIGGER IF EXISTS trg_edges_updated_at ON edges;
 CREATE TRIGGER trg_edges_updated_at
 BEFORE UPDATE ON edges
 FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/migrations/002_add_orders_table.sql
+++ b/migrations/002_add_orders_table.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS orders (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+DROP TRIGGER IF EXISTS update_orders_updated_at ON orders;
 CREATE TRIGGER update_orders_updated_at
 BEFORE UPDATE ON orders
 FOR EACH ROW

--- a/migrations/002_create_maps.sql
+++ b/migrations/002_create_maps.sql
@@ -16,6 +16,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS set_mindmaps_updated_at ON mindmaps;
 CREATE TRIGGER set_mindmaps_updated_at
 BEFORE UPDATE ON mindmaps
 FOR EACH ROW EXECUTE PROCEDURE trigger_set_updated_at();


### PR DESCRIPTION
## Summary
- make SQL migrations idempotent by dropping triggers before creating them
- keep trigger names unique and prevent conflicts on repeated runs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687872bb560c832792bfa02ddc873c95