### PR TITLE
Update FAQ section and accordion behavior

### DIFF
--- a/animatedaccordion.tsx
+++ b/animatedaccordion.tsx
@@ -6,15 +6,19 @@ interface Item {
   a: string
 }
 
-const AccordionItem: React.FC<Item> = ({ q, a }) => {
-  const [open, setOpen] = useState(false)
+interface AccordionItemProps extends Item {
+  isOpen: boolean
+  onToggle: () => void
+}
+
+const AccordionItem: React.FC<AccordionItemProps> = ({ q, a, isOpen, onToggle }) => {
   return (
     <div className="accordion-item">
-      <button className="accordion-header" onClick={() => setOpen(!open)}>
+      <button className="accordion-header" onClick={onToggle}>
         {q}
       </button>
       <AnimatePresence initial={false}>
-        {open && (
+        {isOpen && (
           <motion.div
             className="accordion-body"
             key="content"
@@ -31,12 +35,25 @@ const AccordionItem: React.FC<Item> = ({ q, a }) => {
   )
 }
 
-const AnimatedAccordion: React.FC<{ items: Item[] }> = ({ items }) => (
-  <div className="accordion">
-    {items.map(item => (
-      <AccordionItem key={item.q} {...item} />
-    ))}
-  </div>
-)
+const AnimatedAccordion: React.FC<{ items: Item[] }> = ({ items }) => {
+  const [openIndex, setOpenIndex] = useState<number | null>(null)
+
+  const toggleIndex = (index: number) => {
+    setOpenIndex(prev => (prev === index ? null : index))
+  }
+
+  return (
+    <div className="accordion">
+      {items.map((item, index) => (
+        <AccordionItem
+          key={item.q}
+          {...item}
+          isOpen={openIndex === index}
+          onToggle={() => toggleIndex(index)}
+        />
+      ))}
+    </div>
+  )
+}
 
 export default AnimatedAccordion

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -79,6 +79,10 @@ const faqItems = [
   { q: 'What is MindXdo?', a: 'An AI-driven experience blending mindmaps and todos.' },
   { q: 'How does the AI help?', a: 'It automates task creation and finds connections between ideas.' },
   { q: 'Can I collaborate with my team?', a: 'Yes, share maps and task boards in real time.' },
+  { q: 'Is my data secure?', a: 'All information is encrypted and safely stored in the cloud.' },
+  { q: 'Does it work on mobile devices?', a: 'MindXdo is accessible from any modern browser or device.' },
+  { q: 'What if I need support?', a: 'Our team offers assistance and training whenever you need it.' },
+  { q: 'How do I start?', a: 'Simply sign up and create your first mind map or to-do list.' },
 ]
 
 const Homepage: React.FC = (): JSX.Element => {

--- a/src/global.scss
+++ b/src/global.scss
@@ -557,6 +557,11 @@ hr {
 .faq {
   background-color: var(--color-bg);
   padding: var(--spacing-2xl) var(--spacing-lg);
+  
+  .container {
+    width: 80%;
+    max-width: 80%;
+  }
 }
 
 .accordion {


### PR DESCRIPTION
## Summary
- expand FAQ on homepage to seven items
- update accordion to allow only one open item at a time
- make FAQ section narrower so content occupies about 80% width

## Testing
- `npm test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687c43c5b7ac8327a303ed5617a0f693