### PR TITLE
Improve mobile menu layout

### DIFF
--- a/mobilemenu.tsx
+++ b/mobilemenu.tsx
@@ -96,6 +96,9 @@ const MobileMenu = (): JSX.Element => {
               </li>
             ))}
           </ul>
+          <a href="/login" className="mobile-menu__login" onClick={toggleMenu}>
+            Login
+          </a>
         </div>
       )}
     </nav>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1243,9 +1243,11 @@ hr {
 .mobile-menu__overlay {
   position: fixed;
   inset: 0;
+  padding: var(--spacing-2xl) var(--spacing-xl);
   background: linear-gradient(135deg, rgba(10, 132, 255, 0.8), rgba(48, 209, 88, 0.8));
   backdrop-filter: blur(6px);
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   overflow-y: auto;
@@ -1254,7 +1256,7 @@ hr {
 
 .mobile-menu__list {
   list-style: none;
-  padding: var(--spacing-xl);
+  padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -1285,5 +1287,11 @@ hr {
 .mobile-menu__link:hover {
   background-color: var(--color-warning);
   transform: translateY(-2px);
+}
+
+.mobile-menu__login {
+  margin-top: var(--spacing-lg);
+  color: var(--color-primary);
+  font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- adjust menu overlay centering and spacing
- add login link to the mobile menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf101d1c08327b0dfcdbcfd6656c5