### PR TITLE
Improve mind map animation trigger

### DIFF
--- a/FaintMindmapBackground.tsx
+++ b/FaintMindmapBackground.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { motion } from 'framer-motion'
+import { useEffect, useState, useRef } from 'react'
+import { motion, useInView } from 'framer-motion'
 
 interface NodePos {
   angle: number
@@ -19,16 +19,25 @@ interface BgProps {
 
 export default function FaintMindmapBackground({ className = '' }: BgProps): JSX.Element {
   const [visible, setVisible] = useState(0)
+  const ref = useRef<HTMLDivElement>(null)
+  const isInView = useInView(ref, { margin: '-40% 0px -40% 0px', once: true })
 
   useEffect(() => {
-    const id = setInterval(() => {
-      setVisible(v => (v < nodes.length ? v + 1 : v))
-    }, 800)
-    return () => clearInterval(id)
-  }, [])
+    if (!isInView) return
+    let interval: number | undefined
+    const start = setTimeout(() => {
+      interval = window.setInterval(() => {
+        setVisible(v => (v < nodes.length ? v + 1 : v))
+      }, 800)
+    }, 1000)
+    return () => {
+      clearTimeout(start)
+      if (interval !== undefined) clearInterval(interval)
+    }
+  }, [isInView])
 
   return (
-    <div className={`mindmap-bg-container ${className}`} aria-hidden="true">
+    <div ref={ref} className={`mindmap-bg-container ${className}`} aria-hidden="true">
       <svg viewBox="-150 -150 300 300" className="mindmap-bg">
         <circle
           cx="0"

--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -1,10 +1,22 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
+import { useRef, useEffect, useState } from 'react'
 
 export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
-  const startX = side === 'left' ? -50 : 750
-  const endX = 400
+  const width = 1600
+  const startX = side === 'left' ? -50 : width - 50
+  const endX = width / 2
+  const ref = useRef<SVGSVGElement>(null)
+  const isInView = useInView(ref, { margin: '-40% 0px -40% 0px', once: true })
+  const [start, setStart] = useState(false)
+
+  useEffect(() => {
+    if (!isInView) return
+    const t = setTimeout(() => setStart(true), 1000)
+    return () => clearTimeout(t)
+  }, [isInView])
+
   return (
-    <svg className={`mindmap-arm ${side}`} viewBox="0 0 800 100" aria-hidden="true">
+    <svg ref={ref} className={`mindmap-arm ${side}`} viewBox={`0 0 ${width} 100`} aria-hidden="true">
       <motion.line
         x1={startX}
         y1="50"
@@ -13,8 +25,8 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         stroke="var(--mindmap-color)"
         strokeWidth="6"
         initial={{ pathLength: 0 }}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 4, delay: 2 }}
+        animate={start ? { pathLength: 1 } : { pathLength: 0 }}
+        transition={{ duration: 4 }}
       />
       <motion.circle
         cx={startX}
@@ -24,8 +36,8 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         stroke="var(--mindmap-color)"
         strokeWidth="6"
         initial={{ scale: 0, cx: startX }}
-        animate={{ scale: 1, cx: endX }}
-        transition={{ duration: 4, delay: 2 }}
+        animate={start ? { scale: 1, cx: endX } : { scale: 0, cx: startX }}
+        transition={{ duration: 4 }}
       />
     </svg>
   )

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
+import { useState, useEffect, useRef } from 'react'
+import { motion, useInView } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
 import FaintMindmapBackground from './FaintMindmapBackground'
@@ -69,20 +69,23 @@ interface MindmapDemoProps {
 
 export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.Element {
   useScrollReveal()
+  const sectionRef = useRef<HTMLElement>(null)
+  const inView = useInView(sectionRef, { margin: '-40% 0px -40% 0px', once: true })
   const mapCount = maps.length
   const maxItems = Math.max(...maps.map(m => m.items.length))
   const totalSteps = mapCount * maxItems
   const [step, setStep] = useState(0)
 
   useEffect(() => {
+    if (!inView) return
     if (step >= totalSteps) return
     const t = setTimeout(() => setStep(prev => prev + 1), 600)
     return () => clearTimeout(t)
-  }, [step, totalSteps])
+  }, [inView, step, totalSteps])
 
   return (
     <div className="mindmap-demo-page">
-      <section className="mindmap-demo section reveal relative overflow-hidden">
+      <section ref={sectionRef} className="mindmap-demo section reveal relative overflow-hidden">
         <FaintMindmapBackground />
         <div className="container section--one-col text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />

--- a/src/global.scss
+++ b/src/global.scss
@@ -1057,18 +1057,18 @@ hr {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 800px;
+  width: 1600px;
   height: 100px;
   pointer-events: none;
   opacity: 0.4;
 }
 
 .mindmap-arm.left {
-  left: -100px;
+  left: -400px;
 }
 
 .mindmap-arm.right {
-  right: -100px;
+  right: -400px;
 }
 
 .section-icon {


### PR DESCRIPTION
## Summary
- start mindmap animations only when sections scroll into view
- increase arm width to 1600px and push further from content
- delay FaintMindmapBackground and MindmapArm animations

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687abde44df08327b099078f2d74f79d