### PR TITLE
Update demo visuals

### DIFF
--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -59,28 +59,58 @@ export default function MindmapDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="mindmap-demo section section--two-col reveal">
-      {maps.map((map, mapIndex) => (
-        <div className="mindmap-card" key={map.title}>
-          <h3>{map.title}</h3>
-          <ul className="mindmap-list">
-            {map.items.map((item, itemIndex) => {
-              const visible = step >= itemIndex * mapCount + mapIndex
-              return (
-                <motion.li
-                  className="mindmap-item"
-                  key={item.text}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={visible ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-                  transition={{ duration: 0.5 }}
-                >
-                  {item.text}
-                </motion.li>
-              )
-            })}
-          </ul>
-        </div>
-      ))}
+    <div className="mindmap-demo section reveal">
+      <h1 className="demo-title">MindmapX Visualizer</h1>
+      <p className="demo-sub">Ideas burst from the center of your screen</p>
+      <div className="mindmap-grid">
+        {maps.map((map, mapIndex) => (
+          <div className="mindmap-container" key={map.title}>
+            <svg viewBox="-160 -160 320 320" className="mindmap-svg">
+              <circle cx="0" cy="0" r="35" fill="orange" stroke="black" />
+              <text x="0" y="0" textAnchor="middle" dominantBaseline="middle" className="root-text">
+                {map.title}
+              </text>
+              {map.items.map((item, itemIndex) => {
+                const angle = (itemIndex / map.items.length) * Math.PI * 2 - Math.PI / 2
+                const x = 110 * Math.cos(angle)
+                const y = 110 * Math.sin(angle)
+                const visible = step >= itemIndex * mapCount + mapIndex
+                return (
+                  <g key={item.text}>
+                    <motion.line
+                      x1="0"
+                      y1="0"
+                      x2={visible ? x : 0}
+                      y2={visible ? y : 0}
+                      stroke="black"
+                      strokeWidth="2"
+                      transition={{ duration: 0.6 }}
+                    />
+                    <motion.circle
+                      cx={visible ? x : 0}
+                      cy={visible ? y : 0}
+                      r="25"
+                      fill="orange"
+                      stroke="black"
+                      transition={{ duration: 0.6 }}
+                    />
+                    <motion.text
+                      x={visible ? x : 0}
+                      y={visible ? y : 0}
+                      textAnchor="middle"
+                      dominantBaseline="middle"
+                      className="node-text"
+                      transition={{ duration: 0.6 }}
+                    >
+                      {item.text}
+                    </motion.text>
+                  </g>
+                )
+              })}
+            </svg>
+          </div>
+        ))}
+      </div>
       <div className="mindmap-upgrade">
         <Link to="/payment" className="btn">
           Upgrade

--- a/src/global.scss
+++ b/src/global.scss
@@ -723,6 +723,11 @@ hr {
   text-align: center;
 }
 
+.mindmap-demo {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 .todo-card,
 .mindmap-card {
   background-color: var(--color-surface);
@@ -753,4 +758,54 @@ hr {
 .todo-upgrade,
 .mindmap-upgrade {
   grid-column: span 2;
+}
+
+/* --- Updated Demo Styles --- */
+.demo-title {
+  font-size: 2rem;
+  font-weight: 800;
+  margin-bottom: var(--spacing-md);
+  text-align: center;
+}
+
+.demo-sub {
+  font-size: 1.25rem;
+  margin-bottom: var(--spacing-lg);
+  text-align: center;
+}
+
+.mindmap-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--spacing-lg);
+  width: 100%;
+  justify-items: center;
+}
+
+.mindmap-svg {
+  width: 320px;
+  height: 320px;
+}
+
+.root-text,
+.node-text {
+  fill: #000;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.todo-demo {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.todo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: var(--spacing-lg);
+  justify-items: center;
+}
+
+.sparkle {
+  margin-right: var(--spacing-xs);
 }

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -70,29 +70,33 @@ export default function TodoDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="todo-demo section section--two-col reveal">
-      {lists.map((list, listIndex) => (
-        <div className="todo-card" key={list.title}>
-          <h3>{list.title}</h3>
-          <ul className="todo-list">
-            {list.items.map((item, itemIndex) => {
-              const visible = step >= itemIndex * listCount + listIndex
-              return (
-                <motion.li
-                  className="todo-item"
-                  key={item.text}
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={visible ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
-                  transition={{ duration: 0.5 }}
-                >
-                  {item.text}{' '}
-                  <span className="assignee">- {item.assignee}</span>
-                </motion.li>
-              )
-            })}
-          </ul>
-        </div>
-      ))}
+    <div className="todo-demo section reveal">
+      <h1 className="demo-title">AI Todo Lists</h1>
+      <div className="todo-grid section--two-col">
+        {lists.map((list, listIndex) => (
+          <div className="todo-card" key={list.title}>
+            <h3>{list.title}</h3>
+            <ul className="todo-list">
+              {list.items.map((item, itemIndex) => {
+                const visible = step >= itemIndex * listCount + listIndex
+                return (
+                  <motion.li
+                    className="todo-item"
+                    key={item.text}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={visible ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+                    transition={{ duration: 0.5 }}
+                  >
+                    <span className="sparkle" aria-hidden="true">✨</span>
+                    {item.text}{' '}
+                    <span className="assignee">- {item.assignee}</span>
+                  </motion.li>
+                )
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
       <div className="todo-upgrade">
         <Link to="/payment" className="btn">
           Upgrade


### PR DESCRIPTION
## Summary
- update mindmap demo with animated radial nodes in SVG
- add marketing title & subtitle
- center todo demo grid, title, and sparkle icon
- add new styles for updated demos

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a20face78832784a833bd43ef5523