### PR TITLE
Fix mindmap demo z-index

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -971,7 +971,7 @@ hr {
   inset: 0;
   pointer-events: none;
   opacity: 0.3;
-  z-index: -2;
+  z-index: 1;
 }
 
 .mindmap-bg-small {
@@ -982,7 +982,7 @@ hr {
   right: auto;
   bottom: auto;
   transform: translate(-50%, -50%);
-  z-index: -2;
+  z-index: 1;
 }
 
 .mindmap-bg {
@@ -1127,7 +1127,7 @@ hr {
   height: 100px;
   pointer-events: none;
   opacity: 0.4;
-  z-index: -1;
+  z-index: 1;
 }
 
 .mindmap-arm.left {


### PR DESCRIPTION
## Summary
- ensure the faint mindmap background and animated arms appear above other content by raising their `z-index`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687ad613f1c883278b074cb28281915f