### PR TITLE
Fix TypeScript dev dependency entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "react-router-dom": "^6.30.1",
         "stripe": "^12.0.0",
         "uuid": "^8.3.2",
-        "zod": "^3.21.4",
-        "typescript": "^5.1.0"
+        "zod": "^3.21.4"
       },
       "devDependencies": {
         "@netlify/functions": "^1.1.0",
@@ -34,7 +33,8 @@
         "@types/uuid": "^8.3.4",
         "@vitejs/plugin-react": "^4.0.3",
         "sass": "^1.69.5",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "typescript": "^5.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -3174,7 +3174,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": false,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Summary
- correct `package-lock.json` to list TypeScript under `devDependencies`
- mark TypeScript package as a dev dependency in lock file

## Testing
- `npm run build` *(fails: cannot find modules)*
- `npm test` *(fails: tests cannot run without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ee801a7308327ac2976c46fb0e739