### PR TITLE
Remove top mindmap arms from Todo page

### DIFF
--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -90,8 +90,6 @@ export default function TodoDemo(): JSX.Element {
   return (
     <div className="todo-demo-page">
       <section className="todo-demo section reveal relative overflow-x-visible">
-        <MindmapArm side="left" />
-        <MindmapArm side="right" />
         <FaintMindmapBackground />
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">


### PR DESCRIPTION
## Summary
- remove MindmapArm at the top of `tododemo.tsx`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687aed2d08288327b4c663cc8c1fe09e