### PR TITLE
Restore minimal Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
-  base: '/',
   plugins: [react()],
-  build: {
-    outDir: 'dist',
-    emptyOutDir: true,
-  }
+  base: '/', // ✅ use '/' unless you're deploying under a subpath
 })


### PR DESCRIPTION
## Summary
- simplify `vite.config.ts` to just include the React plugin and base path

## Testing
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6879bf54e0a48327aae5cc6c0a39f148