### PR TITLE
Fix MindmapArm visibility on small screens

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -6,7 +6,11 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
   const startX = side === 'left' ? -50 : width - 50
   const endX = width / 2
   const ref = useRef<SVGSVGElement>(null)
-  const inView = useInView(ref, { amount: 0.2, once: true })
+  // Trigger the animation even if only a small portion of the arm is visible.
+  // A large width combined with `overflow-hidden` containers means the
+  // intersection ratio is often below 0.2 on mobile screens. Reducing the
+  // threshold ensures the animation runs as soon as any part is on screen.
+  const inView = useInView(ref, { amount: 0.05, once: true })
 
   return (
     <motion.svg


### PR DESCRIPTION
## Summary
- reduce the in-view threshold so the arm animation plays when any part is visible

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ae32bdf248327955ddb857e1e7ba6