### PR TITLE
Fix build by removing sass-embedded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@types/stripe": "^8.0.417",
         "@types/uuid": "^8.3.4",
         "@vitejs/plugin-react": "^4.0.3",
-        "sass-embedded": "^1.69.5",
         "sass": "^1.69.5",
         "typescript": "^5.1.0",
         "vite": "^5.0.0"
@@ -3266,7 +3265,6 @@
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
-        "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
         "terser": "^5.4.0"
@@ -3282,9 +3280,6 @@
           "optional": true
         },
         "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
           "optional": true
         },
         "stylus": {
@@ -3391,17 +3386,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/sass-embedded": {
-      "version": "1.69.5",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.69.5.tgz",
-      "integrity": "",
-      "dev": true,
-      "license": "MIT"
-    }
-  },
-  "devDependencies": {
-    "vite": "^5.0.0",
-    "sass-embedded": "^1.69.5",
     "sass": "^1.69.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/stripe": "^8.0.417",
     "@types/uuid": "^8.3.4",
     "@vitejs/plugin-react": "^4.0.3",
-    "sass-embedded": "^1.69.5",
     "sass": "^1.69.5",
     "typescript": "^5.1.0",
     "vite": "^5.0.0"


### PR DESCRIPTION
## Summary
- remove `sass-embedded` dev dependency to avoid missing `@bufbuild/protobuf` module

## Testing
- `npm install` *(fails: "The \"paths[1]\" argument must be of type string" due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6879dc5bbbd48327ac1b20dd9eb9c7b3