### PR TITLE
Fix missing closing brace in Netlify index function

### DIFF
--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -43,6 +43,7 @@ async function createMap(userId: string, data: unknown) {
   } finally {
     client.release()
   }
+}
 
 const handler: Handler = async (event) => {
   try {


### PR DESCRIPTION
## Summary
- close `createMap` function block in `netlify/functions/index.ts`

## Testing
- `npm run compile:functions` *(fails: passwordreset.ts TS1005, TS1128)*

------
https://chatgpt.com/codex/tasks/task_e_687c5c668a4083278edbc3fba0717988