### PR TITLE
Fix missing spaces in animated headings

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -18,7 +18,7 @@ const StackingText: React.FC<{ text: string }> = ({ text }) => (
         viewport={{ once: true }}
         transition={{ delay: i * 0.05 }}
       >
-        {ch}
+        {ch === ' ' ? '\u00A0' : ch}
       </motion.span>
     ))}
   </span>

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -15,7 +15,7 @@ const StackingText: React.FC<{ text: string }> = ({ text }) => (
         viewport={{ once: true }}
         transition={{ delay: i * 0.05 }}
       >
-        {ch}
+        {ch === ' ' ? '\u00A0' : ch}
       </motion.span>
     ))}
   </span>

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -15,7 +15,7 @@ const StackingText: React.FC<{ text: string }> = ({ text }) => (
         viewport={{ once: true }}
         transition={{ delay: i * 0.05 }}
       >
-        {ch}
+        {ch === ' ' ? '\u00A0' : ch}
       </motion.span>
     ))}
   </span>

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -15,7 +15,7 @@ const StackingText: React.FC<{ text: string }> = ({ text }) => (
         viewport={{ once: true }}
         transition={{ delay: i * 0.05 }}
       >
-        {ch}
+        {ch === ' ' ? '\u00A0' : ch}
       </motion.span>
     ))}
   </span>


### PR DESCRIPTION
## Summary
- preserve spaces in StackingText components so words display correctly

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad24e2bd48327875009616dcab371