### PR TITLE
Fix missing vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "@types/pg": "^8.6.6",
     "@types/stripe": "^8.0.417",
     "@types/uuid": "^8.3.4",
-    "@vitejs/plugin-react": "^4.0.3",
+    "@vitejs/plugin-react": "^4.6.0",
     "sass": "^1.69.5",
-    "vite": "^5.0.0",
+    "vite": "^5.4.19",
     "typescript": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- update vite and plugin-react dev deps

## Testing
- `npm test --silent` *(fails: Cannot find package 'typescript' imported from tests)*

------
https://chatgpt.com/codex/tasks/task_e_687fd1ed5904832794abd2db8680767e