### PR TITLE
Expand mindmap arms

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -1,17 +1,17 @@
 import { motion } from 'framer-motion'
 
 export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
-  const startX = side === 'left' ? -50 : 350
-  const endX = 200
+  const startX = side === 'left' ? -50 : 750
+  const endX = 400
   return (
-    <svg className={`mindmap-arm ${side}`} viewBox="0 0 400 100" aria-hidden="true">
+    <svg className={`mindmap-arm ${side}`} viewBox="0 0 800 100" aria-hidden="true">
       <motion.line
         x1={startX}
         y1="50"
         x2={endX}
         y2="50"
         stroke="var(--mindmap-color)"
-        strokeWidth="3"
+        strokeWidth="6"
         initial={{ pathLength: 0 }}
         animate={{ pathLength: 1 }}
         transition={{ duration: 4, delay: 2 }}
@@ -19,9 +19,10 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
       <motion.circle
         cx={startX}
         cy="50"
-        r="20"
+        r="30"
         fill="none"
         stroke="var(--mindmap-color)"
+        strokeWidth="6"
         initial={{ scale: 0, cx: startX }}
         animate={{ scale: 1, cx: endX }}
         transition={{ duration: 4, delay: 2 }}

--- a/src/global.scss
+++ b/src/global.scss
@@ -550,7 +550,7 @@ hr {
   top: -100px;
   left: 50%;
   transform: translateX(-50%);
-  width: 400px;
+  width: 800px;
   height: 300px;
   background: radial-gradient(circle at center, var(--color-secondary), transparent);
 }
@@ -1057,18 +1057,18 @@ hr {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 400px;
+  width: 800px;
   height: 100px;
   pointer-events: none;
   opacity: 0.4;
 }
 
 .mindmap-arm.left {
-  left: -50px;
+  left: -100px;
 }
 
 .mindmap-arm.right {
-  right: -50px;
+  right: -100px;
 }
 
 .section-icon {


### PR DESCRIPTION
## Summary
- extend MindmapArm SVG width and update animation coordinates
- increase stroke widths and circle radius for a bolder look
- widen `.mindmap-arm` element and adjust offsets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ab88c6d5c8327b61831699dce96db