### PR TITLE
Fix todo migration

### DIFF
--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -1,25 +1,41 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-CREATE TYPE IF NOT EXISTS todo_ai_status AS ENUM (
-  'pending',
-  'in_progress',
-  'completed',
-  'failed'
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'todo_ai_status'
+  ) THEN
+    CREATE TYPE todo_ai_status AS ENUM (
+      'pending',
+      'in_progress',
+      'completed',
+      'failed'
+    );
+  END IF;
+END;
+$$;
 
-CREATE TYPE IF NOT EXISTS todo_status AS ENUM (
-  'pending',
-  'in_progress',
-  'completed',
-  'cancelled'
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type WHERE typname = 'todo_status'
+  ) THEN
+    CREATE TYPE todo_status AS ENUM (
+      'pending',
+      'in_progress',
+      'completed',
+      'cancelled'
+    );
+  END IF;
+END;
+$$;
 
 BEGIN;
 
 CREATE TABLE IF NOT EXISTS todos (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  user_id UUID,
+  user_id UUID NOT NULL,
   mindmap_id UUID NOT NULL
 );
 


### PR DESCRIPTION
## Summary
- fix 'CREATE TYPE IF NOT EXISTS' syntax by using DO blocks
- require `user_id` when creating `todos`

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68795fadd840832784906c2665e3b55d