### PR TITLE
Fix homepage mind map layout

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -4,7 +4,8 @@ import { motion, AnimatePresence } from 'framer-motion'
 import AnimatedAccordion from './animatedaccordion'
 import FeatureCard from './featurecard'
 import Demo from './demo'
-import MindmapDemo from './mindmapdemo'
+import { CompactMindmapDemo } from './mindmapdemo'
+import MindmapArm from './MindmapArm'
 import FaintMindmapBackground from './FaintMindmapBackground'
 
 const StackingText: React.FC<{ text: string }> = ({ text }) => (
@@ -178,7 +179,7 @@ const Homepage: React.FC = (): JSX.Element => {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <MindmapDemo />
+            <CompactMindmapDemo />
           </motion.div>
           <motion.div
             className="marketing-text-large"
@@ -189,6 +190,56 @@ const Homepage: React.FC = (): JSX.Element => {
           >
             See how AI instantly creates a map for your ideas.
           </motion.div>
+        </div>
+      </section>
+
+      <section className="section section--one-col section-bg-alt text-center reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <div className="container text-center">
+          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <h2 className="marketing-text-large">
+            <StackingText text="Simple and Powerful" />
+          </h2>
+          <p className="section-subtext">
+            Plan projects effortlessly with intuitive maps that grow alongside your ideas.
+          </p>
+        </div>
+      </section>
+
+      <section className="section section--one-col text-center reveal">
+        <div className="container text-center">
+          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ x: 100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            AI Todo Lists Keep Teams Aligned
+          </motion.h2>
+          <p className="section-subtext">
+            Assign tasks from your maps and watch progress unfold automatically.
+          </p>
+        </div>
+      </section>
+
+      <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-hidden">
+        <MindmapArm side="right" />
+        <div className="container text-center">
+          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.8 }}
+          >
+            See Beyond a Task Board
+          </motion.h2>
+          <p className="section-subtext">
+            Mind map connections provide a bird's-eye view of every project step.
+          </p>
         </div>
       </section>
 

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -63,7 +63,11 @@ const maps: SimpleMap[] = [
   },
 ]
 
-export default function MindmapDemo(): JSX.Element {
+interface MindmapDemoProps {
+  compact?: boolean
+}
+
+export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.Element {
   useScrollReveal()
   const mapCount = maps.length
   const maxItems = Math.max(...maps.map(m => m.items.length))
@@ -161,55 +165,63 @@ export default function MindmapDemo(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section--one-col section-bg-alt text-center reveal relative overflow-hidden">
-        <MindmapArm side="left" />
-        <div className="container text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
-          <h2 className="marketing-text-large">
-            <StackingText text="Simple and Powerful" />
-          </h2>
-          <p className="section-subtext">
-            Plan projects effortlessly with intuitive maps that grow alongside your ideas.
-          </p>
-        </div>
-      </section>
+      {compact ? null : (
+        <>
+          <section className="section section--one-col section-bg-alt text-center reveal relative overflow-hidden">
+            <MindmapArm side="left" />
+            <div className="container text-center">
+              <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+              <h2 className="marketing-text-large">
+                <StackingText text="Simple and Powerful" />
+              </h2>
+              <p className="section-subtext">
+                Plan projects effortlessly with intuitive maps that grow alongside your ideas.
+              </p>
+            </div>
+          </section>
 
-      <section className="section section--one-col text-center reveal">
-        <div className="container text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
-          <motion.h2
-            className="marketing-text-large"
-            initial={{ x: 100, opacity: 0 }}
-            whileInView={{ x: 0, opacity: 1 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-          >
-            AI Todo Lists Keep Teams Aligned
-          </motion.h2>
-          <p className="section-subtext">
-            Assign tasks from your maps and watch progress unfold automatically.
-          </p>
-        </div>
-      </section>
+          <section className="section section--one-col text-center reveal">
+            <div className="container text-center">
+              <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+              <motion.h2
+                className="marketing-text-large"
+                initial={{ x: 100, opacity: 0 }}
+                whileInView={{ x: 0, opacity: 1 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.6 }}
+              >
+                AI Todo Lists Keep Teams Aligned
+              </motion.h2>
+              <p className="section-subtext">
+                Assign tasks from your maps and watch progress unfold automatically.
+              </p>
+            </div>
+          </section>
 
-      <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-hidden">
-        <MindmapArm side="right" />
-        <div className="container text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
-          <motion.h2
-            className="marketing-text-large"
-            initial={{ opacity: 0 }}
-            whileInView={{ opacity: 1 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.8 }}
-          >
-            See Beyond a Task Board
-          </motion.h2>
-          <p className="section-subtext">
-            Mind map connections provide a bird's-eye view of every project step.
-          </p>
-        </div>
-      </section>
+          <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-hidden">
+            <MindmapArm side="right" />
+            <div className="container text-center">
+              <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+              <motion.h2
+                className="marketing-text-large"
+                initial={{ opacity: 0 }}
+                whileInView={{ opacity: 1 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.8 }}
+              >
+                See Beyond a Task Board
+              </motion.h2>
+              <p className="section-subtext">
+                Mind map connections provide a bird's-eye view of every project step.
+              </p>
+            </div>
+          </section>
+        </>
+      )}
     </div>
   )
+}
+
+export function CompactMindmapDemo(): JSX.Element {
+  return <MindmapDemo compact />
 }


### PR DESCRIPTION
## Summary
- add `compact` option to `MindmapDemo` and export `CompactMindmapDemo`
- use the compact demo on the homepage
- move "Simple and Powerful", "AI Todo Lists" and "See Beyond" sections out of the grid

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687abb5b5ddc8327a18835106c58a1cb