### PR TITLE
Fix DO block syntax

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -44,7 +44,7 @@ export async function runMigrations(): Promise<void> {
           ALTER TABLE mindmaps
             ADD COLUMN user_id UUID;
         END IF;
-      END
+      END;
       $$;
     `)
 
@@ -60,8 +60,8 @@ export async function runMigrations(): Promise<void> {
           ALTER TABLE mindmaps
             ADD COLUMN owner_id UUID;
         END IF;
-      END
-      $$;
+        END;
+        $$;
     `)
 
     await client.query(`
@@ -87,7 +87,7 @@ export async function runMigrations(): Promise<void> {
             ADD COLUMN mindmap_id UUID NOT NULL
               REFERENCES mindmaps(id);
         END IF;
-      END
+      END;
       $$;
     `)
 
@@ -102,7 +102,7 @@ export async function runMigrations(): Promise<void> {
             ADD COLUMN mindmap_id UUID
               REFERENCES mindmaps(id) ON DELETE CASCADE;
         END IF;
-      END
+      END;
       $$;
     `)
     const files = fs.readdirSync(migrationsDir)


### PR DESCRIPTION
## Summary
- fix missing semicolons inside `END` statements in `runmigrations.ts`

## Testing
- `grep -n "END;" -n runmigrations.ts`


------
https://chatgpt.com/codex/tasks/task_e_6878aa1c216c8327b62b6b6ca4227fb7