### PR TITLE
Improve marketing copy and mission animation

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -26,6 +26,7 @@ const sections: AboutSection[] = [
     img: './assets/placeholder.svg',
     bulletPoints: [
       'One workspace for mapping and doing',
+      'Kanban board shows todo progress at a glance',
       'Visual and list views always in sync',
       'Seamless flow from brainstorming to execution',
     ],
@@ -71,19 +72,18 @@ export default function AboutPage(): JSX.Element {
         <div className="about-hero-inner">
           <h1>About MindXdo</h1>
           <p>
-            MindXdo blends mind maps and to‑do lists into a single workflow so you
-            can plan and execute without friction.
+            Vision Meets Action. Plan the big picture, create the details and track the action.
           </p>
           <p>
-            Capture ideas in seconds, break them into tasks, and watch our AI keep
-            everything organized while you focus on the big picture.
+            Stop getting lost in the details and focus on what matters. Use AI to find opportunities and aid you in executing your team's vision.
           </p>
           <Link to="/purchase" className="btn">Purchase</Link>
         </div>
       </section>
       {sections.map((s, i) => (
         <section
-          className={`about-section reveal${i % 2 ? ' reverse' : ''}`}
+          className={`about-section reveal${i === 0 ? ' is-visible' : ''}${
+            i % 2 ? ' reverse' : ''}`}
           key={s.title}
         >
           {i % 2 === 0 && (

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -55,6 +55,12 @@ const features = [
     icon: './assets/feature-ai-automation.png',
   },
   {
+    title: 'Kanban Board',
+    description:
+      'A perfect tool for showing progress of todo items from start to finish.',
+    icon: './assets/feature-kanban.png',
+  },
+  {
     title: 'Secure Cloud Storage',
     description:
       'Your data stays safe and synced across devices with encrypted cloud backup.',
@@ -97,11 +103,11 @@ const Homepage: React.FC = (): JSX.Element => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <h1 className="hero-title">MindXdo: Mindmaps Meet Todos with AI</h1>
+          <h1 className="hero-title">MindXdo: Vision Meets Action</h1>
           <p>
-            Experience the power of AI as your ideas become actionable plans.
-            Map a long‑term vision, break it down into tasks, and let MindXdo
-            guide the next steps.
+            Plan the big picture, create the details and track the action.
+            Stop getting lost in the details and focus on what matters.
+            Use AI to find opportunities and aid you in executing your team's vision.
           </p>
           <Link to="/purchase" className="btn">
             Get Started
@@ -133,12 +139,10 @@ const Homepage: React.FC = (): JSX.Element => {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <StackingText text="Mindmaps + Todos + Team Effort" />
+            <StackingText text="Vision Meets Action" />
           </motion.h2>
-          <p className="section-subtext">Use AI to lay out visual plans and structure</p>
-          <p className="section-subtext">
-            Leverage our assistant to instantly convert ideas into organized mind maps.
-          </p>
+          <p className="section-subtext">Plan the big picture, create the details and track the action.</p>
+          <p className="section-subtext">Stop getting lost in the details and focus on what matters.</p>
         </div>
       </section>
 

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -85,7 +85,7 @@ export default function Kanban(): JSX.Element {
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <img src="./assets/placeholder.svg" alt="" className="section-icon" />
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
-            <p className="section-subtext">Marketing tasks glide across each phase</p>
+            <p className="section-subtext">A Kanban board is a perfect tool for showing progress of todo items.</p>
           </div>
           <div className="kanban-board">
             {lanes.map((lane, laneIndex) => {

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -212,10 +212,10 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                 viewport={{ once: true }}
                 transition={{ duration: 0.8 }}
               >
-                See Beyond a Task Board
+                Vision Meets Action
               </motion.h2>
               <p className="section-subtext">
-                Mind map connections provide a bird's-eye view of every project step.
+                Plan the big picture, create the details and track the action with AI assistance.
               </p>
             </div>
           </section>

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -172,10 +172,10 @@ export default function TodoDemo(): JSX.Element {
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
           >
-            Vision Beyond a Task Board
+            Vision Meets Action
           </motion.h2>
           <p className="section-subtext">
-            Mind maps reveal relationships so you plan and execute with clarity.
+            Use AI to find opportunities and aid you in executing your team's vision.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- show mission section immediately on the about page
- refresh about hero text and mention the kanban board
- emphasize "Vision Meets Action" throughout homepage copy
- add kanban feature card to homepage
- tweak kanban demo intro text
- update headings in demo pages to match new vision slogan

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac9327ae48327b7b019904cb8b6ec