### PR TITLE
Fix netlify build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 
 [build]
-  command = "npm run clean && npm install --legacy-peer-deps && npm run build"
+  command = "npm install --legacy-peer-deps && npm run build"
   publish = "dist"
   functions = "netlify/functions"
 


### PR DESCRIPTION
## Summary
- fix build command in `netlify.toml` so Netlify installs dependencies and builds correctly

## Testing
- `npm install` *(fails: ERR_INVALID_ARG_TYPE)*

------
https://chatgpt.com/codex/tasks/task_e_687a0bd398dc83278f13be06fda5ec6a