### PR TITLE
Optimize mobile marketing views

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -64,10 +64,10 @@ export default function AboutPage(): JSX.Element {
         <div className="about-hero-inner">
           <h1>About MindXdo</h1>
           <p>
-            Vision Meets Action. Plan the big picture, create the details and track the action.
+            Vision Meets Action. Plan big ideas and track tasks together.
           </p>
           <p>
-            Stop getting lost in the details and focus on what matters. Use AI to find opportunities and aid you in executing your team's vision.
+            Stay focused on what matters. AI helps your team succeed.
           </p>
           <Link to="/purchase" className="btn">Purchase</Link>
         </div>

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -84,9 +84,7 @@ const Homepage: React.FC = (): JSX.Element => {
         >
           <h1 className="hero-title">Vision Meets Action</h1>
           <p>
-            Plan the big picture, create the details and track the action.
-            Stop getting lost in the details and focus on what matters.
-            Use AI to find opportunities and aid you in executing your team's vision.
+            Plan big ideas and track tasks in one place. Let AI guide your team.
           </p>
           <Link to="/purchase" className="btn">
             Get Started
@@ -109,8 +107,8 @@ const Homepage: React.FC = (): JSX.Element => {
           >
             <StackingText text="MindMap + Todo + Team Vision" />
           </motion.h2>
-          <p className="section-subtext">Plan the big picture, create the details and track the action.</p>
-          <p className="section-subtext">Stop getting lost in the details and focus on what matters.</p>
+          <p className="section-subtext">Plan big ideas and track tasks in one space.</p>
+          <p className="section-subtext">Let AI keep everyone focused.</p>
         </div>
       </section>
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -1179,3 +1179,41 @@ hr {
   margin: 0 auto var(--spacing-lg);
 }
 
+@media (max-width: 640px) {
+  .header__nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding-top: var(--spacing-xl);
+    align-items: center;
+    justify-content: center;
+  }
+  .header__nav-list {
+    align-items: center;
+    gap: var(--spacing-lg);
+  }
+  .banner-image,
+  .site-image,
+  .section-icon,
+  .feature-card__icon,
+  .about-section img {
+    width: 80%;
+    max-width: 80%;
+    height: auto;
+  }
+  .two-column,
+  .purchase-grid {
+    grid-template-columns: 1fr;
+  }
+  .purchase-grid > .form-card {
+    order: -1;
+  }
+  .section-subtext {
+    font-size: 1rem;
+  }
+  .bold-marketing-text {
+    font-size: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak marketing copy for homepage and about page
- add mobile media queries for marketing pages
- ensure purchase form stacks first on small screens

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bea70cca0832783bdeaff29707404