### PR TITLE
Adjust homepage banner spacing

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -416,6 +416,7 @@ hr {
 .hero-banner {
   margin: 0;
   padding: 0;
+  margin-top: -150px;
 }
 
 .site-image {


### PR DESCRIPTION
## Summary
- move hero banner closer to the Get Started button by reducing top margin

## Testing
- `node --test tests/db-client.test.js tests/validateEnv.test.js` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687be77924ac83279befefc2469a05c7