### PR TITLE
Revamp purchase layout

### DIFF
--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import FaintMindmapBackground from '../FaintMindmapBackground'
+import MindmapDemo from '../mindmapdemo'
 
 const PurchasePage = () => {
   const handleSubmit = (e: React.FormEvent) => {
@@ -9,11 +10,57 @@ const PurchasePage = () => {
   return (
     <section className="section relative overflow-hidden">
       <FaintMindmapBackground />
-      <div className="container text-center">
-        <h1 className="mb-md">Purchase MindXdo</h1>
-        <p className="mb-lg">$9.99 per month - Mindmap and Todo platform</p>
-        <div className="form-card">
-          <form className="checkout-form" onSubmit={handleSubmit}>
+      <div className="container">
+        <h1 className="text-center mb-md">Purchase MindXdo</h1>
+        <p className="text-center mb-lg">$9.99 per month - Mindmap and Todo platform</p>
+        <div className="two-column purchase-grid">
+          <div>
+            <div className="mini-mindmap-container mb-lg">
+              <MindmapDemo />
+            </div>
+            <div className="offer-card text-center">
+              <h2 className="mb-md">Monthly Service Includes</h2>
+              <table className="table-auto mx-auto text-left mb-lg">
+                <thead>
+                  <tr>
+                    <th className="px-4 py-2">Item</th>
+                    <th className="px-4 py-2">Limit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td className="border px-4 py-2">Manual mindmaps &amp; todos</td>
+                    <td className="border px-4 py-2">Unlimited</td>
+                  </tr>
+                  <tr>
+                    <td className="border px-4 py-2">AI mind maps</td>
+                    <td className="border px-4 py-2">20 / month</td>
+                  </tr>
+                  <tr>
+                    <td className="border px-4 py-2">AI todo lists</td>
+                    <td className="border px-4 py-2">200 / month</td>
+                  </tr>
+                  <tr>
+                    <td className="border px-4 py-2">Kanban board</td>
+                    <td className="border px-4 py-2">Coming soon</td>
+                  </tr>
+                  <tr>
+                    <td className="border px-4 py-2">Team members</td>
+                    <td className="border px-4 py-2">3 seats</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p className="mb-md">
+                Need more AI credits?{' '}
+                <a href="mailto:hey@mindxdo.com">hey@mindxdo.com</a>
+              </p>
+              <p>
+                Mindmaps, todos and the kanban board can be created separately or together.
+              </p>
+            </div>
+          </div>
+          <div className="form-card">
+            <form className="checkout-form" onSubmit={handleSubmit}>
             <div className="form-field">
               <label className="form-label">
                 Name
@@ -77,45 +124,7 @@ const PurchasePage = () => {
             </div>
           </form>
         </div>
-        <h2 className="mt-xl mb-md">Monthly Service Includes</h2>
-        <table className="table-auto mx-auto text-left mb-lg">
-          <thead>
-            <tr>
-              <th className="px-4 py-2">Item</th>
-              <th className="px-4 py-2">Limit</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td className="border px-4 py-2">Manual mindmaps &amp; todos</td>
-              <td className="border px-4 py-2">Unlimited</td>
-            </tr>
-            <tr>
-              <td className="border px-4 py-2">AI mind maps</td>
-              <td className="border px-4 py-2">20 / month</td>
-            </tr>
-            <tr>
-              <td className="border px-4 py-2">AI todo lists</td>
-              <td className="border px-4 py-2">200 / month</td>
-            </tr>
-            <tr>
-              <td className="border px-4 py-2">Kanban board</td>
-              <td className="border px-4 py-2">Coming soon</td>
-            </tr>
-            <tr>
-              <td className="border px-4 py-2">Team members</td>
-              <td className="border px-4 py-2">3 seats</td>
-            </tr>
-          </tbody>
-        </table>
-        <p className="mb-md">
-          Need more AI credits?{' '}
-          <a href="mailto:hey@mindxdo.com">hey@mindxdo.com</a>
-        </p>
-        <p>
-          Mindmaps, todos and the kanban board can be created separately or
-          together.
-        </p>
+        </div>
       </div>
     </section>
   )

--- a/src/global.scss
+++ b/src/global.scss
@@ -406,6 +406,10 @@ hr {
   justify-items: center;
 }
 
+.purchase-grid {
+  align-items: start;
+}
+
 .three-column {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -981,6 +985,17 @@ hr {
   max-width: 420px;
   margin-left: auto;
   margin-right: auto;
+}
+
+.offer-card {
+  background-color: var(--color-surface);
+  border-radius: 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  padding: var(--spacing-xl);
+  max-width: 420px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: var(--spacing-xl);
 }
 
 .form-field {


### PR DESCRIPTION
## Summary
- highlight monthly services using a new `.offer-card`
- move to a two column purchase layout with a mini mindmap on the left
- reuse the homepage animation by embedding `MindmapDemo`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aaaca9a00832797fe2c7f35f2b76f