### PR TITLE
Adjust hero animation and mobile menu layout

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -15,7 +15,7 @@ const StackingText: React.FC<{ text: string }> = ({ text }) => (
           <motion.span
             initial={{ y: 50, opacity: 0 }}
             whileInView={{ y: 0, opacity: 1 }}
-            viewport={{ once: true }}
+            viewport={{ once: true, amount: 0.5 }}
             transition={{ delay: i * 0.05 }}
           >
             {ch}
@@ -27,7 +27,7 @@ const StackingText: React.FC<{ text: string }> = ({ text }) => (
           key={i}
           initial={{ y: 50, opacity: 0 }}
           whileInView={{ y: 0, opacity: 1 }}
-          viewport={{ once: true }}
+          viewport={{ once: true, amount: 0.5 }}
           transition={{ delay: i * 0.05 }}
         >
           {ch === ' ' ? '\u00A0' : ch}
@@ -117,7 +117,7 @@ const Homepage: React.FC = (): JSX.Element => {
             className="marketing-text-large"
             initial={{ x: -100, opacity: 0 }}
             whileInView={{ x: 0, opacity: 1 }}
-            viewport={{ once: true }}
+            viewport={{ once: true, amount: 0.5 }}
             transition={{ duration: 0.6 }}
           >
             <StackingText text="MindMap + Todo + Team Vision" />

--- a/src/global.scss
+++ b/src/global.scss
@@ -29,6 +29,8 @@
   --spacing-lg: 24px;
   --spacing-xl: 32px;
   --spacing-2xl: 48px;
+  --spacing-3xl: 64px;
+  --spacing-4xl: 96px;
 }
 
 [data-theme='dark'] {
@@ -1273,6 +1275,7 @@ hr {
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 1200;
   padding: var(--spacing-2xl) var(--spacing-xl) var(--spacing-4xl);
   background: #fff;
   display: flex;
@@ -1291,7 +1294,7 @@ hr {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--spacing-xl);
+  gap: var(--spacing-2xl);
   width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- delay hero headline animation until it's near the viewport center
- add missing large spacing variables
- tweak mobile menu overlay stacking and spacing

## Testing
- `npm test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687c23d5dc1883278651f738cd3f23f8