### PR TITLE
Add purchase page details

### DIFF
--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -1,10 +1,71 @@
 import React from 'react'
+import FaintMindmapBackground from '../FaintMindmapBackground'
 
 const PurchasePage = () => {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+  }
+
   return (
-    <div style={{ padding: '2rem', textAlign: 'center' }}>
-      <h1>Purchase</h1>
-    </div>
+    <section className="section relative overflow-hidden">
+      <FaintMindmapBackground />
+      <div className="container text-center">
+        <h1 className="mb-md">Purchase MindXdo</h1>
+        <p className="mb-lg">$9.99 per month - Mindmap and Todo platform</p>
+        <form className="checkout-form" onSubmit={handleSubmit}>
+          <label>
+            Name
+            <input type="text" placeholder="Your Name" required />
+          </label>
+          <label>
+            Email
+            <input type="email" placeholder="Your Email" required />
+          </label>
+          <button type="submit" className="btn" disabled>
+            Place Order
+          </button>
+        </form>
+        <h2 className="mt-xl mb-md">Monthly Service Includes</h2>
+        <table className="table-auto mx-auto text-left mb-lg">
+          <thead>
+            <tr>
+              <th className="px-4 py-2">Item</th>
+              <th className="px-4 py-2">Limit</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border px-4 py-2">Manual mindmaps &amp; todos</td>
+              <td className="border px-4 py-2">Unlimited</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">AI mind maps</td>
+              <td className="border px-4 py-2">20 / month</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">AI todo lists</td>
+              <td className="border px-4 py-2">200 / month</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">Kanban board</td>
+              <td className="border px-4 py-2">Coming soon</td>
+            </tr>
+            <tr>
+              <td className="border px-4 py-2">Team members</td>
+              <td className="border px-4 py-2">3 seats</td>
+            </tr>
+          </tbody>
+        </table>
+        <p className="mb-md">
+          Need more AI credits?{' '}
+          <a href="mailto:hey@mindxdo.com">hey@mindxdo.com</a>
+        </p>
+        <p>
+          Mindmaps, todos and the kanban board can be created separately or
+          together.
+        </p>
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
- flesh out Purchase page with an order form
- describe pricing and monthly service limits
- list upcoming kanban feature and team seats

## Testing
- `node --test tests` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_687aa123fd4c8327950b37f5061498b0