### PR TITLE
Fix build by shipping TypeScript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-router-dom": "^6.30.1",
         "stripe": "^12.0.0",
         "uuid": "^8.3.2",
-        "zod": "^3.21.4"
+        "zod": "^3.21.4",
+        "typescript": "^5.1.0"
       },
       "devDependencies": {
         "@netlify/functions": "^1.1.0",
@@ -33,7 +34,6 @@
         "@types/uuid": "^8.3.4",
         "@vitejs/plugin-react": "^4.0.3",
         "sass": "^1.69.5",
-        "typescript": "^5.1.0",
         "vite": "^5.0.0"
       },
       "engines": {
@@ -3174,7 +3174,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "dev": false,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "stripe": "^12.0.0",
     "uuid": "^8.3.2",
     "zod": "^3.21.4",
-    "immutable": "^4.3.4"
+    "immutable": "^4.3.4",
+    "typescript": "^5.1.0"
   },
   "devDependencies": {
     "@netlify/functions": "^1.0.0",
@@ -43,7 +44,6 @@
     "@types/uuid": "^8.3.4",
     "@vitejs/plugin-react": "^4.0.3",
     "sass": "^1.69.5",
-    "typescript": "^5.1.0",
     "vite": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- include `typescript` as a production dependency so the build command can find `tsc`

## Testing
- `npm test` *(fails: Cannot find package 'pg')*

------
https://chatgpt.com/codex/tasks/task_e_687e90fae65483278b38f2763f876a96