### PR TITLE
Enhance demo pages with marketing sections

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -1,0 +1,31 @@
+import { motion } from 'framer-motion'
+
+export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
+  const startX = side === 'left' ? 0 : 300
+  const endX = 150
+  return (
+    <svg className={`mindmap-arm ${side}`} viewBox="0 0 300 100" aria-hidden="true">
+      <motion.line
+        x1={startX}
+        y1="50"
+        x2={endX}
+        y2="50"
+        stroke="var(--mindmap-color)"
+        strokeWidth="2"
+        initial={{ pathLength: 0 }}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 1 }}
+      />
+      <motion.circle
+        cx={endX}
+        cy="50"
+        r="12"
+        fill="none"
+        stroke="var(--mindmap-color)"
+        initial={{ scale: 0 }}
+        animate={{ scale: 1 }}
+        transition={{ duration: 1, delay: 1 }}
+      />
+    </svg>
+  )
+}

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -3,6 +3,23 @@ import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
 import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
+
+const StackingText: React.FC<{ text: string }> = ({ text }) => (
+  <span className="stacking-text">
+    {text.split('').map((ch, i) => (
+      <motion.span
+        key={i}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ delay: i * 0.05 }}
+      >
+        {ch}
+      </motion.span>
+    ))}
+  </span>
+)
 
 interface MapItem {
   text: string
@@ -60,19 +77,20 @@ export default function MindmapDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="mindmap-demo section reveal relative overflow-hidden">
-      <FaintMindmapBackground />
-      <div className="container">
-        <div className="max-w-2xl mx-auto mb-8 text-center">
-          <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
-          <p className="section-subtext">
-            Mind maps animate to life so you can focus on brainstorming
-          </p>
-        </div>
-        <div className="mindmap-grid section--two-col">
-          {maps.map((map, mapIndex) => (
-            <div className="mindmap-container" key={map.title}>
-            <svg viewBox="-160 -160 320 320" className="mindmap-svg">
+    <div className="mindmap-demo-page">
+      <section className="mindmap-demo section reveal relative overflow-hidden">
+        <FaintMindmapBackground />
+        <div className="container">
+          <div className="max-w-2xl mx-auto mb-8 text-center">
+            <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
+            <p className="section-subtext">
+              Mind maps animate to life so you can focus on brainstorming
+            </p>
+          </div>
+          <div className="mindmap-grid section--two-col">
+            {maps.map((map, mapIndex) => (
+              <div className="mindmap-container" key={map.title}>
+              <svg viewBox="-160 -160 320 320" className="mindmap-svg">
               <circle
                 cx="0"
                 cy="0"
@@ -140,6 +158,54 @@ export default function MindmapDemo(): JSX.Element {
           </Link>
         </div>
       </div>
+      </section>
+
+      <section className="section section-bg-alt reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <div className="container">
+          <h2 className="marketing-text-large">
+            <StackingText text="Simple and Powerful" />
+          </h2>
+          <p className="section-subtext">
+            Plan projects effortlessly with intuitive maps that grow alongside your ideas.
+          </p>
+        </div>
+      </section>
+
+      <section className="section reveal">
+        <div className="container">
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ x: 100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            AI Todo Lists Keep Teams Aligned
+          </motion.h2>
+          <p className="section-subtext">
+            Assign tasks from your maps and watch progress unfold automatically.
+          </p>
+        </div>
+      </section>
+
+      <section className="section section-bg-primary-light reveal relative overflow-hidden">
+        <MindmapArm side="right" />
+        <div className="container">
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.8 }}
+          >
+            See Beyond a Task Board
+          </motion.h2>
+          <p className="section-subtext">
+            Mind map connections provide a bird's-eye view of every project step.
+          </p>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -982,3 +982,21 @@ hr {
   border-color: var(--color-error);
 }
 
+.mindmap-arm {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 300px;
+  height: 100px;
+  pointer-events: none;
+  opacity: 0.4;
+}
+
+.mindmap-arm.left {
+  left: 0;
+}
+
+.mindmap-arm.right {
+  right: 0;
+}
+

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -3,6 +3,23 @@ import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
 import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
+
+const StackingText: React.FC<{ text: string }> = ({ text }) => (
+  <span className="stacking-text">
+    {text.split('').map((ch, i) => (
+      <motion.span
+        key={i}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ delay: i * 0.05 }}
+      >
+        {ch}
+      </motion.span>
+    ))}
+  </span>
+)
 
 interface TodoItem {
   text: string
@@ -71,16 +88,17 @@ export default function TodoDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="todo-demo section reveal relative overflow-hidden">
-      <FaintMindmapBackground />
-      <div className="container">
-        <div className="max-w-2xl mx-auto mb-8 text-center">
-          <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
-          <p className="section-subtext">Watch todos appear with smooth animations</p>
-        </div>
-        <div className="todo-grid section--two-col">
-          {lists.map((list, listIndex) => (
-            <div className="todo-card" key={list.title}>
+    <div className="todo-demo-page">
+      <section className="todo-demo section reveal relative overflow-hidden">
+        <FaintMindmapBackground />
+        <div className="container">
+          <div className="max-w-2xl mx-auto mb-8 text-center">
+            <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
+            <p className="section-subtext">Watch todos appear with smooth animations</p>
+          </div>
+          <div className="todo-grid section--two-col">
+            {lists.map((list, listIndex) => (
+              <div className="todo-card" key={list.title}>
             <h3>{list.title}</h3>
             <ul className="todo-list">
               {list.items.map((item, itemIndex) => {
@@ -109,6 +127,54 @@ export default function TodoDemo(): JSX.Element {
           </Link>
         </div>
       </div>
+      </section>
+
+      <section className="section section-bg-alt reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <div className="container">
+          <h2 className="marketing-text-large">
+            <StackingText text="AI Simplicity" />
+          </h2>
+          <p className="section-subtext">
+            Generate prioritized todos straight from your mind maps in moments.
+          </p>
+        </div>
+      </section>
+
+      <section className="section reveal">
+        <div className="container">
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ x: -100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            Team Management Made Powerful
+          </motion.h2>
+          <p className="section-subtext">
+            Everyone sees their tasks and how they connect to the bigger picture.
+          </p>
+        </div>
+      </section>
+
+      <section className="section section-bg-primary-light reveal relative overflow-hidden">
+        <MindmapArm side="right" />
+        <div className="container">
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.8 }}
+          >
+            Vision Beyond a Task Board
+          </motion.h2>
+          <p className="section-subtext">
+            Mind maps reveal relationships so you plan and execute with clarity.
+          </p>
+        </div>
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add animated **MindmapArm** background element
- style `.mindmap-arm` in global styles
- expand mind map demo with new marketing sections and animations
- expand todo demo with AI power messaging and animated sections

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a917b6154832794eab1368d6ef686