### PR TITLE
Fix migration failure by ensuring owner_id column

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -39,6 +39,13 @@ export async function runMigrations(): Promise<void> {
       ADD COLUMN IF NOT EXISTS user_id UUID
     `)
 
+    // Ensure the owner_id column exists for older migrations that
+    // still reference this column when creating indexes or constraints.
+    await client.query(`
+      ALTER TABLE mindmaps
+      ADD COLUMN IF NOT EXISTS owner_id UUID
+    `)
+
     await client.query(`
       CREATE TABLE IF NOT EXISTS nodes (
         id          UUID PRIMARY KEY,


### PR DESCRIPTION
## Summary
- update `runmigrations.ts` to pre-create `owner_id` on the `mindmaps` table to prevent index creation errors

## Testing
- `npx tsc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687882f681cc8327b770586fda665884