### PR TITLE
Improve marketing copy

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -13,43 +13,43 @@ interface AboutSection {
 const sections: AboutSection[] = [
   {
     title: 'Our Mission',
-    text: 'We help visualize big ideas and break them into manageable steps using AI planning tools.',
+    text: 'MindXdo unites mind maps, todos and Kanban so you can design large visions and execute them from one place.',
     img: './assets/marketing_square_mindmap_people.png',
     bulletPoints: [
       'Capture concepts quickly with intuitive mind maps',
-      'Turn every idea into an actionable task',
+      'Send ideas to your todo list or board with one click',
       'Stay focused thanks to AI-driven guidance',
     ],
   },
   {
     title: 'Key Benefits',
-    text: 'MindXdo keeps your plans and tasks together so you stay organized and focused.',
+    text: 'Build your mind map, auto-create todos and track them on an agile Kanban board—all synchronized.',
     img: './assets/marketing_square_lightbulb_team.png',
     bulletPoints: [
       'One workspace for mapping and doing',
       'Kanban board shows todo progress at a glance',
       'Visual and list views always in sync',
-      'Seamless flow from brainstorming to execution',
+      'Invite teammates to plan and build',
     ],
   },
   {
     title: 'Performance Insights',
-    text: 'Track progress at a glance and let data drive your next move.',
+    text: 'Dashboards reveal how tasks move from mind map to todo to Kanban so you can improve every step.',
     img: './assets/marketing_square_todolist_in_cloud.png',
     bulletPoints: [
       'Dashboards highlight your progress',
       'AI suggestions keep you on the right path',
-      'Data-backed insights for continuous growth',
+      'Prebuilt templates jumpstart your workflow',
     ],
   },
   {
     title: 'Continuous Improvement',
-    text: 'We evolve alongside your workflow so you can focus on what matters most.',
+    text: 'Add tasks manually or let AI expand your map—our Kanban system adapts as your projects grow.',
     img: './assets/marketing_square_ai_connecting.png',
     bulletPoints: [
       'Frequent feature releases based on feedback',
       'Tools that scale with your ambitions',
-      'A platform that grows as you do',
+      'Use AI or manual mode to evolve your plan',
     ],
   },
 ]
@@ -64,10 +64,12 @@ export default function AboutPage(): JSX.Element {
         <div className="about-hero-inner">
           <h1>About MindXdo</h1>
           <p>
-            Vision Meets Action. Plan big ideas and track tasks together.
+            Vision Meets Action. Build ideas in a mind map, send them to your
+            todo list and manage progress on a shared Kanban board.
           </p>
           <p>
-            Stay focused on what matters. AI helps your team succeed.
+            Use each tool alone or combine them with AI to guide your team to
+            success.
           </p>
           <Link to="/purchase" className="btn">Purchase</Link>
         </div>

--- a/hero.tsx
+++ b/hero.tsx
@@ -86,8 +86,8 @@ const Hero: React.FC = () => {
           MindXdo
         </h1>
         <p className="text-lg md:text-xl text-white/80 mb-8 max-w-xl">
-          Organize your mind maps and tasks. Let AI turn your long‑term vision
-          into an actionable roadmap.
+          Mind map your vision, manage todos, and plan on a connected Kanban
+          board. AI or manual tools help you turn ideas into action.
         </p>
         <a
           href="#get-started"

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -64,7 +64,7 @@ const features = [
   {
     title: 'Kanban Board',
     description:
-      'A perfect tool for showing progress of todo items from start to finish.',
+      'Cards sync with your todos so you always know what is in progress and what is done.',
     icon: './assets/feature-kanban.png',
   },
   {
@@ -103,7 +103,8 @@ const Homepage: React.FC = (): JSX.Element => {
         >
           <h1 className="hero-title">Vision Meets Action</h1>
           <p>
-            Plan big ideas and track tasks in one place. Let AI guide your team.
+            Build your vision with mind maps, manage todos, and plan in Kanban—together or separately.
+            AI keeps everything connected.
           </p>
           <Link to="/purchase" className="btn">
             Get Started
@@ -126,8 +127,8 @@ const Homepage: React.FC = (): JSX.Element => {
           >
             <StackingText text="MindMap + Todo + Team Vision" />
           </motion.h2>
-          <p className="section-subtext">Plan big ideas and track tasks in one space.</p>
-          <p className="section-subtext">Let AI keep everyone focused.</p>
+          <p className="section-subtext">Map your vision, create todos and monitor them on the board.</p>
+          <p className="section-subtext">AI or manual tools keep every piece in sync.</p>
         </div>
       </section>
 
@@ -143,7 +144,7 @@ const Homepage: React.FC = (): JSX.Element => {
             Create ideas, flows, systems, & more.
           </motion.h2>
           <p className="section-subtext">
-            Sketch processes and tasks in minutes and refine them with your team.
+            Sketch processes in a mind map and instantly generate todos to manage on your board.
           </p>
         </div>
       </section>
@@ -178,7 +179,7 @@ const Homepage: React.FC = (): JSX.Element => {
             <StackingText text="Simple and Powerful" />
           </h2>
           <p className="section-subtext">
-            Plan projects effortlessly with intuitive maps that grow alongside your ideas.
+            Plan projects effortlessly and send tasks from the map to your Kanban board.
           </p>
         </div>
       </section>
@@ -196,7 +197,7 @@ const Homepage: React.FC = (): JSX.Element => {
               AI Todo Lists Keep Teams Aligned
             </motion.h2>
             <p className="section-subtext">
-              Assign tasks from your maps and watch progress unfold automatically.
+              AI turns map nodes into todos and Kanban cards so everyone stays aligned.
             </p>
           </div>
           <img
@@ -220,7 +221,7 @@ const Homepage: React.FC = (): JSX.Element => {
             See Beyond a Task Board
           </motion.h2>
           <p className="section-subtext">
-            Mind map connections provide a bird's-eye view of every project step.
+            Mind map connections provide a bird's-eye view while Kanban shows progress below.
           </p>
         </div>
       </section>
@@ -254,7 +255,7 @@ const Homepage: React.FC = (): JSX.Element => {
       <section className="section section--one-col">
         <div className="container">
           <div className="bold-marketing-text">
-            Map your ideas visually while keeping tasks in focus.
+            Map big ideas, manage todos and drag cards across the board with ease.
           </div>
           <img
             src="./assets/simple_main_banner_home.png"
@@ -278,10 +279,8 @@ const Homepage: React.FC = (): JSX.Element => {
           AI Superpowers
         </motion.h2>
         <p className="ai-copy">
-          Harness automation to turn complex mind maps into actionable
-          workflows. MindXdo helps you execute ambitious plans with ease.
-          Mind maps show the big picture—our assistant suggests tasks and
-          timelines so you never wonder what comes next.
+          Harness automation to turn complex mind maps into todos and Kanban workflows.
+          MindXdo helps you execute ambitious plans with ease and suggests next steps so you never wonder what comes next.
         </p>
         </div>
       </section>

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -84,7 +84,7 @@ export default function Kanban(): JSX.Element {
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
-            <p className="section-subtext">A Kanban board is a perfect tool for showing progress of todo items.</p>
+            <p className="section-subtext">Boards visualize how your mind map tasks move from to-do to done.</p>
           </div>
           <div className="kanban-board">
             {lanes.map((lane, laneIndex) => {
@@ -138,7 +138,7 @@ export default function Kanban(): JSX.Element {
             <StackingText text="AI Workflows" />
           </h2>
           <p className="section-subtext">
-            Automated boards keep everyone on track through each stage.
+            New cards from your mind map appear instantly so your board stays in sync.
           </p>
         </div>
       </section>
@@ -160,7 +160,7 @@ export default function Kanban(): JSX.Element {
             Stay Organized Every Step
           </motion.h2>
           <p className="section-subtext">
-            Track progress from planning to completion all in one view.
+            Track progress from planning to completion as todos move across your board.
           </p>
         </div>
       </section>
@@ -182,7 +182,7 @@ export default function Kanban(): JSX.Element {
             Coordinate With Clarity
           </motion.h2>
           <p className="section-subtext">
-            Everyone knows what to do as cards move smoothly across lanes.
+            Everyone knows what to do as cards sync with their matching todos.
           </p>
         </div>
       </section>

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -157,8 +157,8 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
           </div>
           <div className="mindmap-info">
             <div className="mindmap-text-block">
-              Harness the power of AI-driven mind mapping to quickly expand and
-              organize your best ideas into actionable plans.
+              Harness AI to expand every idea into todos and Kanban cards so your
+              team can start executing right away.
             </div>
             <div className="mindmap-upgrade text-center">
               <Link to="/purchase" className="btn">
@@ -182,7 +182,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                 <StackingText text="Simple and Powerful" />
               </h2>
               <p className="section-subtext">
-                Plan projects effortlessly with intuitive maps that grow alongside your ideas.
+                Draft your vision in a map and push items into todos whenever you're ready.
               </p>
             </div>
           </section>
@@ -204,7 +204,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                 AI Todo Lists Keep Teams Aligned
               </motion.h2>
               <p className="section-subtext">
-                Assign tasks from your maps and watch progress unfold automatically.
+                AI turns map nodes into todos and Kanban cards so everyone knows what's next.
               </p>
             </div>
           </section>
@@ -226,7 +226,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                 Vision Meets Action
               </motion.h2>
               <p className="section-subtext">
-                Plan the big picture, create the details and track the action with AI assistance.
+                Use AI or manual tools to expand ideas into tasks and track them on your planning board.
               </p>
             </div>
           </section>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1251,7 +1251,7 @@ hr {
     order: -1;
   }
   .section-subtext {
-    font-size: 1rem;
+    font-size: 1.125rem;
   }
   .bold-marketing-text {
     font-size: 1.25rem;

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -94,7 +94,7 @@ export default function TodoDemo(): JSX.Element {
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
-            <p className="section-subtext">Watch todos appear with smooth animations</p>
+            <p className="section-subtext">See how todos flow from mind maps onto the Kanban board</p>
           </div>
           <div className="todo-grid section--two-col">
             {lists.map((list, listIndex) => (
@@ -140,7 +140,7 @@ export default function TodoDemo(): JSX.Element {
             <StackingText text="AI Simplicity" />
           </h2>
           <p className="section-subtext">
-            Generate prioritized todos straight from your mind maps in moments.
+            Generate prioritized todos from any mind map and sync them to your Kanban lanes.
           </p>
         </div>
       </section>
@@ -162,7 +162,7 @@ export default function TodoDemo(): JSX.Element {
             Team Management Made Powerful
           </motion.h2>
           <p className="section-subtext">
-            Everyone sees their tasks and how they connect to the bigger picture.
+            Collaborate on shared lists and boards so the whole team knows what's next.
           </p>
         </div>
       </section>
@@ -184,7 +184,7 @@ export default function TodoDemo(): JSX.Element {
             Vision Meets Action
           </motion.h2>
           <p className="section-subtext">
-            Use AI to find opportunities and aid you in executing your team's vision.
+            Link tasks to your mind map and visualize progress in Kanban while AI keeps you on target.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- update home and demo pages with unique marketing text about mind maps, todos and Kanban
- enlarge mobile subtext font

## Testing
- `npm test` *(fails: test code failure)*

------
https://chatgpt.com/codex/tasks/task_e_687d7f74fbd0832780406f98f18ac066