### PR TITLE
Improve about page and homepage content

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -6,6 +6,7 @@ interface AboutSection {
   title: string
   text: string
   img: string
+  bulletPoints: string[]
 }
 
 const sections: AboutSection[] = [
@@ -13,26 +14,51 @@ const sections: AboutSection[] = [
     title: 'Our Mission',
     text: 'We help visualize big ideas and break them into manageable steps using AI planning tools.',
     img: './assets/placeholder.svg',
+    bulletPoints: [
+      'Capture concepts quickly with intuitive mind maps',
+      'Turn every idea into an actionable task',
+      'Stay focused thanks to AI-driven guidance',
+    ],
   },
   {
     title: 'Key Benefits',
     text: 'MindXdo keeps your plans and tasks together so you stay organized and focused.',
     img: './assets/placeholder.svg',
+    bulletPoints: [
+      'One workspace for mapping and doing',
+      'Visual and list views always in sync',
+      'Seamless flow from brainstorming to execution',
+    ],
   },
   {
     title: 'Earn Rewards',
     text: 'Achieve milestones to unlock perks as you progress through your goals.',
     img: './assets/placeholder.svg',
+    bulletPoints: [
+      'Celebrate wins with badges and perks',
+      'Level up productivity through gamification',
+      'Share achievements with your team',
+    ],
   },
   {
     title: 'Performance Insights',
     text: 'Track progress at a glance and let data drive your next move.',
     img: './assets/placeholder.svg',
+    bulletPoints: [
+      'Dashboards highlight your progress',
+      'AI suggestions keep you on the right path',
+      'Data-backed insights for continuous growth',
+    ],
   },
   {
     title: 'Continuous Improvement',
     text: 'We evolve alongside your workflow so you can focus on what matters most.',
     img: './assets/placeholder.svg',
+    bulletPoints: [
+      'Frequent feature releases based on feedback',
+      'Tools that scale with your ambitions',
+      'A platform that grows as you do',
+    ],
   },
 ]
 
@@ -42,12 +68,18 @@ export default function AboutPage(): JSX.Element {
     <div className="about-page">
       <section className="section section--one-col reveal relative overflow-hidden">
         <FaintMindmapBackground />
-        <h1>About MindXdo</h1>
-        <p>
-          MindXdo blends mind maps and to‑do lists into a single workflow so you
-          can plan and execute without friction.
-        </p>
-        <Link to="/purchase" className="btn">Purchase</Link>
+        <div className="about-hero-inner">
+          <h1>About MindXdo</h1>
+          <p>
+            MindXdo blends mind maps and to‑do lists into a single workflow so you
+            can plan and execute without friction.
+          </p>
+          <p>
+            Capture ideas in seconds, break them into tasks, and watch our AI keep
+            everything organized while you focus on the big picture.
+          </p>
+          <Link to="/purchase" className="btn">Purchase</Link>
+        </div>
       </section>
       {sections.map((s, i) => (
         <section
@@ -60,6 +92,11 @@ export default function AboutPage(): JSX.Element {
           <div>
             <h2>{s.title}</h2>
             <p>{s.text}</p>
+            <ul>
+              {s.bulletPoints.map(point => (
+                <li key={point}>{point}</li>
+              ))}
+            </ul>
           </div>
           {i % 2 === 1 && (
             <img src={s.img} alt={s.title} width={400} height={400} />

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -240,9 +240,18 @@ const Homepage: React.FC = (): JSX.Element => {
 
       <section className="three-column section">
         <div className="container three-column">
-          <div className="bold-marketing-text">Plan</div>
-          <div className="bold-marketing-text">Track</div>
-          <div className="bold-marketing-text">Launch</div>
+          <div>
+            <img src="./assets/placeholder.svg" alt="Plan" />
+            <div className="bold-marketing-text">Plan</div>
+          </div>
+          <div>
+            <img src="./assets/placeholder.svg" alt="Track" />
+            <div className="bold-marketing-text">Track</div>
+          </div>
+          <div>
+            <img src="./assets/placeholder.svg" alt="Launch" />
+            <div className="bold-marketing-text">Launch</div>
+          </div>
         </div>
       </section>
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -408,6 +408,10 @@ hr {
   text-align: center;
   justify-items: center;
 }
+.three-column img {
+  height: 80px;
+  margin-bottom: var(--spacing-sm);
+}
 
 .section--one-col {
   display: grid;
@@ -882,8 +886,8 @@ hr {
   gap: var(--spacing-lg);
   align-items: center;
   justify-items: center;
-  margin: var(--spacing-2xl) auto;
-  max-width: 1200px;
+  margin: var(--spacing-xl) auto;
+  max-width: 1000px;
 }
 .about-section img {
   width: 400px;
@@ -896,6 +900,28 @@ hr {
 }
 .about-section.reverse > * {
   direction: ltr;
+}
+
+.about-hero-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.about-section > div {
+  text-align: center;
+}
+
+.about-section ul {
+  margin-top: var(--spacing-sm);
+  list-style: disc;
+  padding-left: var(--spacing-lg);
+  text-align: left;
 }
 
 .checkout-form {


### PR DESCRIPTION
## Summary
- center and expand the hero section on the about page
- add bullet point lists to about page sections
- style about page content to sit closer to the middle
- show icons above Plan/Track/Launch on the homepage
- style three column section images

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_687a8e5632d0832794382570af522171