### PR TITLE
Fix mobile nav layout on marketing pages

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -749,6 +749,7 @@ hr {
     display: flex;
   }
   .header__nav {
+    display: flex;
     position: absolute;
     top: 100%;
     left: 0;
@@ -1181,6 +1182,7 @@ hr {
 
 @media (max-width: 640px) {
   .header__nav {
+    display: flex;
     position: fixed;
     top: 0;
     left: 0;


### PR DESCRIPTION
## Summary
- ensure mobile nav uses flex layout for centering

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bec280bac83279818dda4b2dda994