### PR TITLE
Enhance dashboard with animations

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -82,6 +82,13 @@ export default function DashboardPage(): JSX.Element {
     }
   }
 
+  const handleTileClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+    const el = e.currentTarget
+    el.classList.remove('clicked')
+    void el.offsetWidth
+    el.classList.add('clicked')
+  }
+
   const now = Date.now()
   const oneDay = 24 * 60 * 60 * 1000
   const oneWeek = 7 * oneDay
@@ -127,7 +134,7 @@ export default function DashboardPage(): JSX.Element {
             </div>
           </div>
           <div className="tiles-grid">
-            <div className="tile">
+            <div className="tile" onClick={handleTileClick}>
               <div className="tile-header">
                 <h2>Mind Maps</h2>
                 <button onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
@@ -140,7 +147,7 @@ export default function DashboardPage(): JSX.Element {
                 ))}
               </ul>
             </div>
-            <div className="tile">
+            <div className="tile" onClick={handleTileClick}>
               <div className="tile-header">
                 <h2>Todos</h2>
                 <button onClick={() => { setCreateType('todo'); setShowModal(true) }}>Create</button>
@@ -155,7 +162,7 @@ export default function DashboardPage(): JSX.Element {
                 ))}
               </ul>
             </div>
-            <div className="tile">
+            <div className="tile" onClick={handleTileClick}>
               <h2>Kanban Boards</h2>
               <Link to="/kanban" className="text-blue-600 underline">Open Kanban</Link>
             </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1198,8 +1198,6 @@ hr {
 
 .mindmap-arm {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
   width: 1200px;
   height: 100px;
   pointer-events: none;
@@ -1210,10 +1208,12 @@ hr {
 
 .mindmap-arm.left {
   left: 0;
+  top: 0;
 }
 
 .mindmap-arm.right {
   right: 0;
+  bottom: 0;
 }
 
 .section-icon {
@@ -1531,6 +1531,7 @@ hr {
 
 .metric-card {
   background-color: var(--color-bg-alt);
+  border-top: 3px solid var(--color-warning);
   border-radius: 8px;
   padding: var(--spacing-md);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
@@ -1545,6 +1546,7 @@ hr {
 
 .tile {
   background-color: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: var(--spacing-lg);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
@@ -1574,4 +1576,47 @@ hr {
   width: 100%;
   max-width: 400px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes outline-flash {
+  0% {
+    box-shadow: 0 0 0 0 var(--color-primary);
+  }
+  100% {
+    box-shadow: 0 0 0 4px transparent;
+  }
+}
+
+.dashboard-page {
+  animation: fade-in 0.6s var(--transition-ease);
+}
+
+.tile.clicked {
+  animation: outline-flash 0.4s var(--transition-ease);
+  border-radius: 8px;
+}
+
+.tile-header button {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-duration) var(--transition-ease);
+}
+
+.tile-header button:hover {
+  background-color: var(--color-warning);
 }


### PR DESCRIPTION
## Summary
- revamp dashboard page with quick outline animations
- style buttons and cards using primary and warning colors
- reposition mindmap arms so left is at top and right at bottom
- add fade-in animation on page load

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_687ff4bf4e808327b727719518e8cac5