### PR TITLE
Fix Netlify function exports

### DIFF
--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -45,7 +45,7 @@ async function createMap(userId: string, data: unknown) {
   }
 }
 
-const handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {
@@ -129,4 +129,4 @@ const handler = async (
     }
   }
 }
-module.exports = { handler }
+

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -31,7 +31,7 @@ const corsHeaders = {
   'Access-Control-Allow-Credentials': 'true'
 }
 
-const handler = async (
+export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {
@@ -184,4 +184,4 @@ const handler = async (
   }
 }
 
-module.exports = { handler }
+

--- a/netlify/functions/me.ts
+++ b/netlify/functions/me.ts
@@ -72,4 +72,4 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
   }
 }
 
-module.exports = { handler }
+

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -118,4 +118,4 @@ export const handler = async (
   }
 }
 
-module.exports = { handler }
+


### PR DESCRIPTION
## Summary
- use ESM exports for Netlify auth functions so they compile correctly

## Testing
- `npm run build:functions` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687f220d17608327a61947e44cf58341