### PR TITLE
Update marketing banners

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -14,7 +14,7 @@ const sections: AboutSection[] = [
   {
     title: 'Our Mission',
     text: 'We help visualize big ideas and break them into manageable steps using AI planning tools.',
-    img: './assets/hero-mindmap.png',
+    img: './assets/marketing_square_mindmap_people.png',
     bulletPoints: [
       'Capture concepts quickly with intuitive mind maps',
       'Turn every idea into an actionable task',
@@ -24,7 +24,7 @@ const sections: AboutSection[] = [
   {
     title: 'Key Benefits',
     text: 'MindXdo keeps your plans and tasks together so you stay organized and focused.',
-    img: './assets/hero-collaboration.png',
+    img: './assets/marketing_square_lightbulb_team.png',
     bulletPoints: [
       'One workspace for mapping and doing',
       'Kanban board shows todo progress at a glance',
@@ -35,7 +35,7 @@ const sections: AboutSection[] = [
   {
     title: 'Performance Insights',
     text: 'Track progress at a glance and let data drive your next move.',
-    img: './assets/hero-todo.png',
+    img: './assets/marketing_square_todolist_in_cloud.png',
     bulletPoints: [
       'Dashboards highlight your progress',
       'AI suggestions keep you on the right path',
@@ -45,7 +45,7 @@ const sections: AboutSection[] = [
   {
     title: 'Continuous Improvement',
     text: 'We evolve alongside your workflow so you can focus on what matters most.',
-    img: './assets/ai-showcase.png',
+    img: './assets/marketing_square_ai_connecting.png',
     bulletPoints: [
       'Frequent feature releases based on feedback',
       'Tools that scale with your ambitions',

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -67,7 +67,7 @@ const faqItems = [
 ]
 
 const Homepage: React.FC = (): JSX.Element => {
-  const heroImage = './assets/hero-todo.png'
+  const heroImage = './assets/main_hero_banner_mindxdo_cloud.png'
 
 
   return (
@@ -248,7 +248,7 @@ const Homepage: React.FC = (): JSX.Element => {
             Map your ideas visually while keeping tasks in focus.
           </div>
           <img
-            src="./assets/integration-banner.png"
+            src="./assets/simple_main_banner_home.png"
             alt="Visual integration banner"
             className="banner-image"
           />
@@ -290,7 +290,7 @@ const Homepage: React.FC = (): JSX.Element => {
           timelines so you never wonder what comes next.
         </p>
         <img
-          src="./assets/ai-showcase.png"
+          src="./assets/system_banner_people.png"
           alt="AI showcase"
           className="banner-image"
         />

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -127,9 +127,13 @@ export default function Kanban(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section-bg-alt reveal relative overflow-x-visible">
+      <section className="about-section reveal">
         <MindmapArm side="left" />
-        <div className="container">
+        <img
+          src="./assets/marketing_square_treasuremap.png"
+          alt="AI Workflows"
+        />
+        <div>
           <h2 className="marketing-text-large">
             <StackingText text="AI Workflows" />
           </h2>
@@ -139,8 +143,13 @@ export default function Kanban(): JSX.Element {
         </div>
       </section>
 
-      <section className="section reveal">
-        <div className="container">
+      <section className="about-section reveal reverse">
+        <MindmapArm side="right" />
+        <img
+          src="./assets/marketing_square_mindmap_people.png"
+          alt="Stay Organized"
+        />
+        <div>
           <motion.h2
             className="marketing-text-large"
             initial={{ x: -100, opacity: 0 }}
@@ -156,9 +165,13 @@ export default function Kanban(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section-bg-primary-light reveal relative overflow-x-visible">
-        <MindmapArm side="right" />
-        <div className="container">
+      <section className="about-section reveal">
+        <MindmapArm side="left" />
+        <img
+          src="./assets/marketing_square_ai_connecting.png"
+          alt="Coordinate With Clarity"
+        />
+        <div>
           <motion.h2
             className="marketing-text-large"
             initial={{ opacity: 0 }}

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -169,9 +169,13 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
 
       {compact ? null : (
         <>
-          <section className="section section--one-col section-bg-alt text-center reveal relative overflow-x-visible">
+          <section className="about-section reveal">
             <MindmapArm side="left" />
-          <div className="container text-center">
+            <img
+              src="./assets/marketing_square_mindmap_people.png"
+              alt="Simple and Powerful"
+            />
+            <div>
               <h2 className="marketing-text-large">
                 <StackingText text="Simple and Powerful" />
               </h2>
@@ -181,33 +185,35 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
             </div>
           </section>
 
-          <section className="section text-center reveal">
-            <div className="container two-column">
-              <div>
-                <motion.h2
-                  className="marketing-text-large"
-                  initial={{ x: 100, opacity: 0 }}
-                  whileInView={{ x: 0, opacity: 1 }}
-                  viewport={{ once: true }}
-                  transition={{ duration: 0.6 }}
-                >
-                  AI Todo Lists Keep Teams Aligned
-                </motion.h2>
-                <p className="section-subtext">
-                  Assign tasks from your maps and watch progress unfold automatically.
-                </p>
-              </div>
-              <img
-                src="./assets/hero-collaboration.png"
-                alt="Collaboration"
-                style={{ width: '400px' }}
-              />
+          <section className="about-section reveal reverse">
+            <MindmapArm side="right" />
+            <img
+              src="./assets/marketing_square_todolist_with_brain.png"
+              alt="AI Todo Lists"
+            />
+            <div>
+              <motion.h2
+                className="marketing-text-large"
+                initial={{ x: 100, opacity: 0 }}
+                whileInView={{ x: 0, opacity: 1 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.6 }}
+              >
+                AI Todo Lists Keep Teams Aligned
+              </motion.h2>
+              <p className="section-subtext">
+                Assign tasks from your maps and watch progress unfold automatically.
+              </p>
             </div>
           </section>
 
-          <section className="section section--one-col section-bg-primary-light text-center reveal relative overflow-x-visible">
-            <MindmapArm side="right" />
-            <div className="container text-center">
+          <section className="about-section reveal">
+            <MindmapArm side="left" />
+            <img
+              src="./assets/marketing_square_ai_connecting.png"
+              alt="Vision Meets Action"
+            />
+            <div>
               <motion.h2
                 className="marketing-text-large"
                 initial={{ opacity: 0 }}

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -129,9 +129,13 @@ export default function TodoDemo(): JSX.Element {
       </div>
       </section>
 
-      <section className="section section-bg-alt reveal relative overflow-x-visible">
+      <section className="about-section reveal">
         <MindmapArm side="left" />
-        <div className="container">
+        <img
+          src="./assets/marketing_square_todolist_in_cloud.png"
+          alt="AI Simplicity"
+        />
+        <div>
           <h2 className="marketing-text-large">
             <StackingText text="AI Simplicity" />
           </h2>
@@ -141,8 +145,13 @@ export default function TodoDemo(): JSX.Element {
         </div>
       </section>
 
-      <section className="section reveal">
-        <div className="container">
+      <section className="about-section reveal reverse">
+        <MindmapArm side="right" />
+        <img
+          src="./assets/marketing_square_lightbulb_team.png"
+          alt="Team Management"
+        />
+        <div>
           <motion.h2
             className="marketing-text-large"
             initial={{ x: -100, opacity: 0 }}
@@ -158,9 +167,13 @@ export default function TodoDemo(): JSX.Element {
         </div>
       </section>
 
-      <section className="section section-bg-primary-light reveal relative overflow-x-visible">
-        <MindmapArm side="right" />
-        <div className="container">
+      <section className="about-section reveal">
+        <MindmapArm side="left" />
+        <img
+          src="./assets/marketing_square_ai_connecting.png"
+          alt="Vision Meets Action"
+        />
+        <div>
           <motion.h2
             className="marketing-text-large"
             initial={{ opacity: 0 }}


### PR DESCRIPTION
## Summary
- switch home hero banner to the new cloud image
- use new banner graphics on the home page
- refresh about page images
- alternate marketing sections with new square images on mindmap, todo and kanban demos

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc92d523083278b757e944fac7310