### PR TITLE
Restore todos migration

### DIFF
--- a/migrations/004_create_todos.sql
+++ b/migrations/004_create_todos.sql
@@ -36,7 +36,40 @@ BEGIN;
 CREATE TABLE IF NOT EXISTS todos (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   user_id UUID NOT NULL,
-  mindmap_id UUID NOT NULL
+  mindmap_id UUID NOT NULL,
+  node_id UUID DEFAULT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  status todo_status NOT NULL DEFAULT 'pending',
+  due_at TIMESTAMPTZ,
+  ai_generated BOOLEAN NOT NULL DEFAULT FALSE,
+  ai_status todo_ai_status,
+  ai_response JSONB,
+  metadata JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (mindmap_id) REFERENCES mindmaps(id) ON DELETE CASCADE,
+  FOREIGN KEY (node_id) REFERENCES nodes(id) ON DELETE SET NULL
 );
 
 COMMIT;
+
+CREATE INDEX IF NOT EXISTS idx_todos_user_id ON todos(user_id);
+CREATE INDEX IF NOT EXISTS idx_todos_mindmap_id ON todos(mindmap_id);
+CREATE INDEX IF NOT EXISTS idx_todos_node_id ON todos(node_id);
+CREATE INDEX IF NOT EXISTS idx_todos_due_at ON todos(due_at);
+CREATE INDEX IF NOT EXISTS idx_todos_user_id_status ON todos(user_id, status);
+
+CREATE OR REPLACE FUNCTION refresh_todos_updated_at() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_refresh_todos_updated_at ON todos;
+CREATE TRIGGER trg_refresh_todos_updated_at
+  BEFORE UPDATE ON todos
+  FOR EACH ROW
+  EXECUTE PROCEDURE refresh_todos_updated_at();


### PR DESCRIPTION
## Summary
- restore the full todo migration structure
- add indexes and trigger logic after COMMIT

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions')*

------
https://chatgpt.com/codex/tasks/task_e_687963b573d083278d324426f4df0ed3