### PR TITLE
Update todo demo heading

### DIFF
--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -94,7 +94,7 @@ export default function TodoDemo(): JSX.Element {
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <h1 className="marketing-text-large">Tackle Tasks Effortlessly</h1>
-            <p className="section-subtext">See how todos flow from mind maps onto the Kanban board so every step reflects the big picture</p>
+            <p className="section-subtext">See how AI can help create todos that flow from mind maps onto the Kanban board so every step reflects the big picture</p>
           </div>
           <div className="todo-grid section--two-col">
             {lists.map((list, listIndex) => (


### PR DESCRIPTION
## Summary
- clarify that AI can help create todos in todo demo heading

## Testing
- `npm test` *(fails: cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687d92f50a608327944c57c0ca624f3f