### PR TITLE
Fix mindmap arm visibility

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -971,6 +971,7 @@ hr {
   inset: 0;
   pointer-events: none;
   opacity: 0.3;
+  z-index: -2;
 }
 
 .mindmap-bg-small {
@@ -981,6 +982,7 @@ hr {
   right: auto;
   bottom: auto;
   transform: translate(-50%, -50%);
+  z-index: -2;
 }
 
 .mindmap-bg {


### PR DESCRIPTION
## Summary
- ensure mindmap arm animation is visible by placing background below it

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ace955cb483279ca9665e8785c2a5