### PR TITLE
Fix width for mindmap sections

### DIFF
--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -80,7 +80,7 @@ export default function MindmapDemo(): JSX.Element {
     <div className="mindmap-demo-page">
       <section className="mindmap-demo section reveal relative overflow-hidden">
         <FaintMindmapBackground />
-        <div className="container section--one-col text-center">
+        <div className="container container-full section--one-col text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
           <p className="section-subtext">
@@ -162,7 +162,7 @@ export default function MindmapDemo(): JSX.Element {
 
       <section className="section section-bg-alt reveal relative overflow-hidden">
         <MindmapArm side="left" />
-        <div className="container section--one-col text-center">
+        <div className="container container-full section--one-col text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <h2 className="marketing-text-large">
             <StackingText text="Simple and Powerful" />
@@ -174,7 +174,7 @@ export default function MindmapDemo(): JSX.Element {
       </section>
 
       <section className="section reveal">
-        <div className="container section--one-col text-center">
+        <div className="container container-full section--one-col text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
@@ -193,7 +193,7 @@ export default function MindmapDemo(): JSX.Element {
 
       <section className="section section-bg-primary-light reveal relative overflow-hidden">
         <MindmapArm side="right" />
-        <div className="container section--one-col text-center">
+        <div className="container container-full section--one-col text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <motion.h2
             className="marketing-text-large"

--- a/src/global.scss
+++ b/src/global.scss
@@ -147,6 +147,12 @@ button {
   }
 }
 
+.container-full {
+  max-width: none;
+  margin-left: 0;
+  margin-right: 0;
+}
+
 .sr-only,
 .visually-hidden {
   position: absolute;


### PR DESCRIPTION
## Summary
- make demo sections use a wide container
- allow `.container-full` to span the entire viewport

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa99fe0888327879c785fd438673e