### PR TITLE
Fix mindmap arm animation

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -1,22 +1,22 @@
-import { motion, useInView } from 'framer-motion'
-import { useRef, useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import { useRef } from 'react'
 
 export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
   const width = 3200
   const startX = side === 'left' ? -50 : width - 50
   const endX = width / 2
   const ref = useRef<SVGSVGElement>(null)
-  const isInView = useInView(ref, { margin: '-40% 0px -40% 0px', once: true })
-  const [start, setStart] = useState(false)
-
-  useEffect(() => {
-    if (!isInView) return
-    const t = setTimeout(() => setStart(true), 500)
-    return () => clearTimeout(t)
-  }, [isInView])
 
   return (
-    <svg ref={ref} className={`mindmap-arm ${side}`} viewBox={`0 0 ${width} 100`} aria-hidden="true">
+    <motion.svg
+      ref={ref}
+      className={`mindmap-arm ${side}`}
+      viewBox={`0 0 ${width} 100`}
+      aria-hidden="true"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true, margin: '-40% 0px -40% 0px' }}
+    >
       <motion.line
         x1={startX}
         y1="50"
@@ -24,9 +24,10 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         y2="50"
         stroke="var(--mindmap-color)"
         strokeWidth="6"
-        initial={{ pathLength: 0 }}
-        animate={start ? { pathLength: 1 } : { pathLength: 0 }}
-        transition={{ duration: 4 }}
+        variants={{
+          hidden: { pathLength: 0 },
+          visible: { pathLength: 1, transition: { duration: 4, delay: 0.5 } },
+        }}
       />
       <motion.circle
         cx={startX}
@@ -35,10 +36,15 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         fill="none"
         stroke="var(--mindmap-color)"
         strokeWidth="6"
-        initial={{ scale: 0, cx: startX }}
-        animate={start ? { scale: 1, cx: endX } : { scale: 0, cx: startX }}
-        transition={{ duration: 4 }}
+        variants={{
+          hidden: { scale: 0, cx: startX },
+          visible: {
+            scale: 1,
+            cx: endX,
+            transition: { duration: 4, delay: 0.5 },
+          },
+        }}
       />
-    </svg>
+    </motion.svg>
   )
 }


### PR DESCRIPTION
## Summary
- use `motion.svg` for `MindmapArm` and trigger animation when in view

## Testing
- `node --test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687ac797f8448327bf49602bc4ff9014