### PR TITLE
Fix sass build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=18",
+    "npm": ">=8.0.0 <10.0.0"
   },
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,13 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        additionalData: `@import "./src/global.scss";`
+      }
+    }
+  },
   base: '/', // ✅ use '/' unless you're deploying under a subpath
   build: {
     rollupOptions: {


### PR DESCRIPTION
## Summary
- add npm version range to engines block
- configure vite for global SCSS imports

## Testing
- `npm install` *(fails: ERR_INVALID_ARG_TYPE)*

------
https://chatgpt.com/codex/tasks/task_e_6879e1af2c9c8327bec6a5d55ba1356c