### PR TITLE
Remove AI banner in AI Superpowers section

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -272,11 +272,6 @@ const Homepage: React.FC = (): JSX.Element => {
           Mind maps show the big picture—our assistant suggests tasks and
           timelines so you never wonder what comes next.
         </p>
-        <img
-          src="./assets/system_banner_people.png"
-          alt="AI showcase"
-          className="banner-image"
-        />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- remove the AI Superpowers banner image from the homepage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bd73386d08327874a959f9c67ff82