### PR TITLE
Fix MindmapArm visibility on marketing pages

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1127,7 +1127,8 @@ hr {
   height: 100px;
   pointer-events: none;
   opacity: 0.4;
-  z-index: 1;
+  /* Appear above faint background but below text */
+  z-index: 2;
 }
 
 .mindmap-arm.left {


### PR DESCRIPTION
## Summary
- bump up `.mindmap-arm` z-index so arms draw above the faint background

## Testing
- `node --test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687ae4896654832794c0b8705f9fdd41