### PR TITLE
Improve sticky header menu styles

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -620,30 +620,38 @@ hr {
   margin: 0 auto;
 }
 
+
 .header__nav-list {
   display: flex;
-  gap: var(--spacing-lg);
+  gap: 0;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
+
 .header__nav-link {
   color: var(--color-text);
-  padding: var(--spacing-sm) var(--spacing-md);
-  border-radius: 4px;
+  padding: var(--spacing-lg);
+  border-radius: 0;
   background-color: rgba(255, 255, 255, 0.2);
   backdrop-filter: blur(6px);
   transition: background-color var(--transition-duration) var(--transition-ease),
-    transform var(--transition-duration) var(--transition-ease),
     color var(--transition-duration) var(--transition-ease);
   font-weight: 500;
+  text-align: center;
 }
 
-.header__nav-link--active,
+.header__nav-link--active {
+  background-color: var(--color-warning);
+  color: var(--color-text-inverse);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
 .header__nav-link:hover {
-  background-color: rgba(255, 255, 255, 0.4);
-  color: var(--color-bg);
+  background-color: #ffb14d;
+  color: var(--color-text-inverse);
   transform: translateY(-2px);
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
## Summary
- modernize sticky header navigation
- make nav items larger and flush
- update active/hover colors to orange

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a9b2fa39c8327a1b7e9eb54bff0f7