### PR TITLE
Fix immutable module error

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-router-dom": "^6.30.1",
     "stripe": "^12.0.0",
     "uuid": "^8.3.2",
-    "zod": "^3.21.4"
+    "zod": "^3.21.4",
+    "immutable": "^4.3.4"
   },
   "devDependencies": {
     "@netlify/functions": "^1.0.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: '/', // ✅ use '/' unless you're deploying under a subpath
+  build: {
+    rollupOptions: {
+      external: ['immutable'],
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add `immutable` to dependencies
- treat `immutable` as an external in Vite config

## Testing
- `node --test tests/db-client.test.js` *(fails: Cannot find package 'pg' imported from /workspace/mindmapx/netlify/functions/db-client.js)*

------
https://chatgpt.com/codex/tasks/task_e_6879d12f897083278cbbbaef3cff93e7