### PR TITLE
Improve About page marketing copy

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -7,15 +7,33 @@ export default function AboutPage(): JSX.Element {
     <div className="about-page">
       <section className="section section--one-col reveal">
         <h1>About MindXdo</h1>
-        <p>MindXdo blends mindmaps and todos with AI so you can plan and execute seamlessly.</p>
+        <p>
+          MindXdo blends mind maps and to‑do lists into a single workflow so you
+          can plan and execute without friction.
+        </p>
         <Link to="/payment" className="btn">Purchase</Link>
       </section>
       <section className="section section--two-col reveal">
         <div>
           <h2>Our Mission</h2>
-          <p>We help you visualize ideas and turn them into actionable tasks.</p>
+          <p>
+            We help you visualize big ideas and break them down into manageable
+            steps. Our AI planning tools jumpstart the process when you are not
+            sure where to begin.
+          </p>
         </div>
         <img src="./assets/placeholder.png" alt="Mission" />
+      </section>
+      <section className="section section--two-col reveal">
+        <img src="./assets/placeholder.png" alt="Mind maps" />
+        <div>
+          <h2>Why Mind Maps + AI?</h2>
+          <p>
+            Mind maps are powerful for brainstorming but often stop short of
+            action. MindXdo turns each node into a task so your vision becomes a
+            roadmap you can follow manually or with AI‑generated suggestions.
+          </p>
+        </div>
       </section>
       <section className="section section--three-col reveal">
         <div>Plan</div>

--- a/hero.tsx
+++ b/hero.tsx
@@ -86,8 +86,8 @@ const Hero: React.FC = () => {
           MindXdo
         </h1>
         <p className="text-lg md:text-xl text-white/80 mb-8 max-w-xl">
-          Organize your mindmaps and todos with AI-driven automations for a
-          seamless experience.
+          Organize your mind maps and tasks. Let AI turn your long‑term vision
+          into an actionable roadmap.
         </p>
         <a
           href="#get-started"

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -97,8 +97,8 @@ const Homepage: React.FC = (): JSX.Element => {
           <h1 className="hero-title">MindXdo: Mindmaps Meet Todos with AI</h1>
           <p>
             Experience the power of AI as your ideas become actionable plans.
-            MindXdo weaves mindmaps and todos together so you can strategize
-            and execute without friction.
+            Map a long‑term vision, break it down into tasks, and let MindXdo
+            guide the next steps.
           </p>
           <Link to="/payment" className="btn">
             Get Started
@@ -256,8 +256,10 @@ const Homepage: React.FC = (): JSX.Element => {
           AI Superpowers
         </motion.h2>
         <p className="ai-copy">
-          Harness automation to turn complex mindmaps into actionable workflows.
-          MindXdo helps you execute ambitious plans with ease.
+          Harness automation to turn complex mind maps into actionable
+          workflows. MindXdo helps you execute ambitious plans with ease.
+          Mind maps show the big picture—our assistant suggests tasks and
+          timelines so you never wonder what comes next.
         </p>
         <img
           src="./assets/placeholder.png"


### PR DESCRIPTION
## Summary
- expand About Us page with details about AI planning and actionable mind maps
- refine hero tagline for MindXdo
- update homepage hero text and AI marketing section

## Testing
- `node --test tests/*.test.js` *(fails: cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687a232c9f3c83278ac436964248b487