### PR TITLE
Remove marketing demo from purchase page

### DIFF
--- a/FaintMindmapBackground.tsx
+++ b/FaintMindmapBackground.tsx
@@ -13,7 +13,11 @@ const nodes: NodePos[] = [
   { angle: 288 },
 ]
 
-export default function FaintMindmapBackground(): JSX.Element {
+interface BgProps {
+  className?: string
+}
+
+export default function FaintMindmapBackground({ className = '' }: BgProps): JSX.Element {
   const [visible, setVisible] = useState(0)
 
   useEffect(() => {
@@ -24,7 +28,7 @@ export default function FaintMindmapBackground(): JSX.Element {
   }, [])
 
   return (
-    <div className="mindmap-bg-container" aria-hidden="true">
+    <div className={`mindmap-bg-container ${className}`} aria-hidden="true">
       <svg viewBox="-150 -150 300 300" className="mindmap-bg">
         <circle
           cx="0"

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import FaintMindmapBackground from '../FaintMindmapBackground'
-import MindmapDemo from '../mindmapdemo'
 
 const PurchasePage = () => {
   const handleSubmit = (e: React.FormEvent) => {
@@ -9,16 +8,13 @@ const PurchasePage = () => {
 
   return (
     <section className="section relative overflow-hidden">
-      <FaintMindmapBackground />
       <div className="container">
         <h1 className="text-center mb-md">Purchase MindXdo</h1>
         <p className="text-center mb-lg">$9.99 per month - Mindmap and Todo platform</p>
         <div className="two-column purchase-grid">
           <div>
-            <div className="mini-mindmap-container mb-lg">
-              <MindmapDemo />
-            </div>
             <div className="offer-card text-center">
+              <FaintMindmapBackground className="mindmap-bg-small" />
               <h2 className="mb-md">Monthly Service Includes</h2>
               <table className="table-auto mx-auto text-left mb-lg">
                 <thead>

--- a/src/global.scss
+++ b/src/global.scss
@@ -910,6 +910,16 @@ hr {
   opacity: 0.3;
 }
 
+.mindmap-bg-small {
+  width: 200px;
+  height: 200px;
+  top: 50%;
+  left: 50%;
+  right: auto;
+  bottom: auto;
+  transform: translate(-50%, -50%);
+}
+
 .mindmap-bg {
   width: 100%;
   height: 100%;
@@ -1004,6 +1014,7 @@ hr {
 }
 
 .offer-card {
+  position: relative;
   background-color: var(--color-surface);
   border-radius: 16px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
## Summary
- remove demo component from `PurchasePage`
- support optional class on `FaintMindmapBackground`
- add new small background style
- overlay the small mind map background behind the feature table

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab671dcac832792335eab9d3492de