### PR TITLE
Update hero banner layout

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -92,10 +92,10 @@ const Homepage: React.FC = (): JSX.Element => {
             Get Started
           </Link>
         </motion.div>
-        <div className="banner-slider">
-          <img src={heroImage} alt="Hero banner" className="banner-image" />
         </div>
-        </div>
+      </section>
+      <section className="hero-banner">
+        <img src={heroImage} alt="Hero banner" className="banner-image" />
       </section>
 
       <section className="section section--one-col section-bg-alt text-center" style={{ marginTop: '100px' }}>

--- a/src/global.scss
+++ b/src/global.scss
@@ -413,6 +413,11 @@ hr {
   object-fit: cover;
 }
 
+.hero-banner {
+  margin: 0;
+  padding: 0;
+}
+
 .site-image {
   width: 100%;
   display: block;


### PR DESCRIPTION
## Summary
- place hero image in its own section so the banner spans the full viewport
- add hero-banner style with no margin or padding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b22ff291c8327adaaa459a8078c2e