### PR TITLE
Fix Netlify build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This project uses Netlify Functions and a Neon database. SQL migration files are
 ## Deploying
 
 1. Install dependencies (optional if the build only runs in CI). Use Node.js 22
-   with npm version 10.9.2 or newer:
+   with npm version 10.9.2 or newer. The build requires dev dependencies such as
+   `vite`, so include them during installation:
    ```bash
-   npm install
+   npm install --include=dev
    ```
 2. Run database migrations (requires a configured Neon connection):
    ```bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,6 @@
 [build]
-  command = "npm install && npm run deploy-seed && npm run build"
+  # Install dev dependencies so the vite build tool is available
+  command = "npm install --include=dev && npm run deploy-seed && npm run build"
   publish = "dist"
   functions = "netlify/functions"
 


### PR DESCRIPTION
## Summary
- install dev dependencies during Netlify build so `vite build` works
- document that dev dependencies must be installed when deploying

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_687fd5d776fc8327b8c134e99cea9c70