### PR TITLE
Fix drawer imports causing useRef runtime error

### DIFF
--- a/drawer.tsx
+++ b/drawer.tsx
@@ -1,3 +1,13 @@
+import { useEffect, useRef, useState, useId, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+export interface DrawerProps {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  children: ReactNode
+}
+
 export function Drawer({ isOpen, onClose, children, title }: DrawerProps): JSX.Element | null {
   const overlayRef = useRef<HTMLDivElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
- fix missing imports and props in `drawer.tsx`

## Testing
- `npm test` *(fails: Cannot find package 'pg' and afterEach not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687c1ae7eaac8327856a839c6835c375