### PR TITLE
Fix demo animations

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -15,7 +15,7 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
       aria-hidden="true"
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: true, margin: '-50% 0px -50% 0px' }}
+      viewport={{ once: true, margin: '-20% 0px -20% 0px' }}
     >
       <motion.line
         x1={startX}

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -70,7 +70,7 @@ interface MindmapDemoProps {
 export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.Element {
   useScrollReveal()
   const sectionRef = useRef<HTMLElement>(null)
-  const inView = useInView(sectionRef, { margin: '-50% 0px -50% 0px', once: true })
+  const inView = useInView(sectionRef, { margin: '-20% 0px -20% 0px', once: true })
   const mapCount = maps.length
   const maxItems = Math.max(...maps.map(m => m.items.length))
   const totalSteps = mapCount * maxItems

--- a/useScrollReveal.ts
+++ b/useScrollReveal.ts
@@ -11,7 +11,7 @@ export default function useScrollReveal(selector = '.reveal') {
           entry.target.classList.add('is-visible')
         }
       })
-    }, { threshold: 0.1, rootMargin: '-50% 0px -50% 0px' })
+    }, { threshold: 0.1, rootMargin: '0px 0px -20% 0px' })
 
     elements.forEach(el => observer.observe(el))
     return () => {


### PR DESCRIPTION
## Summary
- use smaller root margins in scroll reveal logic
- adjust MindmapArm viewport margin
- update mindmap demo inView settings

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687adefdeac08327b65782d60b3ee8d2