### PR TITLE
Move TypeScript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "stripe": "^12.0.0",
     "uuid": "^8.3.2",
     "zod": "^3.21.4",
-    "immutable": "^4.3.4",
-    "typescript": "^5.1.0"
+    "immutable": "^4.3.4"
   },
   "devDependencies": {
     "@netlify/functions": "^1.0.0",
@@ -44,6 +43,7 @@
     "@types/uuid": "^8.3.4",
     "@vitejs/plugin-react": "^4.0.3",
     "sass": "^1.69.5",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "typescript": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- list TypeScript under devDependencies instead of dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ee7095d088327be86c4916836ee0e