### PR TITLE
Fix duplicate trigger names

### DIFF
--- a/migrations/002_create_maps.sql
+++ b/migrations/002_create_maps.sql
@@ -16,8 +16,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS set_mindmaps_updated_at ON mindmaps;
-CREATE TRIGGER set_mindmaps_updated_at
+DROP TRIGGER IF EXISTS set_mindmaps_updated_at_v2 ON mindmaps;
+CREATE TRIGGER set_mindmaps_updated_at_v2
 BEFORE UPDATE ON mindmaps
 FOR EACH ROW EXECUTE PROCEDURE trigger_set_updated_at();
 

--- a/migrations/005_create_payments.sql
+++ b/migrations/005_create_payments.sql
@@ -47,8 +47,8 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS set_payments_updated_at ON payments;
-CREATE TRIGGER set_payments_updated_at
+DROP TRIGGER IF EXISTS set_payments_updated_at_v2 ON payments;
+CREATE TRIGGER set_payments_updated_at_v2
 BEFORE UPDATE ON payments
 FOR EACH ROW
 EXECUTE PROCEDURE payments_set_updated_at();


### PR DESCRIPTION
## Summary
- ensure trigger names are unique across migrations

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68789e53970c8327a355ac11eda4afb9