### PR TITLE
Fix header navigation layout

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -707,10 +707,22 @@ hr {
   margin: 0 auto;
 }
 
+.header__nav {
+  display: flex;
+  flex-grow: 1;
+  justify-content: center;
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
 
 .header__nav-list {
   display: flex;
-  gap: 0;
+  gap: var(--spacing-md);
   list-style: none;
   margin: 0;
   padding: 0;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -98,6 +98,28 @@ const Header = (): JSX.Element => {
               />
             </Link>
           </div>
+          <nav
+            id="primary-navigation"
+            ref={navRef}
+            className={`header__nav${isMobileNavOpen ? ' header__nav--open' : ''}`}
+            aria-label="Main navigation"
+          >
+            <ul className="header__nav-list">
+              {navItems.map(item => (
+                <li key={item.route} className="header__nav-item">
+                  <NavLink
+                    to={item.route}
+                    className={({ isActive }) =>
+                      `header__nav-link${isActive ? ' header__nav-link--active' : ''}`
+                    }
+                    onClick={() => setMobileNavOpen(false)}
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
           <button
             ref={toggleRef}
             className="header__toggle"
@@ -170,28 +192,6 @@ const Header = (): JSX.Element => {
           </div>
         </div>
       </header>
-      <nav
-        id="primary-navigation"
-        ref={navRef}
-        className={`header__nav${isMobileNavOpen ? ' header__nav--open' : ''}`}
-        aria-label="Main navigation"
-      >
-        <ul className="header__nav-list">
-          {navItems.map(item => (
-            <li key={item.route} className="header__nav-item">
-              <NavLink
-                to={item.route}
-                className={({ isActive }) =>
-                  `header__nav-link${isActive ? ' header__nav-link--active' : ''}`
-                }
-                onClick={() => setMobileNavOpen(false)}
-              >
-                {item.label}
-              </NavLink>
-            </li>
-          ))}
-        </ul>
-      </nav>
     </>
   )
 }


### PR DESCRIPTION
## Summary
- put nav back inside the header so it stays centered on desktop
- keep dropdown menu anchored below header on mobile
- add styling for nav and action area

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c1273a6d08327b4d6ae6c456e7095