### PR TITLE
Improve marketing layout

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -78,7 +78,8 @@ const Homepage: React.FC = (): JSX.Element => {
 
   return (
     <div className="homepage">
-      <section className="hero relative">
+      <section className="hero section relative">
+        <div className="container">
         <div className="shape shape-circle hero-shape1" />
         <div className="shape shape-circle hero-shape2" />
         <motion.div
@@ -115,11 +116,13 @@ const Homepage: React.FC = (): JSX.Element => {
             />
           </AnimatePresence>
         </div>
+        </div>
       </section>
 
 
 
-      <section className="features">
+      <section className="features section">
+        <div className="container">
         <h2>Features</h2>
         <div className="feature-grid">
           {features.map((f, i) => (
@@ -139,32 +142,40 @@ const Homepage: React.FC = (): JSX.Element => {
             </motion.div>
           ))}
         </div>
-      </section>
-
-      <section className="demo">
-        <h2>Try It Live</h2>
-        <p>Interactive demo of MindXdo – no signup required.</p>
-        <Demo />
-      </section>
-
-      <section className="two-column">
-        <div className="bold-marketing-text">
-          Map your ideas visually while keeping tasks in focus.
         </div>
-        <img
-          src="./assets/placeholder.png"
-          alt="Two column placeholder"
-          className="banner-image"
-        />
       </section>
 
-      <section className="three-column">
-        <div className="bold-marketing-text">Plan</div>
-        <div className="bold-marketing-text">Track</div>
-        <div className="bold-marketing-text">Launch</div>
+      <section className="demo section">
+        <div className="container">
+          <h2>Try It Live</h2>
+          <p>Interactive demo of MindXdo – no signup required.</p>
+          <Demo />
+        </div>
       </section>
 
-      <section className="ai-power relative">
+      <section className="two-column section">
+        <div className="container two-column">
+          <div className="bold-marketing-text">
+            Map your ideas visually while keeping tasks in focus.
+          </div>
+          <img
+            src="./assets/placeholder.png"
+            alt="Two column placeholder"
+            className="banner-image"
+          />
+        </div>
+      </section>
+
+      <section className="three-column section">
+        <div className="container three-column">
+          <div className="bold-marketing-text">Plan</div>
+          <div className="bold-marketing-text">Track</div>
+          <div className="bold-marketing-text">Launch</div>
+        </div>
+      </section>
+
+      <section className="ai-power section relative">
+        <div className="container">
         <div className="shape shape-circle ai-power-shape" />
         <motion.h2
           initial={{ opacity: 0, scale: 0.8 }}
@@ -183,9 +194,11 @@ const Homepage: React.FC = (): JSX.Element => {
           alt="AI showcase"
           className="banner-image"
         />
+        </div>
       </section>
 
-      <section className="pricing">
+      <section className="pricing section">
+        <div className="container">
         <motion.div
           className="pricing-content"
           initial={{ opacity: 0, scale: 0.9 }}
@@ -209,9 +222,11 @@ const Homepage: React.FC = (): JSX.Element => {
             {loading ? 'Processing...' : 'Upgrade Now'}
           </button>
         </motion.div>
+        </div>
       </section>
 
-      <section className="faq">
+      <section className="faq section">
+        <div className="container">
         <h2>Frequently Asked Questions</h2>
         {[
           { q: 'What is MindXdo?', a: 'An AI-driven experience blending mindmaps and todos.' },
@@ -225,10 +240,13 @@ const Homepage: React.FC = (): JSX.Element => {
             </details>
           </motion.div>
         ))}
+        </div>
       </section>
 
       <footer className="site-footer">
-        <p>&copy; {new Date().getFullYear()} MindXdo. All rights reserved.</p>
+        <div className="container">
+          <p>&copy; {new Date().getFullYear()} MindXdo. All rights reserved.</p>
+        </div>
       </footer>
     </div>
   )

--- a/src/global.scss
+++ b/src/global.scss
@@ -2,21 +2,21 @@
   --font-sans: 'Inter', sans-serif;
   --font-mono: 'Fira Code', monospace;
 
-  --color-primary: #f97316;
-  --color-secondary: #334155;
-  --color-accent: #fb923c;
+  --color-primary: #0a84ff;
+  --color-secondary: #1e1e1e;
+  --color-accent: #30d158;
   --color-success: #10b981;
   --color-warning: #f59e0b;
   --color-error: #ef4444;
-  --color-info: #3b82f6;
+  --color-info: #64d2ff;
 
   --color-bg: #ffffff;
-  --color-bg-alt: #f1f5f9;
+  --color-bg-alt: #f2f2f7;
   --color-surface: #ffffff;
-  --color-border: #e2e8f0;
+  --color-border: #e5e5ea;
 
-  --color-text: #0f172a;
-  --color-text-muted: #475569;
+  --color-text: #1c1c1e;
+  --color-text-muted: #6e6e73;
   --color-text-inverse: #ffffff;
 
   --transition-duration: 0.3s;
@@ -423,4 +423,139 @@ hr {
   width: 300px;
   height: 300px;
   background: radial-gradient(circle at center, var(--color-secondary), transparent);
+}
+
+/* --- Layout Enhancements --- */
+.section {
+  padding: var(--spacing-2xl) var(--spacing-lg);
+}
+
+.section .container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.hero {
+  text-align: center;
+  position: relative;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 10;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background-color: var(--color-bg);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.header__container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  padding: var(--spacing-md);
+  margin: 0 auto;
+}
+
+.header__nav-list {
+  display: flex;
+  gap: var(--spacing-lg);
+}
+
+.header__nav-link {
+  color: var(--color-text);
+  padding: var(--spacing-sm) var(--spacing-xs);
+  transition: color var(--transition-duration) var(--transition-ease);
+  font-weight: 500;
+}
+
+.header__nav-link--active,
+.header__nav-link:hover {
+  color: var(--color-primary);
+}
+
+.header__toggle {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.header__toggle-bar {
+  width: 24px;
+  height: 2px;
+  background-color: var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .header__toggle {
+    display: flex;
+  }
+  .header__nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background-color: var(--color-bg);
+    flex-direction: column;
+    transform: translateY(-200%);
+    transition: transform var(--transition-duration) var(--transition-ease);
+  }
+  .header__nav.header__nav--open {
+    transform: translateY(0);
+  }
+  .header__nav-list {
+    flex-direction: column;
+    padding: var(--spacing-md);
+    gap: var(--spacing-md);
+  }
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--spacing-lg);
+  margin-top: var(--spacing-lg);
+}
+
+.feature-card {
+  background-color: var(--color-surface);
+  border-radius: 8px;
+  padding: var(--spacing-lg);
+  text-align: center;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  transition: transform var(--transition-duration) var(--transition-ease);
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+}
+
+.feature-card__icon {
+  height: 64px;
+  margin-bottom: var(--spacing-md);
+}
+
+.pricing-content {
+  background-color: var(--color-surface);
+  padding: var(--spacing-xl);
+  border-radius: 8px;
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  text-align: center;
+}
+
+.site-footer {
+  text-align: center;
+  padding: var(--spacing-lg) var(--spacing-md);
+  background-color: var(--color-bg-alt);
 }


### PR DESCRIPTION
## Summary
- switch to lighter color palette and build responsive header styles
- modernize marketing homepage with centered sections

## Testing
- `node --test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6879d29c7a0c8327838b32ae272c9cd6