### PR TITLE
Fix login env logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,16 @@
 OPENAI_API_KEY=your-openai-key
 OPENAI_DEFAULT_MODEL=gpt-4o-mini
 # copy this into Netlify’s UI as NETLIFY_DATABASE_URL
+# Either DATABASE_URL or NETLIFY_DATABASE_URL can be used
+DATABASE_URL=postgresql://username:password@host:port/dbname
 NETLIFY_DATABASE_URL=postgresql://username:password@host:port/dbname
+# connection string for unpooled clients
+NETLIFY_DATABASE_URL_UNPOOLED=postgresql://username:password@host:port/dbname
+# secret used to sign JWT tokens
+JWT_SECRET=your-jwt-secret
 # Admin user seeding (for build-time DB seeding)
 ADMIN_EMAIL=
 ADMIN_PASSWORD=
+# environment mode
+# set to production on Netlify
+NODE_ENV=production

--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -1,11 +1,15 @@
 import { Pool } from 'pg'
 
-const connectionString =
-  process.env.DATABASE_URL || process.env.NETLIFY_DATABASE_URL
+const { DATABASE_URL: LOCAL_DB, NETLIFY_DATABASE_URL } = process.env
+const connectionString = LOCAL_DB || NETLIFY_DATABASE_URL
 
 if (!connectionString) {
   throw new Error('Missing DATABASE_URL')
 }
+
+console.info(
+  `db-client using ${LOCAL_DB ? 'DATABASE_URL' : 'NETLIFY_DATABASE_URL'} connection`
+)
 
 const pool = new Pool({
   connectionString,

--- a/netlify/functions/delete.ts
+++ b/netlify/functions/delete.ts
@@ -2,7 +2,11 @@ import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { z } from 'zod'
 import { extractToken, verifySession } from './auth.js'
 import { createClient } from '@vercel/postgres'
-const db = createClient({ connectionString: process.env.NETLIFY_DATABASE_URL_UNPOOLED })
+const dbUrl = process.env.NETLIFY_DATABASE_URL_UNPOOLED
+console.info(
+  `delete function using ${dbUrl ? 'NETLIFY_DATABASE_URL_UNPOOLED' : 'missing connection string'}`
+)
+const db = createClient({ connectionString: dbUrl })
 const DeleteRequest = z.object({
   id: z.string().uuid(),
 })

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -4,10 +4,15 @@ import { z, ZodError } from 'zod'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
 
-const { DATABASE_URL, JWT_SECRET } = process.env
+const { DATABASE_URL: LOCAL_DB, NETLIFY_DATABASE_URL, JWT_SECRET } = process.env
+const DATABASE_URL = LOCAL_DB || NETLIFY_DATABASE_URL
 if (!DATABASE_URL || !JWT_SECRET) {
+  console.error('Missing DATABASE_URL or JWT_SECRET')
   throw new Error('Missing required environment variables')
 }
+console.info(
+  `login using ${LOCAL_DB ? 'DATABASE_URL' : 'NETLIFY_DATABASE_URL'} connection`
+)
 
 const loginSchema = z.object({
   email: z.string().email().transform((s: string) => s.trim().toLowerCase()),

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -4,10 +4,15 @@ import { z, ZodError } from 'zod'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
 
-const { DATABASE_URL, JWT_SECRET, SALT_ROUNDS = '10' } = process.env
+const { DATABASE_URL: LOCAL_DB, NETLIFY_DATABASE_URL, JWT_SECRET, SALT_ROUNDS = '10' } = process.env
+const DATABASE_URL = LOCAL_DB || NETLIFY_DATABASE_URL
 if (!DATABASE_URL || !JWT_SECRET) {
+  console.error('Missing DATABASE_URL or JWT_SECRET')
   throw new Error('Missing required environment variables')
 }
+console.info(
+  `register using ${LOCAL_DB ? 'DATABASE_URL' : 'NETLIFY_DATABASE_URL'} connection`
+)
 
 const registerSchema = z.object({
   email: z.string().email().transform((s: string) => s.trim().toLowerCase()),

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -133,6 +133,10 @@ async function seedAdminUser() {
   const { ADMIN_EMAIL, ADMIN_PASSWORD } = process.env
   const SALT_ROUNDS = parseInt(process.env.SALT_ROUNDS || '10', 10)
 
+  console.info(
+    `seeding admin user using ${ADMIN_EMAIL && ADMIN_PASSWORD ? 'provided credentials' : 'no credentials'}`
+  )
+
   if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
     console.log('Skipping admin user seed: ADMIN_EMAIL or ADMIN_PASSWORD missing')
     return

--- a/src/lib/validateEnv.js
+++ b/src/lib/validateEnv.js
@@ -1,8 +1,9 @@
 export function validateEnv() {
-  const required = ['NETLIFY_DATABASE_URL']
-  for (const key of required) {
-    if (!process.env[key]) {
-      throw new Error(`Missing ${key}`)
-    }
+  const { NETLIFY_DATABASE_URL, DATABASE_URL, JWT_SECRET } = process.env
+  if (!NETLIFY_DATABASE_URL && !DATABASE_URL) {
+    throw new Error('Missing NETLIFY_DATABASE_URL')
+  }
+  if (!JWT_SECRET) {
+    throw new Error('Missing JWT_SECRET')
   }
 }

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -1,18 +1,53 @@
 import { afterEach, test, expect } from 'node:test'
 import { validateEnv } from '../src/lib/validateEnv.js'
 
-// Preserve original value
-const original = process.env.NETLIFY_DATABASE_URL
+// Preserve original values
+const originalDB = process.env.NETLIFY_DATABASE_URL
+const originalLocal = process.env.DATABASE_URL
+const originalJWT = process.env.JWT_SECRET
 
 afterEach(() => {
-  if (original === undefined) {
+  if (originalDB === undefined) {
     delete process.env.NETLIFY_DATABASE_URL
   } else {
-    process.env.NETLIFY_DATABASE_URL = original
+    process.env.NETLIFY_DATABASE_URL = originalDB
+  }
+  if (originalLocal === undefined) {
+    delete process.env.DATABASE_URL
+  } else {
+    process.env.DATABASE_URL = originalLocal
+  }
+  if (originalJWT === undefined) {
+    delete process.env.JWT_SECRET
+  } else {
+    process.env.JWT_SECRET = originalJWT
   }
 })
 
-test('throws if NETLIFY_DATABASE_URL missing', () => {
+test('throws if no database URL provided', () => {
   delete process.env.NETLIFY_DATABASE_URL
+  delete process.env.DATABASE_URL
+  process.env.JWT_SECRET = 'secret'
   expect(() => validateEnv()).toThrow('Missing NETLIFY_DATABASE_URL')
+})
+
+test('throws if JWT_SECRET missing', () => {
+  process.env.NETLIFY_DATABASE_URL = 'postgres://host/db'
+  delete process.env.DATABASE_URL
+  delete process.env.JWT_SECRET
+  expect(() => validateEnv()).toThrow('Missing JWT_SECRET')
+})
+
+test('accepts NETLIFY_DATABASE_URL', () => {
+  process.env.NETLIFY_DATABASE_URL = 'postgres://host/db'
+  delete process.env.DATABASE_URL
+  process.env.JWT_SECRET = 'secret'
+  expect(() => validateEnv()).not.toThrow()
+})
+
+test('accepts DATABASE_URL fallback', () => {
+  delete process.env.NETLIFY_DATABASE_URL
+  process.env.DATABASE_URL = 'postgres://host/db'
+  process.env.JWT_SECRET = 'secret'
+  expect(() => validateEnv()).not.toThrow()
 })


### PR DESCRIPTION
## Summary
- validate JWT_SECRET in `validateEnv`
- log which DB URL is in use
- add admin seeding log and update example env file
- test env validation for JWT_SECRET

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f0b1bd92083278923c621589b87b8