### PR TITLE
Pin Node and npm versions to avoid Netlify incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=18",
-    "npm": ">=8.0.0 <10.0.0"
+    "node": "20.x",
+    "npm": "9.x"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- pin Node to `20.x` and npm to `9.x` in `package.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879e4a0f9ec8327a409d21ff17a8b04