### PR TITLE
Add animated demos for marketing

### DIFF
--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -1,179 +1,90 @@
-const defaultNodes: Node[] = [
-  {
-    id: 'root',
-    label: 'Mindmap',
-    x: 400,
-    y: 300,
-    children: [
-      {
-        id: 'root-1',
-        label: 'Features',
-        x: 200,
-        y: 150,
-        children: [
-          { id: 'root-1-1', label: 'Interactive', x: 100, y: 50 },
-          { id: 'root-1-2', label: 'Responsive', x: 300, y: 50 }
-        ]
-      },
-      {
-        id: 'root-2',
-        label: 'Todo',
-        x: 600,
-        y: 150,
-        children: [
-          { id: 'root-2-1', label: 'List', x: 500, y: 50 },
-          { id: 'root-2-2', label: 'Tasks', x: 700, y: 50 }
-        ]
-      },
-      { id: 'root-3', label: 'Demo', x: 400, y: 450 }
-    ]
-  }
-]
-
-import { useRef, useState, useEffect, useLayoutEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
 
+interface MapItem {
+  text: string
+}
+
+interface SimpleMap {
+  title: string
+  items: MapItem[]
+}
+
+const maps: SimpleMap[] = [
+  {
+    title: 'Product Launch',
+    items: [
+      { text: 'Research market' },
+      { text: 'Design prototype' },
+      { text: 'Gather feedback' },
+      { text: 'Finalize features' },
+      { text: 'Release to users' },
+    ],
+  },
+  {
+    title: 'Brainstorm Session',
+    items: [
+      { text: 'Collect ideas' },
+      { text: 'Group topics' },
+      { text: 'Vote priorities' },
+      { text: 'Assign owners' },
+      { text: 'Plan next steps' },
+    ],
+  },
+  {
+    title: 'Learning Plan',
+    items: [
+      { text: 'Choose resources' },
+      { text: 'Schedule study time' },
+      { text: 'Practice exercises' },
+      { text: 'Review progress' },
+      { text: 'Share knowledge' },
+    ],
+  },
+]
+
 export default function MindmapDemo(): JSX.Element {
   useScrollReveal()
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const [flatNodes, setFlatNodes] = useState<Node[]>([])
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null)
-  const nodesRef = useRef<Node[]>([])
-  const parentMapRef = useRef<Record<string, Node>>({})
+  const mapCount = maps.length
+  const maxItems = Math.max(...maps.map(m => m.items.length))
+  const totalSteps = mapCount * maxItems
+  const [step, setStep] = useState(0)
 
-  // Flatten the tree into a list
   useEffect(() => {
-    const flatten = (nodes: Node[]): Node[] => {
-      let res: Node[] = []
-      nodes.forEach(n => {
-        const { children, ...rest } = n
-        res.push(rest)
-        if (children) {
-          res = res.concat(flatten(children))
-        }
-      })
-      return res
-    }
-    const flat = flatten(defaultNodes)
-    setFlatNodes(flat)
-  }, [])
-
-  // Keep refs up to date
-  useEffect(() => {
-    nodesRef.current = flatNodes
-    const map: Record<string, Node> = {}
-    flatNodes.forEach(n => {
-      map[n.id] = n
-    })
-    parentMapRef.current = map
-  }, [flatNodes])
-
-  // Draw and resize handling
-  useLayoutEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const ctx = canvas.getContext('2d')
-    if (!ctx) return
-
-    let resizeObserver: ResizeObserver
-
-    const draw = () => {
-      const ratio = window.devicePixelRatio || 1
-      const width = canvas.clientWidth
-      const height = canvas.clientHeight
-      canvas.width = Math.floor(width * ratio)
-      canvas.height = Math.floor(height * ratio)
-      ctx.resetTransform()
-      ctx.scale(ratio, ratio)
-      ctx.clearRect(0, 0, width, height)
-
-      // draw connections
-      ctx.strokeStyle = '#ccc'
-      ctx.lineWidth = 1
-      flatNodes.forEach(n => {
-        if (n.id === 'root') return
-        const parentId = n.id.split('-').slice(0, -1).join('-') || 'root'
-        const parent = parentMapRef.current[parentId]
-        if (parent) {
-          ctx.beginPath()
-          ctx.moveTo(parent.x, parent.y)
-          ctx.lineTo(n.x, n.y)
-          ctx.stroke()
-        }
-      })
-
-      // draw nodes
-      flatNodes.forEach(n => {
-        const isSelected = n.id === selectedNodeId
-        ctx.beginPath()
-        ctx.arc(n.x, n.y, 30, 0, Math.PI * 2)
-        ctx.fillStyle = '#fff'
-        ctx.fill()
-        ctx.strokeStyle = isSelected ? '#0070f3' : '#666'
-        ctx.lineWidth = isSelected ? 3 : 1
-        ctx.stroke()
-        ctx.fillStyle = '#000'
-        ctx.font = '14px sans-serif'
-        ctx.textAlign = 'center'
-        ctx.textBaseline = 'middle'
-        ctx.fillText(n.label, n.x, n.y)
-      })
-    }
-
-    // initial draw
-    draw()
-
-    // observe resize of container
-    resizeObserver = new ResizeObserver(() => {
-      draw()
-    })
-    resizeObserver.observe(canvas)
-
-    // also handle window resize
-    window.addEventListener('resize', draw)
-
-    return () => {
-      window.removeEventListener('resize', draw)
-      resizeObserver.disconnect()
-    }
-  }, [flatNodes, selectedNodeId])
-
-  const handleNodeClick = useCallback((nodeId: string) => {
-    setSelectedNodeId(nodeId)
-  }, [])
-
-  // click detection
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas) return
-    const onClick = (e: MouseEvent) => {
-      const rect = canvas.getBoundingClientRect()
-      const x = e.clientX - rect.left
-      const y = e.clientY - rect.top
-      for (const n of nodesRef.current) {
-        const dx = x - n.x
-        const dy = y - n.y
-        if (dx * dx + dy * dy <= 30 * 30) {
-          handleNodeClick(n.id)
-          break
-        }
-      }
-    }
-    canvas.addEventListener('click', onClick)
-    return () => {
-      canvas.removeEventListener('click', onClick)
-    }
-  }, [handleNodeClick])
+    if (step >= totalSteps) return
+    const t = setTimeout(() => setStep(prev => prev + 1), 600)
+    return () => clearTimeout(t)
+  }, [step, totalSteps])
 
   return (
-    <div className="mindmap-demo reveal section section--one-col">
-      <canvas
-        ref={canvasRef}
-        style={{ width: '100%', maxWidth: '800px', height: 'auto', display: 'block' }}
-      />
-      <div className="mt-md">
-        <Link to="/payment" className="btn">Upgrade</Link>
+    <div className="mindmap-demo section section--two-col reveal">
+      {maps.map((map, mapIndex) => (
+        <div className="mindmap-card" key={map.title}>
+          <h3>{map.title}</h3>
+          <ul className="mindmap-list">
+            {map.items.map((item, itemIndex) => {
+              const visible = step >= itemIndex * mapCount + mapIndex
+              return (
+                <motion.li
+                  className="mindmap-item"
+                  key={item.text}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={visible ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+                  transition={{ duration: 0.5 }}
+                >
+                  {item.text}
+                </motion.li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
+      <div className="mindmap-upgrade">
+        <Link to="/payment" className="btn">
+          Upgrade
+        </Link>
       </div>
     </div>
   )

--- a/src/global.scss
+++ b/src/global.scss
@@ -696,3 +696,42 @@ hr {
 .footer__links li {
   margin: 0;
 }
+
+/* --- Demo Styles --- */
+.todo-demo,
+.mindmap-demo {
+  justify-items: center;
+  text-align: center;
+}
+
+.todo-card,
+.mindmap-card {
+  background-color: var(--color-surface);
+  padding: var(--spacing-lg);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  width: 100%;
+  max-width: 300px;
+}
+
+.todo-list,
+.mindmap-list {
+  list-style: none;
+  padding: 0;
+  margin: var(--spacing-sm) 0 0;
+  text-align: left;
+}
+
+.todo-item,
+.mindmap-item {
+  margin-bottom: var(--spacing-sm);
+}
+
+.assignee {
+  opacity: 0.6;
+}
+
+.todo-upgrade,
+.mindmap-upgrade {
+  grid-column: span 2;
+}


### PR DESCRIPTION
## Summary
- rework Todo demo with animated preset lists in two-column layout
- simplify MindMap demo to show animated notes across sample maps
- add shared demo styling in global stylesheet

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a1e30b6c88327917ad1557197d726