### PR TITLE
Fix intersection timing for mindmap arms

### DIFF
--- a/FaintMindmapBackground.tsx
+++ b/FaintMindmapBackground.tsx
@@ -20,7 +20,7 @@ interface BgProps {
 export default function FaintMindmapBackground({ className = '' }: BgProps): JSX.Element {
   const [visible, setVisible] = useState(0)
   const ref = useRef<HTMLDivElement>(null)
-  const isInView = useInView(ref, { margin: '-40% 0px -40% 0px', once: true })
+  const isInView = useInView(ref, { margin: '-50% 0px -50% 0px', once: true })
 
   useEffect(() => {
     if (!isInView) return

--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -15,7 +15,7 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
       aria-hidden="true"
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: true, margin: '-40% 0px -40% 0px' }}
+      viewport={{ once: true, margin: '-50% 0px -50% 0px' }}
     >
       <motion.line
         x1={startX}

--- a/about.tsx
+++ b/about.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import useScrollReveal from './useScrollReveal'
 import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 interface AboutSection {
   title: string
@@ -68,6 +69,7 @@ export default function AboutPage(): JSX.Element {
   return (
     <div className="about-page">
       <section className="section section--one-col reveal relative overflow-hidden">
+        <MindmapArm side="left" />
         <FaintMindmapBackground />
         <div className="about-hero-inner">
           <h1>About MindXdo</h1>
@@ -86,6 +88,7 @@ export default function AboutPage(): JSX.Element {
             i % 2 ? ' reverse' : ''}`}
           key={s.title}
         >
+          <MindmapArm side={i % 2 ? 'right' : 'left'} />
           {i % 2 === 0 && (
             <img src={s.img} alt={s.title} width={400} height={400} />
           )}

--- a/login.tsx
+++ b/login.tsx
@@ -1,4 +1,5 @@
 import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 const LoginPage = (): JSX.Element => {
   const [values, setValues] = useState<LoginFormValues>({ email: '', password: '' })
@@ -95,6 +96,7 @@ const LoginPage = (): JSX.Element => {
 
   return (
     <section className="section login-page relative overflow-hidden">
+      <MindmapArm side="right" />
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">
         <img

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -70,7 +70,7 @@ interface MindmapDemoProps {
 export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.Element {
   useScrollReveal()
   const sectionRef = useRef<HTMLElement>(null)
-  const inView = useInView(sectionRef, { margin: '-40% 0px -40% 0px', once: true })
+  const inView = useInView(sectionRef, { margin: '-50% 0px -50% 0px', once: true })
   const mapCount = maps.length
   const maxItems = Math.max(...maps.map(m => m.items.length))
   const totalSteps = mapCount * maxItems

--- a/useScrollReveal.ts
+++ b/useScrollReveal.ts
@@ -11,7 +11,7 @@ export default function useScrollReveal(selector = '.reveal') {
           entry.target.classList.add('is-visible')
         }
       })
-    }, { threshold: 0.1, rootMargin: '-40% 0px -40% 0px' })
+    }, { threshold: 0.1, rootMargin: '-50% 0px -50% 0px' })
 
     elements.forEach(el => observer.observe(el))
     return () => {


### PR DESCRIPTION
## Summary
- update intersection margin for the MindmapArm component
- trigger scroll reveal when sections reach the center of the viewport
- adjust faint background observer
- add mindmap arms to About and Login pages
- update demo intersection margin

## Testing
- `node --test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687ad13df1b483278aacdb6241574adc