### PR TITLE
Add production-ready Netlify config

### DIFF
--- a/migrations/001_create_users_table.sql
+++ b/migrations/001_create_users_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);

--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -1,10 +1,19 @@
 import { Pool } from 'pg'
 
-export const pool = new Pool({
-  connectionString: process.env.NETLIFY_DATABASE_URL,
+const connectionString =
+  process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL
+
+if (!connectionString) {
+  throw new Error('Missing DATABASE_URL')
+}
+
+const pool = new Pool({
+  connectionString,
+  ssl:
+    process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : undefined,
 })
 
 export async function getClient() {
-  return await pool.connect()
+  return pool.connect()
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "tsc",
     "preview": "vite preview",
     "compile:migrations": "tsc -p tsconfig.migrations.json",
     "compile:functions": "tsc -p tsconfig.functions.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,21 +2,9 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
-    "moduleResolution": "Node16",
-    "outDir": "dist",
-    "rootDir": ".",
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "noImplicitAny": false,
-    "types": ["node"]
+    "esModuleInterop": true,
+    "outDir": "dist"
   },
-  "include": [
-    "src",
-    "netlify/functions/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["netlify/functions"]
 }


### PR DESCRIPTION
## Summary
- use DATABASE_URL in db-client and enable SSL for production
- fallback to NETLIFY_DATABASE_URL for backward compatibility
- simplify TypeScript config to only build functions
- compile with `tsc` by default
- add migration for `users` table

## Testing
- `npm test` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687dd08204f88327a64abd1835acb4c8