### PR TITLE
Wire up missing pages and cleanup footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,12 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import Homepage from '../homepage'
+import AboutPage from '../about'
+import MindmapDemo from '../mindmapdemo'
+import TodoDemo from '../tododemo'
+import ResetPassword from '../reset-password'
+import PrivacyPolicy from '../privacypolicy'
+import TermsOfService from '../terms'
+
 import LoginPage from './LoginPage'
 import DashboardPage from './DashboardPage'
 import BillingPage from './BillingPage'
@@ -13,6 +20,12 @@ export default function App() {
       <Header />
       <Routes>
         <Route path="/" element={<Homepage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="/mindmap-demo" element={<MindmapDemo />} />
+        <Route path="/todo-demo" element={<TodoDemo />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
+        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/terms" element={<TermsOfService />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/payment" element={<BillingPage />} />

--- a/src/footer.tsx
+++ b/src/footer.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom'
 const BRAND_NAME = 'MindXdo'
 const CURRENT_YEAR = new Date().getFullYear();
 const FOOTER_LINKS = [
-  { label: 'GitHub', href: 'https://github.com/your-org/plan-scaler-mindmap-tools', external: true },
   { label: 'Terms of Service', href: '/terms', external: false },
   { label: 'Privacy Policy', href: '/privacy', external: false },
   { label: 'Hosted on Netlify', href: 'https://www.netlify.com', external: true },

--- a/src/global.scss
+++ b/src/global.scss
@@ -599,3 +599,29 @@ hr {
   padding: var(--spacing-lg) var(--spacing-md);
   background-color: var(--color-bg-alt);
 }
+
+.footer {
+  padding: var(--spacing-lg) var(--spacing-md);
+  background-color: var(--color-bg-alt);
+}
+
+.footer__content {
+  max-width: 1200px;
+  margin: 0 auto;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.footer__links {
+  list-style: none;
+  display: flex;
+  gap: var(--spacing-lg);
+  padding: 0;
+  margin-top: var(--spacing-sm);
+  justify-content: center;
+}
+.footer__links li {
+  margin: 0;
+}

--- a/terms.tsx
+++ b/terms.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom'
+
+export default function TermsOfService(): JSX.Element {
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-8">
+      <h1 className="text-3xl font-semibold mb-6">Terms of Service</h1>
+      <p className="text-sm text-gray-600 mb-8">Last updated: July 10, 2024</p>
+      <p className="mb-4">
+        By using MindXdo you agree to the following terms. This demo site is for
+        illustrative purposes only.
+      </p>
+      <p className="mb-4">
+        Please read our <Link to="/privacy" className="text-blue-600">Privacy Policy</Link> to learn how
+        we handle your data.
+      </p>
+      <p>
+        If you have any questions feel free to contact support.
+      </p>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add simple Terms of Service page
- connect marketing routes to real pages
- remove GitHub link from footer
- style footer links to display in a single centered row

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a165f62548327923e90f1f2807749