### PR TITLE
Add warning for repeated migration

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -116,7 +116,10 @@ export async function runMigrations(): Promise<void> {
     const { rows } = await client.query<{ name: string }>('SELECT name FROM migrations')
     const applied = new Set(rows.map((r: any) => r.name))
     for (const file of files) {
-      if (applied.has(file)) continue
+      if (applied.has(file)) {
+        console.warn(`[skip] Migration already applied: ${file}`)
+        continue
+      }
       const filePath = path.join(migrationsDir, file)
       const sql = fs.readFileSync(filePath, 'utf8')
       await client.query('BEGIN')


### PR DESCRIPTION
## Summary
- log when a migration file has already been applied so repeated names don't silently skip

## Testing
- `node --test` *(fails: Cannot find package 'pg' and afterEach not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68792ab5b4148327bbbfe18b085487c8