### PR TITLE
Center mini map and banner sections

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -170,8 +170,8 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="section">
-        <div className="container two-column mini-mindmap-container">
+      <section className="section section--one-col">
+        <div className="container mini-mindmap-container">
           <motion.div
             initial={{ clipPath: 'inset(0 0 100% 0)' }}
             whileInView={{ clipPath: 'inset(0 0 0% 0)' }}
@@ -225,8 +225,8 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="two-column section">
-        <div className="container two-column">
+      <section className="section section--one-col">
+        <div className="container">
           <div className="bold-marketing-text">
             Map your ideas visually while keeping tasks in focus.
           </div>


### PR DESCRIPTION
## Summary
- use a single column layout for the mini mindmap demo section
- use a single column layout for the banner section

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ab79832d883279c26a4278610c399