### PR TITLE
Fix overflow to show mindmap arm

### DIFF
--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -2,8 +2,8 @@ import { motion, useInView } from 'framer-motion'
 import { useRef } from 'react'
 
 export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' }): JSX.Element {
-  const width = 3200
-  const startX = side === 'left' ? -50 : width - 50
+  const width = 1200
+  const startX = side === 'left' ? 0 : width
   const endX = width / 2
   const ref = useRef<SVGSVGElement>(null)
   // Trigger the animation even if only a small portion of the arm is visible.

--- a/about.tsx
+++ b/about.tsx
@@ -68,7 +68,7 @@ export default function AboutPage(): JSX.Element {
   useScrollReveal()
   return (
     <div className="about-page">
-      <section className="section section--one-col reveal relative overflow-hidden">
+      <section className="section section--one-col reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <FaintMindmapBackground />
         <div className="about-hero-inner">

--- a/checkout.tsx
+++ b/checkout.tsx
@@ -11,7 +11,7 @@ export default function CheckoutPage(): JSX.Element {
   }
 
   return (
-    <section className="section relative overflow-hidden">
+    <section className="section relative overflow-x-visible">
       <FaintMindmapBackground />
       <div className="container text-center">
         <h1 className="mb-lg">Checkout</h1>

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -92,7 +92,7 @@ const Homepage: React.FC = (): JSX.Element => {
 
   return (
     <div className="homepage">
-      <section className="hero section relative overflow-hidden">
+        <section className="hero section relative overflow-x-visible">
         <FaintMindmapBackground />
         <div className="container">
         <div className="shape shape-circle hero-shape1" />
@@ -190,7 +190,7 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="section section--one-col section-bg-alt text-center reveal relative overflow-hidden">
+      <section className="section section--one-col section-bg-alt text-center reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <div className="container text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />
@@ -221,7 +221,7 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
-      <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-hidden">
+      <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-x-visible">
         <MindmapArm side="right" />
         <div className="container text-center">
           <img src="./assets/placeholder.svg" alt="" className="section-icon" />

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -79,7 +79,7 @@ export default function Kanban(): JSX.Element {
 
   return (
     <div className="kanban-demo-page">
-      <section className="kanban-demo section reveal relative overflow-hidden">
+      <section className="kanban-demo section reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <MindmapArm side="right" />
         <FaintMindmapBackground />
@@ -129,7 +129,7 @@ export default function Kanban(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section-bg-alt reveal relative overflow-hidden">
+      <section className="section section-bg-alt reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <div className="container">
           <h2 className="marketing-text-large">
@@ -158,7 +158,7 @@ export default function Kanban(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section-bg-primary-light reveal relative overflow-hidden">
+      <section className="section section-bg-primary-light reveal relative overflow-x-visible">
         <MindmapArm side="right" />
         <div className="container">
           <motion.h2

--- a/login.tsx
+++ b/login.tsx
@@ -95,7 +95,7 @@ const LoginPage = (): JSX.Element => {
   }
 
   return (
-    <section className="section login-page relative overflow-hidden">
+    <section className="section login-page relative overflow-x-visible">
       <MindmapArm side="right" />
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -85,7 +85,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
 
   return (
     <div className="mindmap-demo-page">
-      <section ref={sectionRef} className="mindmap-demo section reveal relative overflow-hidden">
+      <section ref={sectionRef} className="mindmap-demo section reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <MindmapArm side="right" />
         <FaintMindmapBackground />
@@ -171,7 +171,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
 
       {compact ? null : (
         <>
-          <section className="section section--one-col section-bg-alt text-center reveal relative overflow-hidden">
+          <section className="section section--one-col section-bg-alt text-center reveal relative overflow-x-visible">
             <MindmapArm side="left" />
           <div className="container text-center">
               <h2 className="marketing-text-large">
@@ -200,7 +200,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
             </div>
           </section>
 
-          <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-hidden">
+          <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-x-visible">
             <MindmapArm side="right" />
             <div className="container text-center">
               <motion.h2

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -8,7 +8,7 @@ const PurchasePage = () => {
   }
 
   return (
-    <section className="section relative overflow-hidden">
+    <section className="section relative overflow-x-visible">
       <div className="container">
         <h1 className="text-center mb-md">Purchase MindXdo</h1>
         <p className="text-center mb-lg">$9.99 per month - Mindmap and Todo platform</p>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1123,20 +1123,20 @@ hr {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  width: 3200px;
+  width: 1200px;
   height: 100px;
   pointer-events: none;
   opacity: 0.4;
   /* Appear above faint background but below text */
-  z-index: 2;
+  z-index: 1;
 }
 
 .mindmap-arm.left {
-  left: -1000px;
+  left: 0;
 }
 
 .mindmap-arm.right {
-  right: -1000px;
+  right: 0;
 }
 
 .section-icon {

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -89,7 +89,7 @@ export default function TodoDemo(): JSX.Element {
 
   return (
     <div className="todo-demo-page">
-      <section className="todo-demo section reveal relative overflow-hidden">
+      <section className="todo-demo section reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <MindmapArm side="right" />
         <FaintMindmapBackground />
@@ -131,7 +131,7 @@ export default function TodoDemo(): JSX.Element {
       </div>
       </section>
 
-      <section className="section section-bg-alt reveal relative overflow-hidden">
+      <section className="section section-bg-alt reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <div className="container">
           <h2 className="marketing-text-large">
@@ -160,7 +160,7 @@ export default function TodoDemo(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section-bg-primary-light reveal relative overflow-hidden">
+      <section className="section section-bg-primary-light reveal relative overflow-x-visible">
         <MindmapArm side="right" />
         <div className="container">
           <motion.h2


### PR DESCRIPTION
## Summary
- let the mindmap arms animate by using overflow-x-visible on sections
- shrink the MindmapArm SVG and adjust start positions
- update global CSS for new arm width and positioning

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ae78993c483279958ba9d009bc683