### PR TITLE
Use marketing images

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -14,7 +14,7 @@ const sections: AboutSection[] = [
   {
     title: 'Our Mission',
     text: 'We help visualize big ideas and break them into manageable steps using AI planning tools.',
-    img: './assets/placeholder.svg',
+    img: './assets/hero-mindmap.png',
     bulletPoints: [
       'Capture concepts quickly with intuitive mind maps',
       'Turn every idea into an actionable task',
@@ -24,7 +24,7 @@ const sections: AboutSection[] = [
   {
     title: 'Key Benefits',
     text: 'MindXdo keeps your plans and tasks together so you stay organized and focused.',
-    img: './assets/placeholder.svg',
+    img: './assets/hero-collaboration.png',
     bulletPoints: [
       'One workspace for mapping and doing',
       'Kanban board shows todo progress at a glance',
@@ -35,7 +35,7 @@ const sections: AboutSection[] = [
   {
     title: 'Earn Rewards',
     text: 'Achieve milestones to unlock perks as you progress through your goals.',
-    img: './assets/placeholder.svg',
+    img: './assets/feature-cross-platform.png',
     bulletPoints: [
       'Celebrate wins with badges and perks',
       'Level up productivity through gamification',
@@ -45,7 +45,7 @@ const sections: AboutSection[] = [
   {
     title: 'Performance Insights',
     text: 'Track progress at a glance and let data drive your next move.',
-    img: './assets/placeholder.svg',
+    img: './assets/hero-todo.png',
     bulletPoints: [
       'Dashboards highlight your progress',
       'AI suggestions keep you on the right path',
@@ -55,7 +55,7 @@ const sections: AboutSection[] = [
   {
     title: 'Continuous Improvement',
     text: 'We evolve alongside your workflow so you can focus on what matters most.',
-    img: './assets/placeholder.svg',
+    img: './assets/ai-showcase.png',
     bulletPoints: [
       'Frequent feature releases based on feedback',
       'Tools that scale with your ambitions',
@@ -72,6 +72,7 @@ export default function AboutPage(): JSX.Element {
         <MindmapArm side="left" />
         <FaintMindmapBackground />
         <div className="about-hero-inner">
+          <img src="./assets/hero-mindmap.png" alt="Mindmap" className="banner-image" />
           <h1>About MindXdo</h1>
           <p>
             Vision Meets Action. Plan the big picture, create the details and track the action.

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -58,6 +58,12 @@ const features = [
       'Your data stays safe and synced across devices with encrypted cloud backup.',
     icon: './assets/feature-secure-storage.png',
   },
+  {
+    title: 'Cross-Platform Sync',
+    description:
+      'Access your maps and tasks anywhere with seamless device syncing.',
+    icon: './assets/feature-cross-platform.png',
+  },
 ]
 
 const faqItems = [
@@ -129,9 +135,9 @@ const Homepage: React.FC = (): JSX.Element => {
             Sketch processes and tasks in minutes and refine them with your team.
           </p>
           <div className="icon-row">
-            <img src="./assets/placeholder.svg" alt="Flow icon" />
-            <img src="./assets/placeholder.svg" alt="Checklist icon" />
-            <img src="./assets/placeholder.svg" alt="Team icon" />
+            <img src="./assets/feature-mind-mapping.png" alt="Flow icon" />
+            <img src="./assets/feature-todo-integration.png" alt="Checklist icon" />
+            <img src="./assets/feature-collaboration.png" alt="Team icon" />
           </div>
         </div>
       </section>
@@ -161,7 +167,7 @@ const Homepage: React.FC = (): JSX.Element => {
       <section className="section section--one-col section-bg-alt text-center reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <div className="container text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <img src="./assets/feature-cross-platform.png" alt="Cross platform" className="section-icon" />
           <h2 className="marketing-text-large">
             <StackingText text="Simple and Powerful" />
           </h2>
@@ -173,7 +179,7 @@ const Homepage: React.FC = (): JSX.Element => {
 
       <section className="section section--one-col text-center reveal">
         <div className="container text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <img src="./assets/hero-collaboration.png" alt="Collaboration" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
             initial={{ x: 100, opacity: 0 }}
@@ -192,7 +198,7 @@ const Homepage: React.FC = (): JSX.Element => {
       <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-x-visible">
         <MindmapArm side="right" />
         <div className="container text-center">
-          <img src="./assets/placeholder.svg" alt="" className="section-icon" />
+          <img src="./assets/hero-mindmap.png" alt="Mindmap" className="section-icon" />
           <motion.h2
             className="marketing-text-large"
             initial={{ opacity: 0 }}
@@ -257,15 +263,15 @@ const Homepage: React.FC = (): JSX.Element => {
       <section className="three-column section">
         <div className="container three-column">
           <div>
-            <img src="./assets/placeholder.svg" alt="Plan" />
+            <img src="./assets/feature-mind-mapping.png" alt="Plan" />
             <div className="bold-marketing-text">Plan</div>
           </div>
           <div>
-            <img src="./assets/placeholder.svg" alt="Track" />
+            <img src="./assets/feature-kanban.png" alt="Track" />
             <div className="bold-marketing-text">Track</div>
           </div>
           <div>
-            <img src="./assets/placeholder.svg" alt="Launch" />
+            <img src="./assets/feature-ai-automation.png" alt="Launch" />
             <div className="bold-marketing-text">Launch</div>
           </div>
         </div>

--- a/login.tsx
+++ b/login.tsx
@@ -100,9 +100,9 @@ const LoginPage = (): JSX.Element => {
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">
         <img
-          src="./assets/placeholder.svg"
+          src="./assets/hero-collaboration.png"
           alt="Login"
-          className="login-icon"
+          className="login-icon banner-image"
         />
       <h2 className="text-2xl font-bold mb-6 text-center">Login</h2>
       {submitError && (

--- a/reset-password.tsx
+++ b/reset-password.tsx
@@ -17,9 +17,9 @@ const ResetPasswordPage = () => {
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">
         <img
-          src="./assets/placeholder.svg"
+          src="./assets/hero-mindmap.png"
           alt="Reset Password"
-          className="login-icon"
+          className="login-icon banner-image"
         />
         <h2 className="text-2xl font-bold mb-6 text-center">Reset Password</h2>
         <form onSubmit={handleSubmit} noValidate>

--- a/src/global.scss
+++ b/src/global.scss
@@ -409,8 +409,15 @@ hr {
 .banner-image {
   width: 100%;
   display: block;
-  max-height: 600px;
+  max-height: 400px;
   object-fit: cover;
+}
+
+.site-image {
+  width: 100%;
+  display: block;
+  max-height: 400px;
+  object-fit: contain;
 }
 
 .two-column {


### PR DESCRIPTION
## Summary
- use hero images in about/login/reset-password sections
- restrict banner image height site wide
- add missing cross-platform feature icon
- replace placeholders in homepage

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687b1c411b448327a21d37aa5932cc3d