### PR TITLE
Add desktop menu support

### DIFF
--- a/layout.tsx
+++ b/layout.tsx
@@ -39,7 +39,9 @@ const Layout = ({ children }: LayoutProps): JSX.Element => {
             aria-controls={navId}
             onClick={() => setMenuOpen(open => !open)}
           >
-            <span className="layout-menu-icon">?</span>
+            <span className="layout-menu-icon">
+              {menuOpen ? '✕' : '☰'}
+            </span>
           </button>
           <nav
             id={navId}

--- a/mobilemenu.tsx
+++ b/mobilemenu.tsx
@@ -8,6 +8,23 @@ const navItems = [
   { label: 'Docs', href: '/docs' },
 ]
 
+const DesktopMenu = (): JSX.Element => (
+  <nav className="desktop-menu" aria-label="Desktop">
+    <ul className="desktop-menu__list">
+      {navItems.map(item => (
+        <li key={item.href} className="desktop-menu__item">
+          <a href={item.href} className="desktop-menu__link">
+            {item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+    <a href="/login" className="desktop-menu__login">
+      Login
+    </a>
+  </nav>
+)
+
 const MobileMenu = (): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false)
   const overlayRef = useRef<HTMLDivElement>(null)
@@ -130,4 +147,11 @@ const CloseIcon = (): JSX.Element => (
   </svg>
 )
 
-export default MobileMenu
+const Menu = (): JSX.Element => (
+  <>
+    <DesktopMenu />
+    <MobileMenu />
+  </>
+)
+
+export default Menu

--- a/src/global.scss
+++ b/src/global.scss
@@ -1195,30 +1195,7 @@ hr {
 
 @media (max-width: 1024px) {
   .header__nav {
-    display: flex;
-    position: fixed;
-    top: 64px;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    padding-top: var(--spacing-2xl);
-    background-color: var(--color-bg);
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-start;
-    overflow-y: auto;
-    z-index: 1000;
-    transform: translateY(-100%);
-    transition: transform var(--transition-duration) var(--transition-ease);
-  }
-  .header__nav.header__nav--open {
-    transform: translateY(0);
-  }
-  .header__nav-list {
-    align-items: center;
-    flex-direction: column;
-    gap: var(--spacing-xl);
-    padding: 0;
+    display: none;
   }
   .hero-banner {
     margin-top: -150px;
@@ -1354,5 +1331,41 @@ hr {
   align-items: center;
   justify-content: center;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.desktop-menu {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-lg);
+}
+
+.desktop-menu__list {
+  display: flex;
+  gap: var(--spacing-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.desktop-menu__link {
+  color: var(--color-text);
+  font-weight: 600;
+  padding: var(--spacing-sm) var(--spacing-md);
+  transition: color var(--transition-duration) var(--transition-ease);
+}
+
+.desktop-menu__link:hover {
+  color: var(--color-primary);
+}
+
+.desktop-menu__login {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .desktop-menu {
+    display: none;
+  }
 }
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -105,6 +105,26 @@ const Header = (): JSX.Element => {
             <span className="header__toggle-bar" />
             <span className="header__toggle-bar" />
           </button>
+
+          <nav className="header__nav" aria-label="Primary">
+            <ul className="header__nav-list">
+              {navItems.map(item => (
+                <li key={item.route} className="header__nav-item">
+                  <NavLink
+                    to={item.route}
+                    className={({ isActive }) =>
+                      `header__nav-link${
+                        isActive ? ' header__nav-link--active' : ''
+                      }`
+                    }
+                    onClick={() => handleNavSelect(item.route)}
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
           <div className="header__actions">
           {user ? (
             <div className="header__avatar-container" ref={avatarRef}>


### PR DESCRIPTION
## Summary
- add horizontal navigation to header for desktop users
- hide header nav on mobile and keep drawer menu
- add desktop navigation component to marketing menu
- replace layout menu button question mark with an x when open
- style new desktop menu

## Testing
- `npm test --silent` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687c1d80cfd48327bdba7f3c3ea09173