### PR TITLE
Fix login api path

### DIFF
--- a/login.tsx
+++ b/login.tsx
@@ -63,7 +63,7 @@ const LoginPage = (): JSX.Element => {
     const controller = new AbortController()
     abortControllerRef.current = controller
 
-    fetch('/api/login', {
+    fetch('/.netlify/functions/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -14,7 +14,7 @@ const LoginPage = () => {
     setError('')
     setIsSubmitting(true)
     try {
-      const res = await fetch('/api/login', {
+      const res = await fetch('/.netlify/functions/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',


### PR DESCRIPTION
## Summary
- update login page fetch to call the correct Netlify function

## Testing
- `npm test` *(fails: cannot find package 'typescript' and expect from node:test)*

------
https://chatgpt.com/codex/tasks/task_e_687f309d2cc08327a52e1096e1c38851