### PR TITLE
Fix migrations for PostgreSQL 9.5

### DIFF
--- a/migrations/003_create_nodes.sql
+++ b/migrations/003_create_nodes.sql
@@ -12,9 +12,17 @@ CREATE TABLE IF NOT EXISTS nodes (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-ALTER TABLE nodes
-  ADD COLUMN IF NOT EXISTS mindmap_id UUID NOT NULL
-    REFERENCES mindmaps(id) ON DELETE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'nodes' AND column_name = 'mindmap_id'
+  ) THEN
+    ALTER TABLE nodes
+      ADD COLUMN mindmap_id UUID NOT NULL REFERENCES mindmaps(id) ON DELETE CASCADE;
+  END IF;
+END$$;
 
 CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes (mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_nodes_parent_id ON nodes (parent_id);

--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -25,9 +25,17 @@ CREATE TABLE IF NOT EXISTS todos (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-ALTER TABLE todos
-  ADD COLUMN IF NOT EXISTS mindmap_id UUID NOT NULL
-    REFERENCES mindmaps(id) ON DELETE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'todos' AND column_name = 'mindmap_id'
+  ) THEN
+    ALTER TABLE todos
+      ADD COLUMN mindmap_id UUID NOT NULL REFERENCES mindmaps(id) ON DELETE CASCADE;
+  END IF;
+END$$;
 
 CREATE INDEX IF NOT EXISTS idx_todos_user_id ON todos(user_id);
 CREATE INDEX IF NOT EXISTS idx_todos_mindmap_id ON todos(mindmap_id);

--- a/migrations/008_add_todo_assignee.sql
+++ b/migrations/008_add_todo_assignee.sql
@@ -1,2 +1,12 @@
-ALTER TABLE todos ADD COLUMN IF NOT EXISTS assignee_id UUID REFERENCES users(id) ON DELETE SET NULL;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'todos' AND column_name = 'assignee_id'
+  ) THEN
+    ALTER TABLE todos
+      ADD COLUMN assignee_id UUID REFERENCES users(id) ON DELETE SET NULL;
+  END IF;
+END$$;
 CREATE INDEX IF NOT EXISTS idx_todos_assignee_id ON todos(assignee_id);

--- a/migrations/014_ensure_mindmap_id.sql
+++ b/migrations/014_ensure_mindmap_id.sql
@@ -1,9 +1,27 @@
 -- Ensure mindmap_id column exists in core tables
-ALTER TABLE nodes
-  ADD COLUMN IF NOT EXISTS mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'nodes' AND column_name = 'mindmap_id'
+  ) THEN
+    ALTER TABLE nodes
+      ADD COLUMN mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
+  END IF;
+END$$;
 
-ALTER TABLE todos
-  ADD COLUMN IF NOT EXISTS mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'todos' AND column_name = 'mindmap_id'
+  ) THEN
+    ALTER TABLE todos
+      ADD COLUMN mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
+  END IF;
+END$$;
 
 CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes(mindmap_id);
 CREATE INDEX IF NOT EXISTS idx_todos_mindmap_id ON todos(mindmap_id);


### PR DESCRIPTION
## Summary
- replace `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements
- use `DO $$` blocks to avoid syntax unsupported in PostgreSQL 9.5

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions')*
- `npm run compile:functions` *(fails: Cannot find module '@netlify/functions' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6878964c8af883279350f5df8a4b022e