### PR TITLE
Remove top mindmap arms

### DIFF
--- a/kanban.tsx
+++ b/kanban.tsx
@@ -80,8 +80,6 @@ export default function Kanban(): JSX.Element {
   return (
     <div className="kanban-demo-page">
       <section className="kanban-demo section reveal relative overflow-x-visible">
-        <MindmapArm side="left" />
-        <MindmapArm side="right" />
         <FaintMindmapBackground />
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -104,7 +104,6 @@ const PurchasePage = () => {
               <button type="button" className="btn btn-paypal">PayPal</button>
             </div>
           </form>
-          <MindmapArm side="right" />
         </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- clean up the Kanban page so the first section has no left or right arms
- keep only the left arm on the Purchase page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687aea937a188327ab17ac47aa22883b