### PR TITLE
Fix npm version instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project uses Netlify Functions and a Neon database. SQL migration files are
 
 ## Deploying
 
-1. Install dependencies (optional if the build only runs in CI):
+1. Install dependencies (optional if the build only runs in CI). Use Node.js 20
+   with npm version 9 or newer:
    ```bash
    npm install
    ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "engines": {
     "node": "20.x",
-    "npm": "9.x"
+    "npm": ">=9"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- broaden the allowed npm version in `package.json`
- clarify required Node and npm versions in the README

## Testing
- `node --test tests/db-client.test.js` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_6879e53a793c83279bc51ec343659d9b