### PR TITLE
Add marketing pages and scroll effects

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+import useScrollReveal from './useScrollReveal'
+
+export default function AboutPage(): JSX.Element {
+  useScrollReveal()
+  return (
+    <div className="about-page">
+      <section className="section section--one-col reveal">
+        <h1>About MindXdo</h1>
+        <p>MindXdo blends mindmaps and todos with AI so you can plan and execute seamlessly.</p>
+        <Link to="/payment" className="btn">Purchase</Link>
+      </section>
+      <section className="section section--two-col reveal">
+        <div>
+          <h2>Our Mission</h2>
+          <p>We help you visualize ideas and turn them into actionable tasks.</p>
+        </div>
+        <img src="./assets/placeholder.png" alt="Mission" />
+      </section>
+      <section className="section section--three-col reveal">
+        <div>Plan</div>
+        <div>Track</div>
+        <div>Launch</div>
+      </section>
+    </div>
+  )
+}

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import FeatureCard from './featurecard'
 import Demo from './demo'
@@ -36,7 +37,6 @@ const features = [
 ]
 
 const Homepage: React.FC = (): JSX.Element => {
-  const [loading, setLoading] = useState(false)
   const heroImages = [
     './assets/placeholder.png',
     './assets/placeholder.png',
@@ -51,30 +51,6 @@ const Homepage: React.FC = (): JSX.Element => {
     return () => clearInterval(id)
   }, [])
 
-  const handleCheckout = async () => {
-    if (loading) return
-    setLoading(true)
-    try {
-      const res = await fetch(
-        '/.netlify/functions/create-checkout-session',
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ planId: 'mindmap_todo_pro' }),
-        }
-      )
-      const data = await res.json()
-      if (data.sessionUrl) {
-        window.location.href = data.sessionUrl
-      } else {
-        console.error('No session URL returned')
-      }
-    } catch (err) {
-      console.error('Checkout error', err)
-    } finally {
-      setLoading(false)
-    }
-  }
 
   return (
     <div className="homepage">
@@ -94,13 +70,9 @@ const Homepage: React.FC = (): JSX.Element => {
             MindXdo weaves mindmaps and todos together so you can strategize
             and execute without friction.
           </p>
-          <button
-            className="btn-primary"
-            onClick={handleCheckout}
-            disabled={loading}
-          >
-            {loading ? 'Processing...' : 'Get Started'}
-          </button>
+          <Link to="/payment" className="btn-primary">
+            Get Started
+          </Link>
         </motion.div>
         <div className="banner-slider">
           <AnimatePresence mode="wait">
@@ -214,13 +186,9 @@ const Homepage: React.FC = (): JSX.Element => {
             <li>Priority support</li>
             <li>All future features</li>
           </ul>
-          <button
-            className="btn-secondary"
-            onClick={handleCheckout}
-            disabled={loading}
-          >
-            {loading ? 'Processing...' : 'Upgrade Now'}
-          </button>
+          <Link to="/payment" className="btn-secondary">
+            Upgrade Now
+          </Link>
         </motion.div>
         </div>
       </section>

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -30,7 +30,12 @@ const defaultNodes: Node[] = [
   }
 ]
 
+import { useRef, useState, useEffect, useLayoutEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import useScrollReveal from './useScrollReveal'
+
 export default function MindmapDemo(): JSX.Element {
+  useScrollReveal()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [flatNodes, setFlatNodes] = useState<Node[]>([])
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
@@ -162,9 +167,14 @@ export default function MindmapDemo(): JSX.Element {
   }, [handleNodeClick])
 
   return (
-    <canvas
-      ref={canvasRef}
-      style={{ width: '100%', maxWidth: '800px', height: 'auto', display: 'block' }}
-    />
+    <div className="mindmap-demo reveal section section--one-col">
+      <canvas
+        ref={canvasRef}
+        style={{ width: '100%', maxWidth: '800px', height: 'auto', display: 'block' }}
+      />
+      <div className="mt-md">
+        <Link to="/payment" className="btn">Upgrade</Link>
+      </div>
+    </div>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,12 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Homepage from '../homepage'
-import LoginPage from './LoginPage'
+import LoginPage from '../login'
+import ResetPasswordPage from '../reset-password'
+import AboutPage from '../about'
+import MindmapDemo from '../mindmapdemo'
+import TodoDemo from '../tododemo'
 import DashboardPage from './DashboardPage'
-import BillingPage from './BillingPage'
+import PaymentPage from '../paymentpage'
 import NotFound from './NotFound'
 import Header from './header'
 import Footer from './footer'
@@ -13,9 +17,13 @@ export default function App() {
       <Header />
       <Routes>
         <Route path="/" element={<Homepage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="/mindmap-demo" element={<MindmapDemo />} />
+        <Route path="/todo-demo" element={<TodoDemo />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
-        <Route path="/payment" element={<BillingPage />} />
+        <Route path="/payment" element={<PaymentPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />

--- a/src/global.scss
+++ b/src/global.scss
@@ -351,6 +351,25 @@ hr {
   text-align: center;
 }
 
+.section--one-col {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-lg);
+}
+
+.section--two-col {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-lg);
+}
+
+.section--three-col {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-lg);
+  text-align: center;
+}
+
 .bold-marketing-text {
   font-size: 1.5rem;
   font-weight: 700;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -18,8 +18,18 @@ const Header = (): JSX.Element => {
   const location = useLocation()
   const { user, logout } = useAuth()
 
+  const marketingItems: NavItem[] = [
+    { label: 'Home', route: '/' },
+    { label: 'About', route: '/about' },
+    { label: 'Mindmap Demo', route: '/mindmap-demo' },
+    { label: 'Todo Demo', route: '/todo-demo' },
+    { label: 'Purchase', route: '/payment' },
+    { label: 'Reset Password', route: '/reset-password' },
+  ]
+
   const navItems: NavItem[] = user
     ? [
+        ...marketingItems,
         { label: 'Dashboard', route: '/dashboard' },
         { label: 'Mindmaps', route: '/mindmaps' },
         { label: 'Todos', route: '/todos' },
@@ -31,7 +41,7 @@ const Header = (): JSX.Element => {
             ]
           : []),
       ]
-    : [{ label: 'Home', route: '/' }]
+    : [...marketingItems, { label: 'Login', route: '/login' }]
 
   const handleAvatarClick = (): void => {
     setProfileMenuOpen(prev => !prev)

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -1,4 +1,9 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import useScrollReveal from './useScrollReveal'
+
 export default function TodoDemo(): JSX.Element {
+  useScrollReveal()
   const [mode, setMode] = useState<Mode>('manual')
   const [todos, setTodos] = useState<Todo[]>([])
   const [inputText, setInputText] = useState<string>('')
@@ -47,7 +52,7 @@ export default function TodoDemo(): JSX.Element {
   }
 
   return (
-    <div className="todo-demo">
+    <div className="todo-demo reveal section section--one-col">
       <div className="mode-toggle">
         <button onClick={() => toggleMode('manual')} disabled={mode === 'manual'}>
           Manual
@@ -85,6 +90,9 @@ export default function TodoDemo(): JSX.Element {
             ))}
           </ul>
         )}
+      </div>
+      <div className="mt-md">
+        <Link to="/payment" className="btn">Upgrade</Link>
       </div>
     </div>
   )

--- a/useScrollReveal.ts
+++ b/useScrollReveal.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+
+export default function useScrollReveal(selector = '.reveal') {
+  useEffect(() => {
+    const elements = Array.from(document.querySelectorAll<HTMLElement>(selector))
+    if (elements.length === 0) return
+
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible')
+        }
+      })
+    }, { threshold: 0.1 })
+
+    elements.forEach(el => observer.observe(el))
+    return () => {
+      elements.forEach(el => observer.unobserve(el))
+    }
+  }, [selector])
+}


### PR DESCRIPTION
## Summary
- add a lightweight scroll reveal hook
- create About page with purchase button
- update Mindmap and Todo demo pages with links to payment page
- enhance navigation with marketing links and reset password page
- link homepage CTAs to the payment page
- support simple column layouts in CSS

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d595ef6c832784e8efacd0d8753b