### PR TITLE
Fix syntax error in vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,12 @@
-const env = loadEnv(mode, process.cwd(), '')
+import { defineConfig, loadEnv } from 'vite'
+import react from '@vitejs/plugin-react'
+import netlify from '@netlify/vite-plugin-netlify'
+import path from 'path'
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
   return {
-    plugins: [
-      react(),
-      netlify()
-    ],
+    plugins: [react(), netlify()],
     envPrefix: 'VITE_',
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- fix malformed vite.config.js file

## Testing
- `npm run build` *(fails: Cannot find type definition file for '@netlify/functions')*

------
https://chatgpt.com/codex/tasks/task_e_68796c28d8888327b6700a56694b5b27