### PR TITLE
Fix Netlify redirects for seed function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,3 @@
-
 [build]
   command = "npm install && npm run deploy-seed && npm run build"
   publish = "dist"
@@ -9,11 +8,11 @@
   NODE_ENV = "production"
 
 [[redirects]]
-from = "/api/*"
-to = "/.netlify/functions/:splat"
-status = 200
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200
 
 [[redirects]]
-from = "/*"
-to = "/index.html"
-status = 200
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
+/api/* /.netlify/functions/:splat 200
 /*  /index.html  200

--- a/vite.js
+++ b/vite.js
@@ -8,7 +8,7 @@ function netlifyRedirect() {
       this.emitFile({
         type: 'asset',
         fileName: '_redirects',
-        source: '/* /index.html 200\n'
+        source: '/api/* /.netlify/functions/:splat 200\n/* /index.html 200\n'
       })
     }
   }


### PR DESCRIPTION
## Summary
- ensure redirect for API functions takes precedence
- generate `_redirects` with API rule during build

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687fd41b725083279c0ee797f524dbbb