### PR TITLE
Fix ALTER TABLE statements in migrations

### DIFF
--- a/migrations/014_ensure_mindmap_id.sql
+++ b/migrations/014_ensure_mindmap_id.sql
@@ -1,8 +1,8 @@
 -- Ensure mindmap_id column exists in core tables
-ALTER TABLE IF EXISTS nodes
+ALTER TABLE nodes
   ADD COLUMN IF NOT EXISTS mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
 
-ALTER TABLE IF EXISTS todos
+ALTER TABLE todos
   ADD COLUMN IF NOT EXISTS mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
 
 CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes(mindmap_id);

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -65,7 +65,7 @@ export async function runMigrations(): Promise<void> {
     `)
 
     await client.query(`
-      ALTER TABLE IF EXISTS todos
+      ALTER TABLE todos
       ADD COLUMN IF NOT EXISTS mindmap_id UUID
         REFERENCES mindmaps(id) ON DELETE CASCADE
     `)


### PR DESCRIPTION
## Summary
- remove unsupported `IF EXISTS` from `ALTER TABLE` statements in migrations and initialization script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_687890970ac0832789d1daab7d2682be