### PR TITLE
Fix error boundary rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preview": "vite preview",
     "compile:migrations": "tsc -p tsconfig.migrations.json",
     "compile:functions": "tsc -p tsconfig.functions.json",
-    "migrate": "node dist/runmigrations.js"
+    "migrate": "node dist/runmigrations.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.1",

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -13,6 +13,7 @@ class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
     this.state = { hasError: false }
+    this.reset = this.reset.bind(this)
   }
 
   static getDerivedStateFromError(error: Error): State {
@@ -23,9 +24,23 @@ class ErrorBoundary extends Component<Props, State> {
     console.error('ErrorBoundary caught an error', error, errorInfo)
   }
 
+  reset() {
+    this.setState({ hasError: false, error: undefined })
+  }
+
   render() {
     if (this.state.hasError) {
-      return <div role="alert">Something went wrong.</div>
+      return (
+        <div role="alert" style={{ padding: '1rem', textAlign: 'center' }}>
+          <h2>Something went wrong.</h2>
+          {this.state.error && (
+            <pre style={{ color: 'red' }}>{this.state.error.message}</pre>
+          )}
+          <button onClick={this.reset} style={{ marginTop: '1rem' }}>
+            Try again
+          </button>
+        </div>
+      )
     }
 
     return this.props.children


### PR DESCRIPTION
## Summary
- improve the error boundary to show the error message and a retry button
- add a `test` script so `npm test` works

## Testing
- `npm test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687c182b933c8327afb920f8a228528d