### PR TITLE
Adjust homepage layout and animations

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -14,17 +14,17 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         strokeWidth="2"
         initial={{ pathLength: 0 }}
         animate={{ pathLength: 1 }}
-        transition={{ duration: 1 }}
+        transition={{ duration: 4, delay: 2 }}
       />
       <motion.circle
-        cx={endX}
+        cx={startX}
         cy="50"
         r="12"
         fill="none"
         stroke="var(--mindmap-color)"
-        initial={{ scale: 0 }}
-        animate={{ scale: 1 }}
-        transition={{ duration: 1, delay: 1 }}
+        initial={{ scale: 0, cx: startX }}
+        animate={{ scale: 1, cx: endX }}
+        transition={{ duration: 4, delay: 2 }}
       />
     </svg>
   )

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -123,7 +123,7 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="section">
+      <section className="section section-bg-alt" style={{ marginTop: '-300px' }}>
         <div className="container">
           <h2 className="marketing-text-large">
             <StackingText text="Mindmaps + Todos + Team Effort" />

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -80,8 +80,8 @@ export default function MindmapDemo(): JSX.Element {
     <div className="mindmap-demo-page">
       <section className="mindmap-demo section reveal relative overflow-hidden">
         <FaintMindmapBackground />
-        <div className="container">
-          <div className="max-w-2xl mx-auto mb-8 text-center">
+        <div className="container text-center">
+          <div className="max-w-2xl mx-auto mb-8">
             <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
             <p className="section-subtext">
               Mind maps animate to life so you can focus on brainstorming


### PR DESCRIPTION
## Summary
- move the Mindmaps + Todos + Team Effort section upward
- center the hero text in the demo
- delay and extend animation of MindmapArm line and circle

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a9cade70c8327a4e53ecd8aef9858