### PR TITLE
Fix mindmap arm animation

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
 import { useRef } from 'react'
 
 export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
@@ -6,6 +6,7 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
   const startX = side === 'left' ? -50 : width - 50
   const endX = width / 2
   const ref = useRef<SVGSVGElement>(null)
+  const inView = useInView(ref, { amount: 0.2, once: true })
 
   return (
     <motion.svg
@@ -13,9 +14,6 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
       className={`mindmap-arm ${side}`}
       viewBox={`0 0 ${width} 100`}
       aria-hidden="true"
-      initial="hidden"
-      whileInView="visible"
-      viewport={{ once: true, margin: '-20% 0px -20% 0px' }}
     >
       <motion.line
         x1={startX}
@@ -24,10 +22,8 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         y2="50"
         stroke="var(--mindmap-color)"
         strokeWidth="6"
-        variants={{
-          hidden: { pathLength: 0 },
-          visible: { pathLength: 1, transition: { duration: 4, delay: 0.5 } },
-        }}
+        animate={inView ? { pathLength: 1 } : { pathLength: 0 }}
+        transition={{ duration: 4, delay: 0.5 }}
       />
       <motion.circle
         cx={startX}
@@ -36,14 +32,8 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         fill="none"
         stroke="var(--mindmap-color)"
         strokeWidth="6"
-        variants={{
-          hidden: { scale: 0, cx: startX },
-          visible: {
-            scale: 1,
-            cx: endX,
-            transition: { duration: 4, delay: 0.5 },
-          },
-        }}
+        animate={inView ? { scale: 1, cx: endX } : { scale: 0, cx: startX }}
+        transition={{ duration: 4, delay: 0.5 }}
       />
     </motion.svg>
   )


### PR DESCRIPTION
## Summary
- switch MindmapArm to use `useInView`
- drive line and circle animation when component enters viewport

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae0d96dc083279b2ed928d1cf1470