### PR TITLE
Adjust hero banners and icons

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -88,7 +88,7 @@ const Homepage: React.FC = (): JSX.Element => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <h1 className="hero-title">MindXdo: Vision Meets Action</h1>
+          <h1 className="hero-title">Vision Meets Action</h1>
           <p>
             Plan the big picture, create the details and track the action.
             Stop getting lost in the details and focus on what matters.
@@ -129,16 +129,11 @@ const Homepage: React.FC = (): JSX.Element => {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            Rapidly prototype business ideas, flows, systems, and more.
+            Rapidly prototype ideas, flows, systems, & more.
           </motion.h2>
           <p className="section-subtext">
             Sketch processes and tasks in minutes and refine them with your team.
           </p>
-          <div className="icon-row">
-            <img src="./assets/feature-mind-mapping.png" alt="Flow icon" />
-            <img src="./assets/feature-todo-integration.png" alt="Checklist icon" />
-            <img src="./assets/feature-collaboration.png" alt="Team icon" />
-          </div>
         </div>
       </section>
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -409,7 +409,7 @@ hr {
 .banner-image {
   width: 100%;
   display: block;
-  max-height: 400px;
+  max-height: 600px;
   object-fit: cover;
 }
 
@@ -465,7 +465,8 @@ hr {
   justify-items: center;
 }
 .three-column img {
-  height: 96px;
+  width: 200px;
+  height: auto;
   margin: 0 auto var(--spacing-sm);
   display: block;
 }
@@ -643,8 +644,8 @@ hr {
 }
 
 .icon-row img {
-  height: 48px;
-  width: 48px;
+  width: 200px;
+  height: auto;
 }
 
 .section .container {
@@ -788,7 +789,8 @@ hr {
 }
 
 .feature-card__icon {
-  height: 96px;
+  width: 200px;
+  height: auto;
   margin: 0 auto var(--spacing-md);
   display: block;
 }
@@ -1150,7 +1152,7 @@ hr {
 }
 
 .section-icon {
-  width: 96px;
+  width: 200px;
   margin: 0 auto var(--spacing-md);
   display: block;
 }
@@ -1167,7 +1169,7 @@ hr {
 }
 
 .login-icon {
-  width: 96px;
+  width: 200px;
   margin: 0 auto var(--spacing-lg);
 }
 


### PR DESCRIPTION
## Summary
- keep banner images full width and limit height to 600px
- enlarge various icon styles to 200px wide
- tweak homepage headline and marketing copy
- remove icons below the prototype section

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b1f168a388327ab293a411462a4e8