### PR TITLE
Update mindmap animation

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -2,7 +2,7 @@ import { motion, useInView } from 'framer-motion'
 import { useRef, useEffect, useState } from 'react'
 
 export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
-  const width = 1600
+  const width = 3200
   const startX = side === 'left' ? -50 : width - 50
   const endX = width / 2
   const ref = useRef<SVGSVGElement>(null)
@@ -11,7 +11,7 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
 
   useEffect(() => {
     if (!isInView) return
-    const t = setTimeout(() => setStart(true), 1000)
+    const t = setTimeout(() => setStart(true), 500)
     return () => clearTimeout(t)
   }, [isInView])
 

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import FaintMindmapBackground from '../FaintMindmapBackground'
+import MindmapArm from '../MindmapArm'
 
 const PurchasePage = () => {
   const handleSubmit = (e: React.FormEvent) => {
@@ -8,6 +9,8 @@ const PurchasePage = () => {
 
   return (
     <section className="section relative overflow-hidden">
+      <MindmapArm side="left" />
+      <MindmapArm side="right" />
       <div className="container">
         <h1 className="text-center mb-md">Purchase MindXdo</h1>
         <p className="text-center mb-lg">$9.99 per month - Mindmap and Todo platform</p>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1098,18 +1098,18 @@ hr {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 1600px;
+  width: 3200px;
   height: 100px;
   pointer-events: none;
   opacity: 0.4;
 }
 
 .mindmap-arm.left {
-  left: -400px;
+  left: -1000px;
 }
 
 .mindmap-arm.right {
-  right: -400px;
+  right: -1000px;
 }
 
 .section-icon {


### PR DESCRIPTION
## Summary
- slow down the arm start so it waits 0.5s before animating
- double the arm length and adjust offsets
- show the animated arms on the purchase page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac40ae0388327af01e8fa841d7189