### PR TITLE
Restore Vite build output and main entry

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,16 +2,8 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 
-console.log('main.tsx: script start')
-
-const root = document.getElementById('root')
-if (!root) {
-  console.error('Missing #root div in index.html')
-} else {
-  console.log('main.tsx: rendering App')
-  ReactDOM.createRoot(root).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  )
-}
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   build: {
-    outDir: 'dist'
+    outDir: 'dist',
+    emptyOutDir: true,
   }
 })


### PR DESCRIPTION
## Summary
- restore the default `main.tsx` setup
- ensure `vite.config.ts` cleans the dist directory before building

## Testing
- `node --test` *(fails: cannot find package / pg and afterEach is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6879b7c412348327a4f5d10fa06d3a21