### PR TITLE
Update marketing copy

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -13,7 +13,7 @@ interface AboutSection {
 const sections: AboutSection[] = [
   {
     title: 'Our Mission',
-    text: 'MindXdo unites mind maps, todos and Kanban so you can design large visions and execute them from one place.',
+    text: 'MindXdo unites mind maps, todos and Kanban so every task stays linked to the big picture you want to achieve.',
     img: './assets/marketing_square_mindmap_people.png',
     bulletPoints: [
       'Capture concepts quickly with intuitive mind maps',
@@ -23,7 +23,7 @@ const sections: AboutSection[] = [
   },
   {
     title: 'Key Benefits',
-    text: 'Build your mind map, auto-create todos and track them on an agile Kanban board—all synchronized.',
+    text: 'Build your mind map, auto-create todos and track them on an agile Kanban board so the entire plan stays connected.',
     img: './assets/marketing_square_lightbulb_team.png',
     bulletPoints: [
       'One workspace for mapping and doing',
@@ -34,7 +34,7 @@ const sections: AboutSection[] = [
   },
   {
     title: 'Performance Insights',
-    text: 'Dashboards reveal how tasks move from mind map to todo to Kanban so you can improve every step.',
+    text: 'Dashboards reveal how tasks flow from mind map to todo to Kanban so you never lose sight of the whole plan.',
     img: './assets/marketing_square_todolist_in_cloud.png',
     bulletPoints: [
       'Dashboards highlight your progress',
@@ -44,7 +44,7 @@ const sections: AboutSection[] = [
   },
   {
     title: 'Continuous Improvement',
-    text: 'Add tasks manually or let AI expand your map—our Kanban system adapts as your projects grow.',
+    text: 'Add tasks manually or let AI expand your map—our Kanban system adapts as your projects grow while keeping everything tied to your vision.',
     img: './assets/marketing_square_ai_connecting.png',
     bulletPoints: [
       'Frequent feature releases based on feedback',
@@ -65,7 +65,7 @@ export default function AboutPage(): JSX.Element {
           <h1>About MindXdo</h1>
           <p>
             Vision Meets Action. Build ideas in a mind map, send them to your
-            todo list and manage progress on a shared Kanban board.
+            todo list and manage progress on a shared Kanban board so you always see the big picture.
           </p>
           <p>
             Use each tool alone or combine them with AI to guide your team to

--- a/hero.tsx
+++ b/hero.tsx
@@ -86,8 +86,8 @@ const Hero: React.FC = () => {
           MindXdo
         </h1>
         <p className="text-lg md:text-xl text-white/80 mb-8 max-w-xl">
-          AI helps auto-create your vision and todos so you build plans faster.
-          Let automation generate maps and tasks so you can focus on bringing
+          AI helps auto-create your vision, todos and Kanban cards so you build plans faster.
+          Automation keeps every task tied to the big picture while you focus on bringing
           ideas to life.
         </p>
         <a

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -104,7 +104,7 @@ const Homepage: React.FC = (): JSX.Element => {
           <h1 className="hero-title">AI Builds Your Vision</h1>
           <p>
             Craft your roadmap with mind maps while AI auto-creates todos and Kanban cards.
-            Automation links every element so you can form complete plans faster.
+            Every task stays connected to the board so the big picture is always clear.
           </p>
           <Link to="/purchase" className="btn">
             Get Started
@@ -128,10 +128,10 @@ const Homepage: React.FC = (): JSX.Element => {
             <StackingText text="MindMap + Todo + Team Vision" />
           </motion.h2>
           <p className="section-subtext">
-            Start with a mind map and let AI auto-build your todos and Kanban cards as you outline your goals.
+            Start with a mind map to organize your goals, then instantly turn nodes into todos and Kanban cards that mirror the big picture.
           </p>
           <p className="section-subtext">
-            AI assistance can even expand your map so you create more complete plans while staying connected.
+            AI assistance can even expand your map so every todo links back to the board and the broader vision.
           </p>
         </div>
       </section>
@@ -148,7 +148,7 @@ const Homepage: React.FC = (): JSX.Element => {
             Create ideas, flows, systems, & more.
           </motion.h2>
           <p className="section-subtext">
-            Sketch processes in a mind map and instantly generate todos to manage on your board.
+            Sketch processes in a mind map and instantly generate todos that sync to your Kanban board for full visibility.
           </p>
         </div>
       </section>
@@ -170,7 +170,7 @@ const Homepage: React.FC = (): JSX.Element => {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            See how AI instantly creates a map for your ideas.
+            See how AI instantly creates a connected map so tasks flow right to your board.
           </motion.div>
         </div>
       </section>
@@ -183,7 +183,7 @@ const Homepage: React.FC = (): JSX.Element => {
             <StackingText text="Simple and Powerful" />
           </h2>
           <p className="section-subtext">
-            Plan projects effortlessly and send tasks from the map to your Kanban board.
+            Plan projects effortlessly by sending tasks from the map to your Kanban board so the big picture never gets lost.
           </p>
         </div>
       </section>
@@ -225,7 +225,7 @@ const Homepage: React.FC = (): JSX.Element => {
             See Beyond a Task Board
           </motion.h2>
           <p className="section-subtext">
-            Mind map connections provide a bird's-eye view while Kanban shows progress below.
+            Mind map connections provide a bird's-eye view while Kanban boards track execution so teams see the full picture.
           </p>
         </div>
       </section>
@@ -259,7 +259,7 @@ const Homepage: React.FC = (): JSX.Element => {
       <section className="section section--one-col">
         <div className="container">
           <div className="bold-marketing-text">
-            AI auto-builds maps and todos so you can turn big ideas into complete plans faster.
+            AI auto-builds maps and todos so you can turn big ideas into complete plans while keeping your board in view.
           </div>
           <img
             src="./assets/simple_main_banner_home.png"
@@ -284,7 +284,7 @@ const Homepage: React.FC = (): JSX.Element => {
         </motion.h2>
         <p className="ai-copy">
           Harness automation to turn complex mind maps into todos and Kanban workflows.
-          AI builds out your plan so you can execute faster and always know the next step.
+          AI builds out your plan so you can execute faster while staying aware of the big picture.
         </p>
         </div>
       </section>

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -84,7 +84,7 @@ export default function Kanban(): JSX.Element {
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
-            <p className="section-subtext">Boards visualize how your mind map tasks move from to-do to done.</p>
+            <p className="section-subtext">Kanban boards are perfect for executing your vision across a team, showing how mind map tasks move from to-do to done.</p>
           </div>
           <div className="kanban-board">
             {lanes.map((lane, laneIndex) => {

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -90,7 +90,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
         <div className="container section--one-col text-center">
           <h1 className="marketing-text-large">Visualize Ideas in Seconds</h1>
           <p className="section-subtext">
-            Mind maps animate to life so you can focus on brainstorming
+            Mind maps animate to life and AI can auto-create them so you focus purely on brainstorming
           </p>
           <div className="mindmap-grid">
             {maps.map((map, mapIndex) => (
@@ -182,7 +182,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                 <StackingText text="Simple and Powerful" />
               </h2>
               <p className="section-subtext">
-                Draft your vision in a map and push items into todos whenever you're ready.
+                Draft your vision in a map and push items into todos whenever you're ready, keeping your Kanban board in sync.
               </p>
             </div>
           </section>

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -94,7 +94,7 @@ export default function TodoDemo(): JSX.Element {
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
-            <p className="section-subtext">See how todos flow from mind maps onto the Kanban board</p>
+            <p className="section-subtext">See how todos flow from mind maps onto the Kanban board so every step reflects the big picture</p>
           </div>
           <div className="todo-grid section--two-col">
             {lists.map((list, listIndex) => (
@@ -140,7 +140,7 @@ export default function TodoDemo(): JSX.Element {
             <StackingText text="AI Simplicity" />
           </h2>
           <p className="section-subtext">
-            Generate prioritized todos from any mind map and sync them to your Kanban lanes.
+            Generate prioritized todos from any mind map and sync them to your Kanban lanes so the board and your vision stay unified.
           </p>
         </div>
       </section>
@@ -184,7 +184,7 @@ export default function TodoDemo(): JSX.Element {
             Vision Meets Action
           </motion.h2>
           <p className="section-subtext">
-            Link tasks to your mind map and visualize progress in Kanban while AI keeps you on target.
+            Link tasks to your mind map and visualize progress in Kanban while AI keeps the big picture front and center.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- refresh hero text and homepage sections to focus on big‑picture planning
- highlight board integration across about page
- tweak demo page captions to mention AI and kanban connections
- clarify Kanban description

## Testing
- `npm test --silent` *(fails: Cannot find package 'pg' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_687d8893734883278950d3efe2330d04