### PR TITLE
Add KanBan demo page and menu entry

### DIFF
--- a/kanban.tsx
+++ b/kanban.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import useScrollReveal from './useScrollReveal'
+import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
+
+const StackingText: React.FC<{ text: string }> = ({ text }) => (
+  <span className="stacking-text">
+    {text.split('').map((ch, i) => (
+      <motion.span
+        key={i}
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ delay: i * 0.05 }}
+      >
+        {ch}
+      </motion.span>
+    ))}
+  </span>
+)
+
+interface Card {
+  title: string
+  assignee: string
+}
+
+interface Lane {
+  title: string
+  cards: Card[]
+}
+
+const lanes: Lane[] = [
+  {
+    title: 'Planning',
+    cards: [
+      { title: 'Research audience', assignee: 'Alice' },
+      { title: 'Define goals', assignee: 'Bob' },
+      { title: 'Outline strategy', assignee: 'Carol' }
+    ]
+  },
+  {
+    title: 'Creation',
+    cards: [
+      { title: 'Design assets', assignee: 'Dave' },
+      { title: 'Write copy', assignee: 'Eve' },
+      { title: 'Build pages', assignee: 'Frank' }
+    ]
+  },
+  {
+    title: 'Review',
+    cards: [
+      { title: 'Collect feedback', assignee: 'Grace' },
+      { title: 'Refine materials', assignee: 'Heidi' }
+    ]
+  },
+  {
+    title: 'Done',
+    cards: [
+      { title: 'Launch campaign', assignee: 'Ivan' },
+      { title: 'Report metrics', assignee: 'Judy' }
+    ]
+  }
+]
+
+export default function Kanban(): JSX.Element {
+  useScrollReveal()
+  const laneCount = lanes.length
+  const maxCards = Math.max(...lanes.map(l => l.cards.length))
+  const totalSteps = laneCount + laneCount * maxCards
+  const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    if (step >= totalSteps) return
+    const t = setTimeout(() => setStep(prev => prev + 1), 600)
+    return () => clearTimeout(t)
+  }, [step, totalSteps])
+
+  return (
+    <div className="kanban-demo-page">
+      <section className="kanban-demo section reveal relative overflow-hidden">
+        <FaintMindmapBackground />
+        <div className="container">
+          <div className="max-w-2xl mx-auto mb-8 text-center">
+            <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+            <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
+            <p className="section-subtext">Marketing tasks glide across each phase</p>
+          </div>
+          <div className="kanban-board">
+            {lanes.map((lane, laneIndex) => {
+              const laneVisible = step >= laneIndex
+              return (
+                <motion.div
+                  className="kanban-lane"
+                  key={lane.title}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={laneVisible ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+                  transition={{ duration: 0.5 }}
+                >
+                  <h3 className="lane-title">{lane.title}</h3>
+                  {lane.cards.map((card, cardIndex) => {
+                    const cardStepStart = laneCount + laneIndex * maxCards + cardIndex
+                    const cardVisible = step >= cardStepStart
+                    return (
+                      <motion.div
+                        className="kanban-card"
+                        key={card.title}
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={cardVisible ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+                        transition={{ duration: 0.5 }}
+                      >
+                        <span className="sparkle" aria-hidden="true">✨</span>
+                        <strong>{card.title}</strong>
+                        <div className="assignee">- {card.assignee}</div>
+                      </motion.div>
+                    )
+                  })}
+                </motion.div>
+              )
+            })}
+          </div>
+          <div className="kanban-upgrade text-center">
+            <Link to="/purchase" className="btn">
+              Upgrade
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="section section-bg-alt reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <div className="container">
+          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <h2 className="marketing-text-large">
+            <StackingText text="AI Workflows" />
+          </h2>
+          <p className="section-subtext">
+            Automated boards keep everyone on track through each stage.
+          </p>
+        </div>
+      </section>
+
+      <section className="section reveal">
+        <div className="container">
+          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ x: -100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+          >
+            Stay Organized Every Step
+          </motion.h2>
+          <p className="section-subtext">
+            Track progress from planning to completion all in one view.
+          </p>
+        </div>
+      </section>
+
+      <section className="section section-bg-primary-light reveal relative overflow-hidden">
+        <MindmapArm side="right" />
+        <div className="container">
+          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <motion.h2
+            className="marketing-text-large"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.8 }}
+          >
+            Coordinate With Clarity
+          </motion.h2>
+          <p className="section-subtext">
+            Everyone knows what to do as cards move smoothly across lanes.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Homepage from '../homepage'
 import AboutPage from '../about'
 import MindmapDemo from '../mindmapdemo'
 import TodoDemo from '../tododemo'
+import Kanban from '../kanban'
 import ResetPassword from '../reset-password'
 import PrivacyPolicy from '../privacypolicy'
 import TermsOfService from '../terms'
@@ -26,6 +27,7 @@ export default function App() {
         <Route path="/about" element={<AboutPage />} />
         <Route path="/mindmap-demo" element={<MindmapDemo />} />
         <Route path="/todo-demo" element={<TodoDemo />} />
+        <Route path="/kanban" element={<Kanban />} />
         <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
         <Route path="/terms" element={<TermsOfService />} />

--- a/src/global.scss
+++ b/src/global.scss
@@ -806,7 +806,8 @@ hr {
 
 /* --- Demo Styles --- */
 .todo-demo,
-.mindmap-demo {
+.mindmap-demo,
+.kanban-demo {
   justify-items: center;
   text-align: center;
 }
@@ -817,7 +818,8 @@ hr {
 }
 
 .todo-card,
-.mindmap-card {
+.mindmap-card,
+.kanban-card {
   background-color: var(--color-surface);
   padding: var(--spacing-lg);
   border-radius: 8px;
@@ -827,7 +829,8 @@ hr {
 }
 
 .todo-list,
-.mindmap-list {
+.mindmap-list,
+.kanban-list {
   list-style: none;
   padding: 0;
   margin: var(--spacing-sm) 0 0;
@@ -835,7 +838,8 @@ hr {
 }
 
 .todo-item,
-.mindmap-item {
+.mindmap-item,
+.kanban-item {
   margin-bottom: var(--spacing-sm);
 }
 
@@ -903,6 +907,31 @@ hr {
   grid-template-columns: repeat(2, minmax(250px, 1fr));
   gap: var(--spacing-lg);
   justify-items: center;
+}
+
+.kanban-board {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(200px, 1fr));
+  gap: var(--spacing-lg);
+  justify-items: stretch;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.kanban-lane {
+  background-color: var(--color-bg-alt);
+  padding: var(--spacing-md);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+@media (max-width: 640px) {
+  .kanban-board {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -21,8 +21,9 @@ const Header = (): JSX.Element => {
   const marketingItems: NavItem[] = [
     { label: 'Home', route: '/' },
     { label: 'About', route: '/about' },
-    { label: 'Mindmap Demo', route: '/mindmap-demo' },
-    { label: 'Todo Demo', route: '/todo-demo' },
+    { label: 'Mindmap', route: '/mindmap-demo' },
+    { label: 'Todo', route: '/todo-demo' },
+    { label: 'KanBan', route: '/kanban' },
     { label: 'Purchase', route: '/purchase' },
   ]
 


### PR DESCRIPTION
## Summary
- add `kanban.tsx` demo page with animated board
- update header navigation to show Mindmap, Todo and KanBan
- register Kanban route
- extend styles for Kanban board

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac1d265308327afc1ec244082a25c