### PR TITLE
Improve about and demos layout

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -2,6 +2,40 @@ import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
 import FaintMindmapBackground from './FaintMindmapBackground'
 
+interface AboutSection {
+  title: string
+  text: string
+  img: string
+}
+
+const sections: AboutSection[] = [
+  {
+    title: 'Our Mission',
+    text: 'We help visualize big ideas and break them into manageable steps using AI planning tools.',
+    img: './assets/placeholder.svg',
+  },
+  {
+    title: 'Key Benefits',
+    text: 'MindXdo keeps your plans and tasks together so you stay organized and focused.',
+    img: './assets/placeholder.svg',
+  },
+  {
+    title: 'Earn Rewards',
+    text: 'Achieve milestones to unlock perks as you progress through your goals.',
+    img: './assets/placeholder.svg',
+  },
+  {
+    title: 'Performance Insights',
+    text: 'Track progress at a glance and let data drive your next move.',
+    img: './assets/placeholder.svg',
+  },
+  {
+    title: 'Continuous Improvement',
+    text: 'We evolve alongside your workflow so you can focus on what matters most.',
+    img: './assets/placeholder.svg',
+  },
+]
+
 export default function AboutPage(): JSX.Element {
   useScrollReveal()
   return (
@@ -15,33 +49,23 @@ export default function AboutPage(): JSX.Element {
         </p>
         <Link to="/payment" className="btn">Purchase</Link>
       </section>
-      <section className="section section--two-col reveal">
-        <div>
-          <h2>Our Mission</h2>
-          <p>
-            We help you visualize big ideas and break them down into manageable
-            steps. Our AI planning tools jumpstart the process when you are not
-            sure where to begin.
-          </p>
-        </div>
-        <img src="./assets/placeholder.png" alt="Mission" />
-      </section>
-      <section className="section section--two-col reveal">
-        <img src="./assets/placeholder.png" alt="Mind maps" />
-        <div>
-          <h2>Why Mind Maps + AI?</h2>
-          <p>
-            Mind maps are powerful for brainstorming but often stop short of
-            action. MindXdo turns each node into a task so your vision becomes a
-            roadmap you can follow manually or with AI‑generated suggestions.
-          </p>
-        </div>
-      </section>
-      <section className="section section--three-col reveal">
-        <div>Plan</div>
-        <div>Track</div>
-        <div>Launch</div>
-      </section>
+      {sections.map((s, i) => (
+        <section
+          className={`about-section reveal${i % 2 ? ' reverse' : ''}`}
+          key={s.title}
+        >
+          {i % 2 === 0 && (
+            <img src={s.img} alt={s.title} width={400} height={400} />
+          )}
+          <div>
+            <h2>{s.title}</h2>
+            <p>{s.text}</p>
+          </div>
+          {i % 2 === 1 && (
+            <img src={s.img} alt={s.title} width={400} height={400} />
+          )}
+        </section>
+      ))}
     </div>
   )
 }

--- a/billing.tsx
+++ b/billing.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 import FaintMindmapBackground from './FaintMindmapBackground'
 
 interface BillingInfo {
@@ -67,6 +68,9 @@ export default function BillingPage(): JSX.Element {
           >
             Cancel Subscription
           </button>
+          <div className="mt-lg text-center">
+            <Link to="/checkout" className="btn">Checkout</Link>
+          </div>
         </div>
       )}
       </div>

--- a/checkout.tsx
+++ b/checkout.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import FaintMindmapBackground from './FaintMindmapBackground'
+
+export default function CheckoutPage(): JSX.Element {
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setTimeout(() => setLoading(false), 1000)
+  }
+
+  return (
+    <section className="section relative overflow-hidden">
+      <FaintMindmapBackground />
+      <div className="container text-center">
+        <h1 className="mb-lg">Checkout</h1>
+        <form className="checkout-form" onSubmit={handleSubmit}>
+          <label>
+            Name
+            <input type="text" required />
+          </label>
+          <label>
+            Card Number
+            <input type="text" required />
+          </label>
+          <button type="submit" className="btn" disabled={loading}>
+            {loading ? 'Processing...' : 'Submit Payment'}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -62,15 +62,16 @@ export default function MindmapDemo(): JSX.Element {
   return (
     <div className="mindmap-demo section reveal relative overflow-hidden">
       <FaintMindmapBackground />
-      <div className="max-w-2xl mx-auto mb-8">
-        <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
-        <p className="section-subtext">
-          Mind maps animate to life so you can focus on brainstorming
-        </p>
-      </div>
-      <div className="mindmap-grid section--two-col">
-        {maps.map((map, mapIndex) => (
-          <div className="mindmap-container" key={map.title}>
+      <div className="container">
+        <div className="max-w-2xl mx-auto mb-8 text-center">
+          <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
+          <p className="section-subtext">
+            Mind maps animate to life so you can focus on brainstorming
+          </p>
+        </div>
+        <div className="mindmap-grid section--two-col">
+          {maps.map((map, mapIndex) => (
+            <div className="mindmap-container" key={map.title}>
             <svg viewBox="-160 -160 320 320" className="mindmap-svg">
               <circle
                 cx="0"
@@ -122,11 +123,12 @@ export default function MindmapDemo(): JSX.Element {
             </svg>
           </div>
         ))}
-      </div>
-      <div className="mindmap-upgrade">
-        <Link to="/payment" className="btn">
-          Upgrade
-        </Link>
+        </div>
+        <div className="mindmap-upgrade text-center">
+          <Link to="/payment" className="btn">
+            Upgrade
+          </Link>
+        </div>
       </div>
     </div>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import TodoDemo from '../tododemo'
 import ResetPassword from '../reset-password'
 import PrivacyPolicy from '../privacypolicy'
 import TermsOfService from '../terms'
+import CheckoutPage from '../checkout'
 
 import LoginPage from './LoginPage'
 import DashboardPage from './DashboardPage'
@@ -29,6 +30,7 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/payment" element={<BillingPage />} />
+        <Route path="/checkout" element={<CheckoutPage />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />

--- a/src/global.scss
+++ b/src/global.scss
@@ -837,3 +837,41 @@ hr {
 :root {
   --mindmap-color: rgba(255, 165, 0, 0.4);
 }
+
+.about-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: var(--spacing-lg);
+  align-items: center;
+  justify-items: center;
+  margin: var(--spacing-2xl) auto;
+  max-width: 1200px;
+}
+.about-section img {
+  width: 400px;
+  height: 400px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+.about-section.reverse {
+  direction: rtl;
+}
+.about-section.reverse > * {
+  direction: ltr;
+}
+
+.checkout-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  max-width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.checkout-form input {
+  width: 100%;
+  padding: var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+}
+

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -73,13 +73,14 @@ export default function TodoDemo(): JSX.Element {
   return (
     <div className="todo-demo section reveal relative overflow-hidden">
       <FaintMindmapBackground />
-      <div className="max-w-2xl mx-auto mb-8">
-        <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
-        <p className="section-subtext">Watch todos appear with smooth animations</p>
-      </div>
-      <div className="todo-grid section--two-col">
-        {lists.map((list, listIndex) => (
-          <div className="todo-card" key={list.title}>
+      <div className="container">
+        <div className="max-w-2xl mx-auto mb-8 text-center">
+          <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
+          <p className="section-subtext">Watch todos appear with smooth animations</p>
+        </div>
+        <div className="todo-grid section--two-col">
+          {lists.map((list, listIndex) => (
+            <div className="todo-card" key={list.title}>
             <h3>{list.title}</h3>
             <ul className="todo-list">
               {list.items.map((item, itemIndex) => {
@@ -101,11 +102,12 @@ export default function TodoDemo(): JSX.Element {
             </ul>
           </div>
         ))}
-      </div>
-      <div className="todo-upgrade">
-        <Link to="/payment" className="btn">
-          Upgrade
-        </Link>
+        </div>
+        <div className="todo-upgrade text-center">
+          <Link to="/payment" className="btn">
+            Upgrade
+          </Link>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- redesign About page to alternate text and image columns
- improve MindmapDemo and TodoDemo layout with container centering
- add placeholder checkout page
- show checkout link from Billing page
- add CSS styling for new layouts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_687a2752b49883279f7aaf2b897bab84