### PR TITLE
Restrict compilation scope for Netlify functions

### DIFF
--- a/tsconfig.functions.json
+++ b/tsconfig.functions.json
@@ -3,12 +3,12 @@
     "target": "ES2020",
     "module": "ES2020",
     "moduleResolution": "node",
-    "rootDir": "./",
-    "outDir": "dist/netlify/functions",
+    "rootDir": "netlify/functions",
+    "outDir": "netlify/functions",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["*.ts"]
+  "include": ["netlify/functions/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- narrow TypeScript compilation for serverless functions

## Testing
- `npm run test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_687f2b025cb083279ddb210ea33ac0fe