### PR TITLE
Switch Netlify function to CommonJS export

### DIFF
--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -44,7 +44,7 @@ async function createMap(userId: string, data: unknown) {
     client.release()
   }
 
-export const handler: Handler = async (event) => {
+const handler: Handler = async (event) => {
   try {
     const userId = await getUserId(event.headers)
     if (event.httpMethod === "GET") {
@@ -121,3 +121,4 @@ export const handler: Handler = async (event) => {
     }
   }
 }
+module.exports = { handler }


### PR DESCRIPTION
## Summary
- convert the `netlify/functions/index.ts` handler to CommonJS export so Node runtime doesn't balk at `export` syntax

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_687c5a8ebc1083278ceb69a9d9959110