### PR TITLE
Refine demos and login page

### DIFF
--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
+import FaintMindmapBackground from './FaintMindmapBackground'
 
 interface MapItem {
   text: string
@@ -59,14 +60,25 @@ export default function MindmapDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="mindmap-demo section reveal">
-      <h1 className="demo-title">MindmapX Visualizer</h1>
-      <p className="demo-sub">Ideas burst from the center of your screen</p>
-      <div className="mindmap-grid">
+    <div className="mindmap-demo section reveal relative overflow-hidden">
+      <FaintMindmapBackground />
+      <div className="max-w-2xl mx-auto mb-8">
+        <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
+        <p className="section-subtext">
+          Mind maps animate to life so you can focus on brainstorming
+        </p>
+      </div>
+      <div className="mindmap-grid section--two-col">
         {maps.map((map, mapIndex) => (
           <div className="mindmap-container" key={map.title}>
             <svg viewBox="-160 -160 320 320" className="mindmap-svg">
-              <circle cx="0" cy="0" r="35" fill="orange" stroke="black" />
+              <circle
+                cx="0"
+                cy="0"
+                r="35"
+                fill="orange"
+                stroke="var(--color-border)"
+              />
               <text x="0" y="0" textAnchor="middle" dominantBaseline="middle" className="root-text">
                 {map.title}
               </text>
@@ -82,7 +94,7 @@ export default function MindmapDemo(): JSX.Element {
                       y1="0"
                       x2={visible ? x : 0}
                       y2={visible ? y : 0}
-                      stroke="black"
+                      stroke="var(--color-border)"
                       strokeWidth="2"
                       transition={{ duration: 0.6 }}
                     />
@@ -91,7 +103,7 @@ export default function MindmapDemo(): JSX.Element {
                       cy={visible ? y : 0}
                       r="25"
                       fill="orange"
-                      stroke="black"
+                      stroke="var(--color-border)"
                       transition={{ duration: 0.6 }}
                     />
                     <motion.text

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, FormEvent } from 'react'
+import FaintMindmapBackground from '../FaintMindmapBackground'
 
 const LoginPage = () => {
   const [email, setEmail] = useState('')
@@ -14,20 +15,42 @@ const LoginPage = () => {
   }
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Login</h1>
-      <form onSubmit={handleSubmit}>
-        <div>
-          <label>Email</label>
-          <input type="email" value={email} onChange={e => setEmail(e.target.value)} />
-        </div>
-        <div>
-          <label>Password</label>
-          <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
-        </div>
-        <button type="submit">Submit</button>
-      </form>
-    </div>
+    <section className="section relative overflow-hidden">
+      <FaintMindmapBackground />
+      <div className="max-w-sm w-full mx-auto bg-white p-6 rounded shadow text-center">
+        <h1 className="marketing-text-large mb-4">Welcome Back</h1>
+        <p className="section-subtext mb-6">Sign in to continue</p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-left mb-1">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+          <div>
+            <label htmlFor="password" className="block text-left mb-1">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2"
+            />
+          </div>
+          <button type="submit" className="btn w-full">
+            Login
+          </button>
+        </form>
+      </div>
+    </section>
   )
 }
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -776,10 +776,16 @@ hr {
 
 .mindmap-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
   gap: var(--spacing-lg);
   width: 100%;
   justify-items: center;
+}
+
+@media (max-width: 640px) {
+  .mindmap-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .mindmap-svg {
@@ -801,9 +807,15 @@ hr {
 
 .todo-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(2, minmax(250px, 1fr));
   gap: var(--spacing-lg);
   justify-items: center;
+}
+
+@media (max-width: 640px) {
+  .todo-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .sparkle {

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
+import FaintMindmapBackground from './FaintMindmapBackground'
 
 interface TodoItem {
   text: string
@@ -70,8 +71,12 @@ export default function TodoDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="todo-demo section reveal">
-      <h1 className="demo-title">AI Todo Lists</h1>
+    <div className="todo-demo section reveal relative overflow-hidden">
+      <FaintMindmapBackground />
+      <div className="max-w-2xl mx-auto mb-8">
+        <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
+        <p className="section-subtext">Watch todos appear with smooth animations</p>
+      </div>
       <div className="todo-grid section--two-col">
         {lists.map((list, listIndex) => (
           <div className="todo-card" key={list.title}>


### PR DESCRIPTION
## Summary
- brighten login page with central layout
- improve mindmap demo with marketing heading and subtle background
- revise todo demo layout and heading
- enforce two-column grid styles for demos

## Testing
- `node --test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687a25b8344c8327a752a0e957aab7da