### PR TITLE
Adjust mobile menu and banner styles

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1195,11 +1195,12 @@ hr {
   }
   .header__nav-list {
     align-items: center;
+    flex-direction: column;
     gap: var(--spacing-xl);
     padding: 0;
   }
   .hero-banner {
-    margin-top: 0;
+    margin-top: -150px;
     padding-top: 50px;
     padding-bottom: 50px;
     text-align: center;


### PR DESCRIPTION
## Summary
- keep hero banner offset on mobile
- stack navigation links vertically for mobile menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c010091708327abfe7b32067e0fe5