### PR TITLE
Fix rowCount checks

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -60,7 +60,8 @@ export const handler: Handler = async (
         'SELECT 1 FROM mindmaps WHERE id = $1 AND user_id = $2',
         [data.mindMapId, userId]
       )
-      if (ownershipResult.rowCount === 0) {
+      const count = ownershipResult.rowCount ?? 0
+      if (count === 0) {
         return { statusCode: 404, headers, body: JSON.stringify({ error: 'Mind map not found' }) }
       }
 

--- a/netlify/functions/delete.ts
+++ b/netlify/functions/delete.ts
@@ -96,8 +96,8 @@ export const handler: Handler = async (
       WHERE id = ${id} AND user_id = ${userId}
       RETURNING id
     `
-    const deleted = result.rowCount
-    if (!deleted || deleted === 0) {
+    const deleted = result.rowCount ?? 0
+    if (deleted === 0) {
       return {
         statusCode: 404,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/netlify/functions/forgotpassword.ts
+++ b/netlify/functions/forgotpassword.ts
@@ -64,7 +64,8 @@ export const handler: Handler = async (
 
   try {
     const userRes = await client.query('SELECT id FROM users WHERE email = $1', [normalizedEmail])
-    if (userRes.rowCount > 0) {
+    const count = userRes.rowCount ?? 0
+    if (count > 0) {
       const userId = userRes.rows[0].id
 
       const rateRes = await client.query(

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -110,7 +110,8 @@ const handler: Handler = async (
       [email]
     )
 
-    if (result.rowCount === 0) {
+    const count = result.rowCount ?? 0
+    if (count === 0) {
       recent.push(now)
       failedLoginAttempts.set(ip, recent)
       return {

--- a/netlify/functions/mapid.ts
+++ b/netlify/functions/mapid.ts
@@ -79,7 +79,8 @@ async function getMap(mapId: string): Promise<{ id: string; data: MapData; creat
   const client = await getClient()
   try {
     const res = await client.query('SELECT id, data, created_at, updated_at FROM mindmaps WHERE id = $1', [mapId])
-    return res.rowCount > 0 ? res.rows[0] : null
+    const count = res.rowCount ?? 0
+    return count > 0 ? res.rows[0] : null
   } finally {
     client.release()
   }
@@ -92,7 +93,8 @@ async function updateMap(mapId: string, data: MapData): Promise<{ id: string; da
       'UPDATE mindmaps SET data = $2, updated_at = NOW() WHERE id = $1 RETURNING id, data, created_at, updated_at',
       [mapId, data]
     )
-    return res.rowCount > 0 ? res.rows[0] : null
+    const count = res.rowCount ?? 0
+    return count > 0 ? res.rows[0] : null
   } finally {
     client.release()
   }
@@ -102,7 +104,8 @@ async function deleteMap(mapId: string): Promise<number> {
   const client = await getClient()
   try {
     const res = await client.query('DELETE FROM mindmaps WHERE id = $1', [mapId])
-    return res.rowCount
+    const count = res.rowCount ?? 0
+    return count
   } finally {
     client.release()
   }

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -77,7 +77,8 @@ export const handler: Handler = async (
       'SELECT id FROM users WHERE email = $1',
       [email]
     )
-    if (existingUser.rowCount > 0) {
+    const count = existingUser.rowCount ?? 0
+    if (count > 0) {
       return {
         statusCode: 409,
         headers: corsHeaders,

--- a/netlify/functions/resetpassword.ts
+++ b/netlify/functions/resetpassword.ts
@@ -55,7 +55,8 @@ async function updatePassword(userId: string, newPassword: string): Promise<void
       'UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2',
       [passwordHash, userId]
     )
-    if (result.rowCount === 0) throw new Error('User not found')
+    const count = result.rowCount ?? 0
+    if (count === 0) throw new Error('User not found')
     await client.query('DELETE FROM password_reset_tokens WHERE user_id = $1', [userId])
     await client.query('COMMIT')
   } catch (err) {

--- a/netlify/functions/stripe.ts
+++ b/netlify/functions/stripe.ts
@@ -56,7 +56,8 @@ export const handler: Handler = async (
       'INSERT INTO stripe_events(id, type, created_at) VALUES($1, $2, to_timestamp($3)) ON CONFLICT(id) DO NOTHING',
       [stripeEvent.id, stripeEvent.type, stripeEvent.created]
     )
-    if (insertResult.rowCount === 0) {
+    const count = insertResult.rowCount ?? 0
+    if (count === 0) {
       console.log(`Duplicate event ${stripeEvent.id} of type ${stripeEvent.type} skipped.`)
       return { statusCode: 200, body: 'OK' }
     }

--- a/netlify/functions/todoid.ts
+++ b/netlify/functions/todoid.ts
@@ -34,7 +34,8 @@ async function getTodo(todoId: string, userId: string): Promise<Todo> {
         WHERE t.id = $1 AND t.user_id = $2`,
       [todoId, userId]
     )
-    if (result.rowCount === 0) {
+    const count = result.rowCount ?? 0
+    if (count === 0) {
       throw new Error('NotFound')
     }
     return result.rows[0]
@@ -79,7 +80,8 @@ async function updateTodo(
   const client = await getClient()
   try {
     const result = await client.query(query, values)
-    if (result.rowCount === 0) {
+    const count = result.rowCount ?? 0
+    if (count === 0) {
       throw new Error('NotFound')
     }
     return result.rows[0]
@@ -95,7 +97,8 @@ async function deleteTodo(todoId: string, userId: string): Promise<void> {
       'DELETE FROM todos WHERE id = $1 AND user_id = $2',
       [todoId, userId]
     )
-    if (result.rowCount === 0) {
+    const count = result.rowCount ?? 0
+    if (count === 0) {
       throw new Error('NotFound')
     }
   } finally {

--- a/netlify/functions/update.ts
+++ b/netlify/functions/update.ts
@@ -104,7 +104,8 @@ export const handler: Handler = async (
       keys.length + 1
     } RETURNING *`
     const result = await db.query(query, [...values, id])
-    if (result.rowCount === 0) {
+    const count = result.rowCount ?? 0
+    if (count === 0) {
       return {
         statusCode: 404,
         headers,

--- a/todo.js
+++ b/todo.js
@@ -187,7 +187,8 @@ async function updateTodo(event, user) {
       updated_at AS "updatedAt"
   `
   const res = await client.query(query, values)
-  if (res.rowCount === 0) {
+  const count = res.rowCount ?? 0
+  if (count === 0) {
     return {
       statusCode: 404,
       headers: jsonHeaders,
@@ -226,7 +227,8 @@ async function deleteTodo(event, user) {
      RETURNING id`,
     [id, user.id]
   )
-  if (res.rowCount === 0) {
+  const countDel = res.rowCount ?? 0
+  if (countDel === 0) {
     return {
       statusCode: 404,
       headers: jsonHeaders,


### PR DESCRIPTION
## Summary
- guard against null `rowCount` for todo endpoints and other DB actions
- prevent errors if a query returns no results

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_687ef861783c8327a57cd51d09f47a90