### PR TITLE
Update hero text to highlight AI planning

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -64,7 +64,7 @@ export default function AboutPage(): JSX.Element {
         <div className="about-hero-inner">
           <h1>About MindXdo</h1>
           <p>
-            Vision Meets Action. Build ideas in a mind map, send them to your
+            AI Turns Vision Into Action. Build ideas in a mind map, send them to your
             todo list and manage progress on a shared Kanban board so you always see the big picture.
           </p>
           <p>

--- a/hero.tsx
+++ b/hero.tsx
@@ -86,9 +86,8 @@ const Hero: React.FC = () => {
           MindXdo
         </h1>
         <p className="text-lg md:text-xl text-white/80 mb-8 max-w-xl">
-          AI helps auto-create your vision, todos and Kanban cards so you build plans faster.
-          Automation keeps every task tied to the big picture while you focus on bringing
-          ideas to life.
+          AI assists you in shaping mind maps and auto-creating todos so every idea becomes part of a complete plan.
+          Automation keeps tasks linked to the big picture while you bring ideas to life.
         </p>
         <a
           href="#get-started"

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -101,10 +101,9 @@ const Homepage: React.FC = (): JSX.Element => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
         >
-          <h1 className="hero-title">Vision Meets Action</h1>
+          <h1 className="hero-title">AI Turns Vision Into Action</h1>
           <p>
-            Map your ideas while AI helps create tasks and build boards so your vision becomes a complete plan.
-            Every task stays connected to keep the big picture clear.
+            Map your ideas while AI builds mind maps and auto-creates todos so your vision becomes a complete plan. Every task stays connected to keep the big picture clear.
           </p>
           <Link to="/purchase" className="btn">
             Get Started

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -213,7 +213,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
             <MindmapArm side="left" />
             <img
               src="./assets/marketing_square_ai_connecting.png"
-              alt="Vision Meets Action"
+              alt="AI Turns Vision Into Action"
             />
             <div>
               <motion.h2
@@ -223,7 +223,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                 viewport={{ once: true }}
                 transition={{ duration: 0.8 }}
               >
-                Vision Meets Action
+                AI Turns Vision Into Action
               </motion.h2>
               <p className="section-subtext">
                 Use AI or manual tools to expand ideas into tasks and track them on your planning board.

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -171,7 +171,7 @@ export default function TodoDemo(): JSX.Element {
         <MindmapArm side="left" />
         <img
           src="./assets/marketing_square_ai_connecting.png"
-          alt="Vision Meets Action"
+          alt="AI Turns Vision Into Action"
         />
         <div>
           <motion.h2
@@ -181,7 +181,7 @@ export default function TodoDemo(): JSX.Element {
             viewport={{ once: true }}
             transition={{ duration: 0.8 }}
           >
-            Vision Meets Action
+            AI Turns Vision Into Action
           </motion.h2>
           <p className="section-subtext">
             Link tasks to your mind map and visualize progress in Kanban while AI keeps the big picture front and center.


### PR DESCRIPTION
## Summary
- refine hero text to mention AI planning
- sync tagline across marketing pages

## Testing
- `npm test` *(fails: testCodeFailure)*

------
https://chatgpt.com/codex/tasks/task_e_687d8c018ea883279dce826c67f55517