### PR TITLE
Remove explicit Handler type hints

### DIFF
--- a/netlify/functions/ai-create-mindmap.ts
+++ b/netlify/functions/ai-create-mindmap.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from "@netlify/functions"
-import type { Handler } from './types.js'
 import OpenAI from 'openai'
 import { randomUUID } from 'crypto'
 import { getClient } from './db-client.js'
@@ -8,7 +7,7 @@ if (!openaiKey) throw new Error('Missing OPENAI_API_KEY')
 const openai = new OpenAI({ apiKey: openaiKey })
 const MODEL = process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-4o-mini'
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import OpenAI from 'openai'
 
 const openaiKey = process.env.OPENAI_API_KEY
@@ -7,7 +6,7 @@ if (!openaiKey) throw new Error('Missing OPENAI_API_KEY')
 const openai = new OpenAI({ apiKey: openaiKey })
 const MODEL = process.env.OPENAI_DEFAULT_MODEL ?? 'gpt-4o-mini'
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import OpenAI from 'openai'
 import { z } from 'zod'
@@ -25,7 +24,7 @@ const todosResponseSchema = z.array(todoItemSchema).max(50)
 
 const headers = { 'Content-Type': 'application/json' }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   context: HandlerContext
 ) => {

--- a/netlify/functions/aitodoservice.ts
+++ b/netlify/functions/aitodoservice.ts
@@ -1,4 +1,4 @@
-import type { Handler, HandlerEvent, HandlerContext, HandlerResponse } from "@netlify/functions"
+import type { HandlerEvent, HandlerContext, HandlerResponse } from "@netlify/functions"
 import OpenAI from 'openai'
 import { randomUUID } from 'crypto'
 import cors from './corsmiddleware.js'
@@ -62,7 +62,7 @@ if (!API_KEY) {
 }
 const todoService = initTodoService(API_KEY)
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   context: HandlerContext
 ): Promise<HandlerResponse> => {

--- a/netlify/functions/analytics.ts
+++ b/netlify/functions/analytics.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { extractToken, verifySession } from './auth.js'
 
@@ -16,7 +15,7 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'Authorization,Content-Type'
 }
 
-export const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+export const handler = async (event: HandlerEvent, context: HandlerContext) => {
   if (event.httpMethod === 'OPTIONS') {
     return {
       statusCode: 204,

--- a/netlify/functions/checkout.ts
+++ b/netlify/functions/checkout.ts
@@ -1,7 +1,6 @@
 import { createCheckoutSession } from './stripeclient.js'
 import { getClient } from './db-client.js'
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function getCorsHeaders(origin?: string) {
@@ -29,7 +28,7 @@ function getCorsHeaders(origin?: string) {
   }
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/corsmiddleware.ts
+++ b/netlify/functions/corsmiddleware.ts
@@ -1,6 +1,5 @@
-import type { Handler } from './types.js'
 
-const handler: Handler = async () => ({
+const handler = async () => ({
   statusCode: 204,
   headers: {
     'Access-Control-Allow-Origin': '*',

--- a/netlify/functions/create.ts
+++ b/netlify/functions/create.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { extractToken, verifySession } from './auth.js'
 import { createMindMapSchema } from './validationschemas.js'
@@ -18,7 +17,7 @@ const headers = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization'
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/delete.ts
+++ b/netlify/functions/delete.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { z } from 'zod'
 import { extractToken, verifySession } from './auth.js'
 import { createClient } from '@vercel/postgres'
@@ -14,7 +13,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type,Authorization',
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   context: HandlerContext
 ) => {

--- a/netlify/functions/forgotpassword.ts
+++ b/netlify/functions/forgotpassword.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { randomBytes, createHmac } from 'crypto'
 import { getClient } from './db-client.js'
 const {
@@ -23,7 +22,7 @@ function hashToken(token: string): string {
 }
 
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/get.ts
+++ b/netlify/functions/get.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'
@@ -19,7 +18,7 @@ const QuerySchema = z.object({
   ).optional()
 })
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   context: HandlerContext
 ) => {

--- a/netlify/functions/healthcheck.ts
+++ b/netlify/functions/healthcheck.ts
@@ -1,8 +1,7 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 
-export const handler: Handler = async (event, context) => {
+export const handler = async (event: HandlerEvent, context: HandlerContext) => {
   context.callbackWaitsForEmptyEventLoop = false
   let dbHealthy = false
   try {

--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { verify, JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 import { z, ZodError } from 'zod'
@@ -46,7 +45,7 @@ async function createMap(userId: string, data: unknown) {
   }
 }
 
-const handler: Handler = async (
+const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/list.ts
+++ b/netlify/functions/list.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'
@@ -33,7 +32,7 @@ const QuerySchema = z.object({
 
 const JwtPayloadSchema = z.object({ userId: z.string() })
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import bcrypt from 'bcrypt'
@@ -26,7 +25,7 @@ const corsHeaders = {
   'Access-Control-Allow-Credentials': 'true'
 }
 
-const handler: Handler = async (
+const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/mapid.ts
+++ b/netlify/functions/mapid.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z } from 'zod'
 
@@ -24,7 +23,7 @@ function createResponse(statusCode: number, body?: unknown, headers: Record<stri
   return response
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/passwordreset.ts
+++ b/netlify/functions/passwordreset.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 
 import { randomBytes } from 'crypto'
@@ -29,7 +28,7 @@ const headers = {
   "Content-Type": "application/json",
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/payme.ts
+++ b/netlify/functions/payme.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import Stripe from 'stripe'
 import { getClient } from './db-client.js'
 const db = {
@@ -19,7 +18,7 @@ if (!stripeSecret || !stripeWebhookSecret) {
 }
 const stripe = new Stripe(stripeSecret, { apiVersion: '2022-11-15' })
 
-export const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+export const handler = async (event: HandlerEvent, context: HandlerContext) => {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: { Allow: 'POST' }, body: 'Method Not Allowed' }
   }

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import bcrypt from 'bcrypt'
@@ -23,7 +22,7 @@ const corsHeaders = {
   'Content-Type': 'application/json'
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/resetpassword.ts
+++ b/netlify/functions/resetpassword.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { createHash } from 'crypto'
 import bcrypt from 'bcrypt'
@@ -67,7 +66,7 @@ async function updatePassword(userId: string, newPassword: string): Promise<void
   }
 }
 
-export const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+export const handler = async (event: HandlerEvent, context: HandlerContext) => {
   if (event.httpMethod !== 'POST') {
     return {
       statusCode: 405,

--- a/netlify/functions/stripe.ts
+++ b/netlify/functions/stripe.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { verifySignature } from './stripeclient.js'
 import Stripe from 'stripe'
 import type { Client } from 'pg'
@@ -26,7 +25,7 @@ declare global {
 
 import { getClient } from './db-client.js'
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/stripecheckout.ts
+++ b/netlify/functions/stripecheckout.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import Stripe from 'stripe'
 const HEADERS = {
   'Access-Control-Allow-Origin': '*',
@@ -8,7 +7,7 @@ const HEADERS = {
   'Content-Type': 'application/json'
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/team-members.ts
+++ b/netlify/functions/team-members.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { extractToken, verifySession } from './auth.js'
 import { z } from 'zod'
@@ -13,7 +12,7 @@ const headers = {
 
 const payloadSchema = z.object({ email: z.string().email() })
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {

--- a/netlify/functions/todoid.ts
+++ b/netlify/functions/todoid.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z } from 'zod'
 import type { Todo } from './types.js'
@@ -106,7 +105,7 @@ async function deleteTodo(todoId: string, userId: string): Promise<void> {
   }
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   context: HandlerContext
 ) => {

--- a/netlify/functions/update.ts
+++ b/netlify/functions/update.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 
@@ -52,7 +51,7 @@ const resourceConfigs: Record<string, { table: string; schema: z.ZodTypeAny }> =
   }
 }
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   context: HandlerContext
 ) => {

--- a/netlify/functions/users.ts
+++ b/netlify/functions/users.ts
@@ -1,5 +1,4 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
-import type { Handler } from './types.js'
 import { getClient } from './db-client.js'
 import { z, ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'
@@ -16,7 +15,7 @@ const updateSchema = z.object({
   role: z.enum(['user', 'admin']).optional(),
 })
 
-export const handler: Handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {


### PR DESCRIPTION
## Summary
- drop `Handler` type annotations from API handlers
- keep parameter typing but let TypeScript infer response shape

## Testing
- `npm test` *(fails: Cannot find package 'pg'; afterEach not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687efef385408327a644b6db6ff3d347