### PR TITLE
Fix routing and add basic pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,9 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Homepage from './homepage'
+import LoginPage from './LoginPage'
+import DashboardPage from './DashboardPage'
+import BillingPage from './BillingPage'
+import NotFound from './NotFound'
 import Header from './header'
 import Footer from './footer'
 
@@ -9,6 +13,10 @@ export default function App() {
       <Header />
       <Routes>
         <Route path="/" element={<Homepage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/payment" element={<BillingPage />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/BillingPage.tsx
+++ b/src/BillingPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const BillingPage = () => {
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Billing</h1>
+    </div>
+  )
+}
+
+export default BillingPage

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const DashboardPage = () => {
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>Dashboard</h1>
+    </div>
+  )
+}
+
+export default DashboardPage

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import React, { Component, ReactNode, ErrorInfo } from 'react'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error?: Error
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div role="alert">Something went wrong.</div>
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -1,0 +1,34 @@
+import React, { useState, FormEvent } from 'react'
+
+const LoginPage = () => {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    })
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Email</label>
+          <input type="email" value={email} onChange={e => setEmail(e.target.value)} />
+        </div>
+        <div>
+          <label>Password</label>
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        </div>
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  )
+}
+
+export default LoginPage

--- a/src/NotFound.tsx
+++ b/src/NotFound.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+const NotFound = () => {
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h1>404 - Page Not Found</h1>
+      <Link to="/">Go Home</Link>
+    </div>
+  )
+}
+
+export default NotFound

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import ErrorBoundary from './ErrorBoundary'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <ErrorBoundary>
     <App />
-  </React.StrictMode>
+  </ErrorBoundary>
 )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- add ErrorBoundary component and use in main.tsx
- create simple pages for Login, Dashboard, Billing, and NotFound
- update App routing with BrowserRouter, Header and Footer
- set Vite base path

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6879bb318c3c8327964ee879ccdd332a