### PR TITLE
Fix missing vite in build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,8 @@
   "name": "netlify-vite-neon-app",
   "version": "0.1.0",
   "lockfileVersion": 3,
-  "packages": {}
+  "packages": {},
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@vercel/postgres": "^0.10.0"
   },
   "devDependencies": {
+    "vite": "^5.0.0",
     "typescript": "^5.1.0",
     "@types/node": "^20.0.0",
     "@types/pg": "^8.6.6",


### PR DESCRIPTION
## Summary
- add vite to devDependencies
- record vite dev dependency in lockfile

## Testing
- `npm install --save-dev vite` *(fails: 403 Forbidden; environment lacks network)*

------
https://chatgpt.com/codex/tasks/task_e_68796a20663c83278a65e79eccdb9718