### PR TITLE
Update marketing banners

### DIFF
--- a/kanban.tsx
+++ b/kanban.tsx
@@ -80,10 +80,11 @@ export default function Kanban(): JSX.Element {
   return (
     <div className="kanban-demo-page">
       <section className="kanban-demo section reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <MindmapArm side="right" />
         <FaintMindmapBackground />
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
-            <img src="./assets/placeholder.svg" alt="" className="section-icon" />
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
             <p className="section-subtext">A Kanban board is a perfect tool for showing progress of todo items.</p>
           </div>
@@ -131,7 +132,6 @@ export default function Kanban(): JSX.Element {
       <section className="section section-bg-alt reveal relative overflow-hidden">
         <MindmapArm side="left" />
         <div className="container">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <h2 className="marketing-text-large">
             <StackingText text="AI Workflows" />
           </h2>
@@ -143,7 +143,6 @@ export default function Kanban(): JSX.Element {
 
       <section className="section reveal">
         <div className="container">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
             initial={{ x: -100, opacity: 0 }}
@@ -162,7 +161,6 @@ export default function Kanban(): JSX.Element {
       <section className="section section-bg-primary-light reveal relative overflow-hidden">
         <MindmapArm side="right" />
         <div className="container">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
             initial={{ opacity: 0 }}

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -86,9 +86,10 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
   return (
     <div className="mindmap-demo-page">
       <section ref={sectionRef} className="mindmap-demo section reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <MindmapArm side="right" />
         <FaintMindmapBackground />
         <div className="container section--one-col text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
           <p className="section-subtext">
             Mind maps animate to life so you can focus on brainstorming
@@ -172,8 +173,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
         <>
           <section className="section section--one-col section-bg-alt text-center reveal relative overflow-hidden">
             <MindmapArm side="left" />
-            <div className="container text-center">
-              <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <div className="container text-center">
               <h2 className="marketing-text-large">
                 <StackingText text="Simple and Powerful" />
               </h2>
@@ -185,7 +185,6 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
 
           <section className="section section--one-col text-center reveal">
             <div className="container text-center">
-              <img src="./assets/placeholder.svg" alt="" className="section-icon" />
               <motion.h2
                 className="marketing-text-large"
                 initial={{ x: 100, opacity: 0 }}
@@ -204,7 +203,6 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
           <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-hidden">
             <MindmapArm side="right" />
             <div className="container text-center">
-              <img src="./assets/placeholder.svg" alt="" className="section-icon" />
               <motion.h2
                 className="marketing-text-large"
                 initial={{ opacity: 0 }}

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -90,10 +90,11 @@ export default function TodoDemo(): JSX.Element {
   return (
     <div className="todo-demo-page">
       <section className="todo-demo section reveal relative overflow-hidden">
+        <MindmapArm side="left" />
+        <MindmapArm side="right" />
         <FaintMindmapBackground />
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
-            <img src="./assets/placeholder.svg" alt="" className="section-icon" />
             <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
             <p className="section-subtext">Watch todos appear with smooth animations</p>
           </div>
@@ -133,7 +134,6 @@ export default function TodoDemo(): JSX.Element {
       <section className="section section-bg-alt reveal relative overflow-hidden">
         <MindmapArm side="left" />
         <div className="container">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <h2 className="marketing-text-large">
             <StackingText text="AI Simplicity" />
           </h2>
@@ -145,7 +145,6 @@ export default function TodoDemo(): JSX.Element {
 
       <section className="section reveal">
         <div className="container">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
             initial={{ x: -100, opacity: 0 }}
@@ -164,7 +163,6 @@ export default function TodoDemo(): JSX.Element {
       <section className="section section-bg-primary-light reveal relative overflow-hidden">
         <MindmapArm side="right" />
         <div className="container">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
             initial={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- remove placeholder SVGs from demo pages
- add animated arms to the hero banners

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_687ae64d84a88327ababf2c95e29058a