### PR TITLE
Specify npm 9.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project uses Netlify Functions and a Neon database. SQL migration files are
 ## Deploying
 
 1. Install dependencies (optional if the build only runs in CI). Use Node.js 20
-   with npm version 9 or newer:
+   with npm version 9.9.4 or newer:
    ```bash
    npm install
    ```

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ publish = "dist"
 
 [build.environment]
 NODE_VERSION = "20"
-NPM_VERSION = "9"
+NPM_VERSION = "9.9.4"
 
 [[redirects]]
 from = "/api/*"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=9.0.0"
+    "npm": ">=9.9.4"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- document the minimum npm version as `9.9.4`
- enforce npm `>=9.9.4` in package.json engines
- set Netlify build to use npm `9.9.4`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879ecd2e20c8327a972542e34f115ec