### PR TITLE
Fix header/footer blank page issue

### DIFF
--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -1,4 +1,6 @@
-const BRAND_NAME = 'Mindxdo';
+import { Link } from 'react-router-dom'
+
+const BRAND_NAME = 'Mindxdo'
 const CURRENT_YEAR = new Date().getFullYear();
 const FOOTER_LINKS = [
   { label: 'GitHub', href: 'https://github.com/your-org/plan-scaler-mindmap-tools', external: true },
@@ -11,7 +13,7 @@ function Footer(): JSX.Element {
   return (
     <footer className="footer" role="contentinfo">
       <div className="footer__content">
-        <p>? {CURRENT_YEAR} {BRAND_NAME}. All rights reserved.</p>
+        <p>&copy; {CURRENT_YEAR} {BRAND_NAME}. All rights reserved.</p>
         <nav aria-label="Footer navigation">
           <ul className="footer__links">
             {FOOTER_LINKS.map(({ label, href, external }) => (

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -1,3 +1,12 @@
+import { useState, useRef, useEffect } from 'react'
+import { Link, NavLink, useNavigate, useLocation } from 'react-router-dom'
+import { useAuth } from './useAuth'
+
+export interface NavItem {
+  label: string
+  route: string
+}
+
 const Header = (): JSX.Element => {
   const [isProfileMenuOpen, setProfileMenuOpen] = useState(false)
   const [isMobileNavOpen, setMobileNavOpen] = useState(false)

--- a/src/useAuth.ts
+++ b/src/useAuth.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react'
+
+export interface User {
+  name: string
+  avatarUrl?: string
+  role?: string
+}
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null)
+  const logout = () => setUser(null)
+  return { user, logout }
+}


### PR DESCRIPTION
## Summary
- import necessary React and router helpers in Header
- define `NavItem` interface for navigation links
- fix Footer imports and copy text
- add simple `useAuth` hook

## Testing
- ❌ `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6879b968afd0832791e1ebea2dd37deb