### PR TITLE
Fix header object typing

### DIFF
--- a/netlify/functions/forgotpassword.ts
+++ b/netlify/functions/forgotpassword.ts
@@ -28,9 +28,13 @@ export const handler: Handler = async (
   _context: HandlerContext
 ) => {
   if (event.httpMethod !== 'POST') {
+    const headers: Record<string, string> = {
+      'Content-Type': 'text/plain',
+      Allow: 'POST'
+    }
     return {
       statusCode: 405,
-      headers: { 'Content-Type': 'text/plain', Allow: 'POST' },
+      headers,
       body: 'Method Not Allowed'
     }
   }

--- a/netlify/functions/get.ts
+++ b/netlify/functions/get.ts
@@ -24,12 +24,13 @@ export const handler: Handler = async (
   context: HandlerContext
 ) => {
   if (event.httpMethod !== 'GET') {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Allow: 'GET'
+    }
     return {
       statusCode: 405,
-      headers: {
-        'Content-Type': 'application/json',
-        Allow: 'GET'
-      },
+      headers,
       body: JSON.stringify({ error: 'Method Not Allowed' })
     }
   }

--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -98,14 +98,15 @@ const handler: Handler = async (
         body: JSON.stringify(map),
       }
     }
-    return {
-      statusCode: 405,
-      headers: {
-        Allow: "GET, POST",
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ error: "Method not allowed" }),
-    }
+  const headers: Record<string, string> = {
+    Allow: "GET, POST",
+    "Content-Type": "application/json",
+  }
+  return {
+    statusCode: 405,
+    headers,
+    body: JSON.stringify({ error: "Method not allowed" }),
+  }
   } catch (err: any) {
     if (
       err instanceof JsonWebTokenError ||

--- a/netlify/functions/todoid.ts
+++ b/netlify/functions/todoid.ts
@@ -168,15 +168,16 @@ export const handler: Handler = async (
         }
       }
       default:
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          Allow: 'GET, PUT, DELETE',
+        }
         return {
           statusCode: 405,
-          headers: {
-            'Content-Type': 'application/json',
-            Allow: 'GET, PUT, DELETE',
-          },
+          headers,
           body: JSON.stringify({ error: 'Method Not Allowed' }),
         }
-    }
+      }
   } catch (err: any) {
     if (err.message === 'NotFound') {
       return {


### PR DESCRIPTION
## Summary
- ensure `Allow` headers use typed records in Netlify functions

## Testing
- `npm test` *(fails: cannot find module 'pg')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687ef6e73f2c8327baf5bd6a152e6f44