### PR TITLE
Update mobile styles

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
+import React from 'react'
 import AnimatedAccordion from './animatedaccordion'
 import FeatureCard from './featurecard'
 import Demo from './demo'
@@ -8,17 +9,31 @@ import MindmapArm from './MindmapArm'
 
 const StackingText: React.FC<{ text: string }> = ({ text }) => (
   <span className="stacking-text">
-    {text.split('').map((ch, i) => (
-      <motion.span
-        key={i}
-        initial={{ y: 50, opacity: 0 }}
-        whileInView={{ y: 0, opacity: 1 }}
-        viewport={{ once: true }}
-        transition={{ delay: i * 0.05 }}
-      >
-        {ch === ' ' ? '\u00A0' : ch}
-      </motion.span>
-    ))}
+    {text.split('').map((ch, i) =>
+      ch === '+' ? (
+        <React.Fragment key={i}>
+          <motion.span
+            initial={{ y: 50, opacity: 0 }}
+            whileInView={{ y: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ delay: i * 0.05 }}
+          >
+            {ch}
+          </motion.span>
+          <br className="mobile-linebreak" />
+        </React.Fragment>
+      ) : (
+        <motion.span
+          key={i}
+          initial={{ y: 50, opacity: 0 }}
+          whileInView={{ y: 0, opacity: 1 }}
+          viewport={{ once: true }}
+          transition={{ delay: i * 0.05 }}
+        >
+          {ch === ' ' ? '\u00A0' : ch}
+        </motion.span>
+      )
+    )}
   </span>
 )
 const features = [

--- a/mobilemenu.tsx
+++ b/mobilemenu.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+
 const navItems = [
   { label: 'Home', href: '#home' },
   { label: 'Features', href: '#features' },
@@ -99,6 +101,14 @@ const MobileMenu = (): JSX.Element => {
           <a href="/login" className="mobile-menu__login" onClick={toggleMenu}>
             Login
           </a>
+          <button
+            type="button"
+            className="mobile-menu__close"
+            aria-label="Close menu"
+            onClick={toggleMenu}
+          >
+            <CloseIcon />
+          </button>
         </div>
       )}
     </nav>

--- a/src/global.scss
+++ b/src/global.scss
@@ -518,6 +518,16 @@ hr {
   display: inline-block;
 }
 
+.mobile-linebreak {
+  display: none;
+}
+
+@media (max-width: 640px) {
+  .mobile-linebreak {
+    display: block;
+  }
+}
+
 .mini-mindmap-container .btn {
   display: none;
 }
@@ -1189,7 +1199,9 @@ hr {
     padding: 0;
   }
   .hero-banner {
-    margin-top: 50px;
+    margin-top: 0;
+    padding-top: 50px;
+    padding-bottom: 50px;
     text-align: center;
   }
   .banner-image {
@@ -1204,6 +1216,12 @@ hr {
     width: 80%;
     max-width: 80%;
     height: auto;
+  }
+  .about-section {
+    grid-template-columns: 1fr;
+  }
+  .about-section.reverse img {
+    order: -1;
   }
   .two-column,
   .purchase-grid {
@@ -1248,9 +1266,10 @@ hr {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   overflow-y: auto;
   animation: fade-in var(--transition-duration) var(--transition-ease);
+  padding-bottom: var(--spacing-4xl);
 }
 
 .mobile-menu__list {
@@ -1292,5 +1311,22 @@ hr {
   margin-top: var(--spacing-lg);
   color: var(--color-primary);
   font-weight: 600;
+}
+
+.mobile-menu__close {
+  position: absolute;
+  bottom: var(--spacing-xl);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background-color: var(--color-primary);
+  color: var(--color-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 


### PR DESCRIPTION
## Summary
- adjust hero banner spacing on mobile
- stack about sections vertically on mobile
- tweak mobile menu layout and add close button
- support line breaks after + in homepage headline

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfa0da548832797c77bd6fe55026f