### PR TITLE
Fix handler type imports

### DIFF
--- a/netlify/functions/ai-create-mindmap.ts
+++ b/netlify/functions/ai-create-mindmap.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions"
+import type { HandlerEvent, HandlerContext } from "@netlify/functions"
+import type { Handler } from './types.js'
 import OpenAI from 'openai'
 import { randomUUID } from 'crypto'
 import { getClient } from './db-client.js'

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import OpenAI from 'openai'
 
 const openaiKey = process.env.OPENAI_API_KEY

--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import OpenAI from 'openai'
 import { z } from 'zod'

--- a/netlify/functions/analytics.ts
+++ b/netlify/functions/analytics.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { extractToken, verifySession } from './auth.js'
 

--- a/netlify/functions/checkout.ts
+++ b/netlify/functions/checkout.ts
@@ -1,6 +1,7 @@
 import { createCheckoutSession } from './stripeclient.js'
 import { getClient } from './db-client.js'
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function getCorsHeaders(origin?: string) {

--- a/netlify/functions/corsmiddleware.ts
+++ b/netlify/functions/corsmiddleware.ts
@@ -1,4 +1,4 @@
-import type { Handler } from '@netlify/functions'
+import type { Handler } from './types.js'
 
 const handler: Handler = async () => ({
   statusCode: 204,

--- a/netlify/functions/create.ts
+++ b/netlify/functions/create.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { extractToken, verifySession } from './auth.js'
 import { createMindMapSchema } from './validationschemas.js'

--- a/netlify/functions/delete.ts
+++ b/netlify/functions/delete.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { z } from 'zod'
 import { extractToken, verifySession } from './auth.js'
 import { createClient } from '@vercel/postgres'

--- a/netlify/functions/forgotpassword.ts
+++ b/netlify/functions/forgotpassword.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { randomBytes, createHmac } from 'crypto'
 import { getClient } from './db-client.js'
 const {

--- a/netlify/functions/get.ts
+++ b/netlify/functions/get.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'

--- a/netlify/functions/healthcheck.ts
+++ b/netlify/functions/healthcheck.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 
 export const handler: Handler = async (event, context) => {

--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { verify, JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { z, ZodError } from 'zod'

--- a/netlify/functions/list.ts
+++ b/netlify/functions/list.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import bcrypt from 'bcrypt'

--- a/netlify/functions/mapid.ts
+++ b/netlify/functions/mapid.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z } from 'zod'
 

--- a/netlify/functions/passwordreset.ts
+++ b/netlify/functions/passwordreset.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 
 import { randomBytes } from 'crypto'

--- a/netlify/functions/payme.ts
+++ b/netlify/functions/payme.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import Stripe from 'stripe'
 import { getClient } from './db-client.js'
 const db = {

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import bcrypt from 'bcrypt'

--- a/netlify/functions/resetpassword.ts
+++ b/netlify/functions/resetpassword.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { createHash } from 'crypto'
 import bcrypt from 'bcrypt'

--- a/netlify/functions/stripe.ts
+++ b/netlify/functions/stripe.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { verifySignature } from './stripeclient.js'
 import Stripe from 'stripe'
 import type { Client } from 'pg'

--- a/netlify/functions/stripecheckout.ts
+++ b/netlify/functions/stripecheckout.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import Stripe from 'stripe'
 const HEADERS = {
   'Access-Control-Allow-Origin': '*',

--- a/netlify/functions/team-members.ts
+++ b/netlify/functions/team-members.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { extractToken, verifySession } from './auth.js'
 import { z } from 'zod'

--- a/netlify/functions/todoid.ts
+++ b/netlify/functions/todoid.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z } from 'zod'
 import type { Todo } from './types.js'

--- a/netlify/functions/types.ts
+++ b/netlify/functions/types.ts
@@ -8,3 +8,16 @@ export interface Todo {
   created_at:   string
   updated_at:   string
 }
+
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+
+export interface HandlerResponse {
+  statusCode: number
+  headers?: Record<string, string>
+  body?: string
+}
+
+export type Handler = (
+  event: HandlerEvent,
+  context: HandlerContext
+) => HandlerResponse | Promise<HandlerResponse>

--- a/netlify/functions/update.ts
+++ b/netlify/functions/update.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 

--- a/netlify/functions/users.ts
+++ b/netlify/functions/users.ts
@@ -1,4 +1,5 @@
-import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'


### PR DESCRIPTION
## Summary
- add custom `Handler` return type for Netlify functions
- update all functions to import the custom Handler interface

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ef4921e30832785b25cc8d701c5f7