### PR TITLE
Display marketing home with styling

### DIFF
--- a/hero.tsx
+++ b/hero.tsx
@@ -83,7 +83,7 @@ const Hero: React.FC = () => {
       <div className="shape shape-circle hero-shape2" />
       <div className="relative z-10 flex flex-col items-center justify-center h-full text-center px-4">
         <h1 className="text-5xl md:text-6xl font-extrabold text-white mb-4">
-          Mindxdo
+          MindXdo
         </h1>
         <p className="text-lg md:text-xl text-white/80 mb-8 max-w-xl">
           Organize your mindmaps and todos with AI-driven automations for a

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -30,7 +30,7 @@ const features = [
   {
     title: 'AI Automation',
     description:
-      'Let Mindxdo suggest tasks and connections so you can focus on the experience.',
+      'Let MindXdo suggest tasks and connections so you can focus on the experience.',
     icon: './assets/placeholder.png',
   },
 ]
@@ -87,10 +87,10 @@ const Homepage: React.FC = (): JSX.Element => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <h1>Mindxdo: Mindmaps Meet Todos with AI</h1>
+          <h1>MindXdo: Mindmaps Meet Todos with AI</h1>
           <p>
             Experience the power of AI as your ideas become actionable plans.
-            Mindxdo weaves mindmaps and todos together so you can strategize
+            MindXdo weaves mindmaps and todos together so you can strategize
             and execute without friction.
           </p>
           <button
@@ -143,7 +143,7 @@ const Homepage: React.FC = (): JSX.Element => {
 
       <section className="demo">
         <h2>Try It Live</h2>
-        <p>Interactive demo of Mindxdo ? no signup required.</p>
+        <p>Interactive demo of MindXdo – no signup required.</p>
         <Demo />
       </section>
 
@@ -176,7 +176,7 @@ const Homepage: React.FC = (): JSX.Element => {
         </motion.h2>
         <p className="ai-copy">
           Harness automation to turn complex mindmaps into actionable workflows.
-          Mindxdo helps you execute ambitious plans with ease.
+          MindXdo helps you execute ambitious plans with ease.
         </p>
         <img
           src="./assets/placeholder.png"
@@ -214,7 +214,7 @@ const Homepage: React.FC = (): JSX.Element => {
       <section className="faq">
         <h2>Frequently Asked Questions</h2>
         {[
-          { q: 'What is Mindxdo?', a: 'An AI-driven experience blending mindmaps and todos.' },
+          { q: 'What is MindXdo?', a: 'An AI-driven experience blending mindmaps and todos.' },
           { q: 'How does the AI help?', a: 'It automates task creation and finds connections between ideas.' },
           { q: 'Can I collaborate with my team?', a: 'Yes, share maps and task boards in real time.' },
         ].map(item => (
@@ -228,7 +228,7 @@ const Homepage: React.FC = (): JSX.Element => {
       </section>
 
       <footer className="site-footer">
-        <p>&copy; {new Date().getFullYear()} Mindxdo. All rights reserved.</p>
+        <p>&copy; {new Date().getFullYear()} MindXdo. All rights reserved.</p>
       </footer>
     </div>
   )

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mindxdo</title>
+    <title>MindXdo</title>
+    <link rel="stylesheet" href="/global.scss" />
   </head>
   <body>
     <div id="root"></div>

--- a/layout.tsx
+++ b/layout.tsx
@@ -29,7 +29,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
       </a>
       <header className="layout-header">
         <div className="layout-header-inner">
-          <h1 className="layout-logo">Mindxdo</h1>
+          <h1 className="layout-logo">MindXdo</h1>
           <button
             type="button"
             ref={buttonRef}
@@ -98,7 +98,7 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
       </main>
       <footer className="layout-footer">
         <div className="layout-footer-inner">
-          &copy; {new Date().getFullYear()} Mindxdo. All rights reserved.
+          &copy; {new Date().getFullYear()} MindXdo. All rights reserved.
         </div>
       </footer>
     </div>

--- a/privacypolicy.tsx
+++ b/privacypolicy.tsx
@@ -7,7 +7,7 @@ export default function PrivacyPolicy(): JSX.Element {
       <section className="mb-8">
         <h2 className="text-2xl font-semibold mb-4">1. Introduction</h2>
         <p>
-          Welcome to Mindxdo. Your privacy is important to us. This Privacy Policy
+          Welcome to MindXdo. Your privacy is important to us. This Privacy Policy
           explains how we collect, use, disclose, and safeguard your information when you
           visit our website and use our services.
         </p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
-import Homepage from './homepage'
+import Homepage from '../homepage'
 import LoginPage from './LoginPage'
 import DashboardPage from './DashboardPage'
 import BillingPage from './BillingPage'

--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 
-const BRAND_NAME = 'Mindxdo'
+const BRAND_NAME = 'MindXdo'
 const CURRENT_YEAR = new Date().getFullYear();
 const FOOTER_LINKS = [
   { label: 'GitHub', href: 'https://github.com/your-org/plan-scaler-mindmap-tools', external: true },

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -82,7 +82,7 @@ const Header = (): JSX.Element => {
           <Link to="/" aria-label="Home">
             <img
               src="./assets/placeholder.png"
-              alt="Mindxdo logo"
+              alt="MindXdo logo"
               className="header__logo-img"
             />
           </Link>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import ErrorBoundary from './ErrorBoundary'
+import '../global.scss'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <ErrorBoundary>


### PR DESCRIPTION
## Summary
- show actual marketing Homepage component
- pull in global styles and update site title
- use consistent MindXdo branding across pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c12539e0832798e4603720a455b7