### PR TITLE
Fix mobile drawer layout

### DIFF
--- a/drawer.tsx
+++ b/drawer.tsx
@@ -126,7 +126,7 @@ export function Drawer({ isOpen, onClose, children, title }: DrawerProps): JSX.E
               lineHeight: 1,
             }}
           >
-            ?
+            ×
           </button>
         </div>
         <div style={{ flex: 1, overflowY: 'auto' }}>

--- a/src/global.scss
+++ b/src/global.scss
@@ -728,6 +728,16 @@ hr {
   padding: 0;
 }
 
+.header__nav-list--vertical {
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+
+.header__nav-list--vertical .header__nav-link {
+  width: 100%;
+}
+
 
 .header__nav-link {
   color: var(--color-text);

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -189,11 +189,11 @@ const Header = (): JSX.Element => {
         onClose={() => setMenuOpen(false)}
         title="Menu"
       >
-        <nav id="mobile-navigation">
-          <ul className="header__nav-list">
-            {navItems.map(item => (
-              <li key={item.route} className="header__nav-item">
-                <NavLink
+          <nav id="mobile-navigation">
+            <ul className="header__nav-list header__nav-list--vertical">
+              {navItems.map(item => (
+                <li key={item.route} className="header__nav-item">
+                  <NavLink
                   to={item.route}
                   className={({ isActive }) =>
                     `header__nav-link${isActive ? ' header__nav-link--active' : ''}`


### PR DESCRIPTION
## Summary
- update Drawer close button from `?` to `×`
- stack navigation vertically in the mobile drawer

## Testing
- `npm test` *(fails: cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687c20bb81c883278567f0b157590faf