### PR TITLE
Fix SQL syntax in todo migration

### DIFF
--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -19,7 +19,7 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS todos (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  user_id UUID NOT NULL,
+  user_id UUID,
   mindmap_id UUID NOT NULL
 );
 


### PR DESCRIPTION
## Summary
- remove `NOT NULL` constraint on `user_id` in `004_create_todos.sql`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68795ca7278c8327bf49d088b9b20052