### PR TITLE
Fix DO block syntax in SQL migrations

### DIFF
--- a/migrations/002_add_orders_table.sql
+++ b/migrations/002_add_orders_table.sql
@@ -16,7 +16,7 @@ BEGIN
   ) THEN
     CREATE TYPE order_status AS ENUM ('pending', 'paid', 'canceled');
   END IF;
-END
+END;
 $$;
 
 CREATE TABLE IF NOT EXISTS orders (

--- a/migrations/003_create_nodes.sql
+++ b/migrations/003_create_nodes.sql
@@ -22,7 +22,7 @@ BEGIN
     ALTER TABLE nodes
       ADD COLUMN mindmap_id UUID NOT NULL REFERENCES mindmaps(id) ON DELETE CASCADE;
   END IF;
-END
+END;
 $$;
 
 CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes (mindmap_id);

--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -35,7 +35,7 @@ BEGIN
     ALTER TABLE todos
       ADD COLUMN mindmap_id UUID NOT NULL REFERENCES mindmaps(id) ON DELETE CASCADE;
   END IF;
-END
+END;
 $$;
 
 CREATE INDEX IF NOT EXISTS idx_todos_user_id ON todos(user_id);

--- a/migrations/005_create_payments.sql
+++ b/migrations/005_create_payments.sql
@@ -17,7 +17,7 @@ BEGIN
       'refunded'
     );
   END IF;
-END
+END;
 $$;
 
 CREATE TABLE IF NOT EXISTS payments (

--- a/migrations/008_add_todo_assignee.sql
+++ b/migrations/008_add_todo_assignee.sql
@@ -8,6 +8,6 @@ BEGIN
     ALTER TABLE todos
       ADD COLUMN assignee_id UUID REFERENCES users(id) ON DELETE SET NULL;
   END IF;
-END
+END;
 $$;
 CREATE INDEX IF NOT EXISTS idx_todos_assignee_id ON todos(assignee_id);

--- a/migrations/014_ensure_mindmap_id.sql
+++ b/migrations/014_ensure_mindmap_id.sql
@@ -9,7 +9,7 @@ BEGIN
     ALTER TABLE nodes
       ADD COLUMN mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
   END IF;
-END
+END;
 $$;
 
 DO $$
@@ -22,7 +22,7 @@ BEGIN
     ALTER TABLE todos
       ADD COLUMN mindmap_id UUID REFERENCES mindmaps(id) ON DELETE CASCADE;
   END IF;
-END
+END;
 $$;
 
 CREATE INDEX IF NOT EXISTS idx_nodes_mindmap_id ON nodes(mindmap_id);


### PR DESCRIPTION
## Summary
- fix missing semicolons in DO blocks across migration files

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6878a5d4c90083279e24f8c5c3fe674a