### PR TITLE
Enhance mobile menu styling

### DIFF
--- a/mobilemenu.tsx
+++ b/mobilemenu.tsx
@@ -56,8 +56,9 @@ const MobileMenu = (): JSX.Element => {
   }, [isOpen])
 
   return (
-    <nav className="mobile-menu">
+    <nav className="mobile-menu" role="navigation" aria-label="Mobile">
       <button
+        type="button"
         className="mobile-menu__button"
         aria-label={isOpen ? 'Close menu' : 'Open menu'}
         aria-expanded={isOpen}

--- a/src/global.scss
+++ b/src/global.scss
@@ -1219,3 +1219,71 @@ hr {
     font-size: 1.25rem;
   }
 }
+
+/* Fancy mobile menu styles */
+.mobile-menu {
+  position: relative;
+  z-index: 1100;
+}
+
+.mobile-menu__button {
+  padding: var(--spacing-sm);
+  border-radius: 50%;
+  background-color: var(--color-primary);
+  color: var(--color-bg);
+  border: none;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition: transform var(--transition-duration) var(--transition-ease);
+}
+
+.mobile-menu__button:hover {
+  transform: translateY(-2px);
+}
+
+.mobile-menu__overlay {
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(10, 132, 255, 0.8), rgba(48, 209, 88, 0.8));
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow-y: auto;
+  animation: fade-in var(--transition-duration) var(--transition-ease);
+}
+
+.mobile-menu__list {
+  list-style: none;
+  padding: var(--spacing-xl);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-lg);
+}
+
+.mobile-menu__item {
+  width: 100%;
+  text-align: center;
+}
+
+.mobile-menu__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-sm) var(--spacing-xl);
+  border-radius: 9999px;
+  background-color: var(--color-primary);
+  color: var(--color-bg);
+  font-weight: 600;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  transition:
+    background-color var(--transition-duration) var(--transition-ease),
+    transform var(--transition-duration) var(--transition-ease);
+}
+
+.mobile-menu__link:hover {
+  background-color: var(--color-warning);
+  transform: translateY(-2px);
+}
+


### PR DESCRIPTION
## Summary
- style the mobile menu with a gradient overlay and button effects
- keep menu links centered with larger spacing
- add proper roles on the mobile menu

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bed7959f88327ae2b42bfbd36c289