### PR TITLE
Improve homepage marketing sections

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -3,6 +3,23 @@ import { Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import FeatureCard from './featurecard'
 import Demo from './demo'
+import MindmapDemo from './mindmapdemo'
+
+const StackingText: React.FC<{ text: string }> = ({ text }) => (
+  <span className="stacking-text">
+    {text.split('').map((ch, i) => (
+      <motion.span
+        key={i}
+        initial={{ y: 50, opacity: 0 }}
+        whileInView={{ y: 0, opacity: 1 }}
+        viewport={{ once: true }}
+        transition={{ delay: i * 0.05 }}
+      >
+        {ch}
+      </motion.span>
+    ))}
+  </span>
+)
 const features = [
   {
     title: 'Mind Mapping',
@@ -97,6 +114,63 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
+      <section className="section">
+        <div className="container">
+          <h2 className="marketing-text-large">
+            <StackingText text="Mindmaps + Todos + Team Effort" />
+          </h2>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ x: -100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            Use AI to lay out visual plans and structure
+          </motion.h2>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container">
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            Rapidly prototype business ideas, flows, systems, and more.
+          </motion.h2>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="container two-column mini-mindmap-container">
+          <motion.div
+            initial={{ clipPath: 'inset(0 0 100% 0)' }}
+            whileInView={{ clipPath: 'inset(0 0 0% 0)' }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            <MindmapDemo />
+          </motion.div>
+          <motion.div
+            className="marketing-text-large"
+            initial={{ x: 100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            See how AI instantly creates a map for your ideas.
+          </motion.div>
+        </div>
+      </section>
 
 
       <section className="features section">

--- a/src/global.scss
+++ b/src/global.scss
@@ -346,6 +346,8 @@ hr {
   gap: var(--spacing-lg);
   align-items: center;
   margin: var(--spacing-2xl) 0;
+  text-align: center;
+  justify-items: center;
 }
 
 .three-column {
@@ -354,6 +356,7 @@ hr {
   gap: var(--spacing-lg);
   margin: var(--spacing-2xl) 0;
   text-align: center;
+  justify-items: center;
 }
 
 .section--one-col {
@@ -366,6 +369,8 @@ hr {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: var(--spacing-lg);
+  text-align: center;
+  justify-items: center;
 }
 
 .section--three-col {
@@ -373,11 +378,26 @@ hr {
   grid-template-columns: repeat(3, 1fr);
   gap: var(--spacing-lg);
   text-align: center;
+  justify-items: center;
 }
 
 .bold-marketing-text {
   font-size: 1.5rem;
   font-weight: 700;
+}
+
+.marketing-text-large {
+  font-size: clamp(2rem, 6vw, 3rem);
+  font-weight: 800;
+  text-align: center;
+}
+
+.stacking-text span {
+  display: inline-block;
+}
+
+.mini-mindmap-container .btn {
+  display: none;
 }
 
 .ai-button {


### PR DESCRIPTION
## Summary
- center homepage grid sections
- add marketing text animations
- showcase AI generated mini mindmap

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a190d7854832781548b45712b405a