### PR TITLE
Update reset page and header animation

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -117,8 +117,8 @@ const Homepage: React.FC = (): JSX.Element => {
             className="marketing-text-large"
             initial={{ x: -100, opacity: 0 }}
             whileInView={{ x: 0, opacity: 1 }}
-            viewport={{ once: true, amount: 0.5 }}
-            transition={{ duration: 0.6 }}
+            viewport={{ once: true, amount: 0.8 }}
+            transition={{ duration: 0.6, delay: 0.3 }}
           >
             <StackingText text="MindMap + Todo + Team Vision" />
           </motion.h2>

--- a/reset-password.tsx
+++ b/reset-password.tsx
@@ -16,11 +16,6 @@ const ResetPasswordPage = () => {
     <section className="section login-page relative overflow-hidden">
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">
-        <img
-          src="./assets/hero-mindmap.png"
-          alt="Reset Password"
-          className="login-icon banner-image"
-        />
         <h2 className="text-2xl font-bold mb-6 text-center">Reset Password</h2>
         <form onSubmit={handleSubmit} noValidate>
           <div className="form-field">


### PR DESCRIPTION
## Summary
- remove the reset page image
- delay homepage headline animation and trigger it later in viewport

## Testing
- `npm test` *(fails: Cannot find package 'pg'; afterEach not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687c2891796c832784ade4c49cb6da00