### PR TITLE
Fix admin seeding and login error message

### DIFF
--- a/login.tsx
+++ b/login.tsx
@@ -73,13 +73,17 @@ const LoginPage = (): JSX.Element => {
       .then(async response => {
         if (!response.ok) {
           let errorMsg = 'Login failed'
-          const contentType = response.headers.get('Content-Type') || ''
-          if (contentType.includes('application/json')) {
-            try {
-              const errorData = await response.json()
-              errorMsg = errorData.error || errorMsg
-            } catch {
-              // ignore parse error
+          if (response.status === 401) {
+            errorMsg = 'Unable to login. Username or password was not found'
+          } else {
+            const contentType = response.headers.get('Content-Type') || ''
+            if (contentType.includes('application/json')) {
+              try {
+                const errorData = await response.json()
+                errorMsg = errorData.error || errorMsg
+              } catch {
+                // ignore parse error
+              }
             }
           }
           throw new Error(errorMsg)

--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -11,7 +11,7 @@ console.info(
   `db-client using ${LOCAL_DB ? 'DATABASE_URL' : 'NETLIFY_DATABASE_URL'} connection`
 )
 
-const pool = new Pool({
+export const pool = new Pool({
   connectionString,
   ssl:
     process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : undefined,


### PR DESCRIPTION
## Summary
- export the Postgres connection pool so migrations can seed an admin account
- show a friendly message on the login page when credentials are incorrect

## Testing
- `node --test` *(fails: Cannot find package 'typescript' imported from tests)*

------
https://chatgpt.com/codex/tasks/task_e_687f343ed6d4832793c7ee311f23ed45