### PR TITLE
Improve hero layout

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -696,14 +696,28 @@ hr {
 }
 
 .hero-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: clamp(2.5rem, 5vw, 4rem);
   font-weight: 800;
   margin-bottom: var(--spacing-md);
+  gap: var(--spacing-sm);
 }
+
 .hero-title .hero-logo {
   height: 100px;
-  margin-right: var(--spacing-sm);
   vertical-align: middle;
+}
+
+@media (max-width: 640px) {
+  .hero-title {
+    flex-direction: column;
+  }
+
+  .hero-title .hero-logo {
+    margin-bottom: var(--spacing-sm);
+  }
 }
 
 .header {


### PR DESCRIPTION
## Summary
- keep the hero logo and heading on one line on desktop
- stack the logo above the text on small screens

## Testing
- `npm test` *(fails: Cannot find package 'typescript' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f0ed340108327a00e0b5468618b85