### PR TITLE
Implement fancy modal and board creation

### DIFF
--- a/netlify/functions/boards.ts
+++ b/netlify/functions/boards.ts
@@ -1,12 +1,35 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 
+let boards = [
+  { id: 'demo1', title: 'Demo Board', created_at: new Date().toISOString() }
+]
+
 export const handler = async (
-  _event: HandlerEvent,
+  event: HandlerEvent,
   _context: HandlerContext
 ) => {
-  const boards = [
-    { id: 'demo1', title: 'Demo Board', created_at: new Date().toISOString() }
-  ]
+  if (event.httpMethod === 'POST') {
+    try {
+      const data = JSON.parse(event.body || '{}') as { title?: string }
+      const newBoard = {
+        id: Date.now().toString(),
+        title: data.title || 'Untitled Board',
+        created_at: new Date().toISOString()
+      }
+      boards.push(newBoard)
+      return {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        },
+        body: JSON.stringify(newBoard)
+      }
+    } catch {
+      return { statusCode: 400, body: 'Invalid body' }
+    }
+  }
+
   return {
     statusCode: 200,
     headers: {

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -38,7 +38,7 @@ export default function DashboardPage(): JSX.Element {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
-  const [createType, setCreateType] = useState<'map' | 'todo'>('map')
+  const [createType, setCreateType] = useState<'map' | 'todo' | 'board'>('map')
   const [form, setForm] = useState({ title: '', description: '' })
 
   const fetchData = async (): Promise<void> => {
@@ -82,11 +82,17 @@ export default function DashboardPage(): JSX.Element {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(form),
         })
-      } else {
+      } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title: form.title, description: form.description }),
+        })
+      } else {
+        await fetch('/.netlify/functions/boards', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title: form.title }),
         })
       }
       setShowModal(false)
@@ -205,7 +211,7 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile" onClick={handleTileClick}>
               <div className="tile-header">
                 <h2>Kanban Boards</h2>
-                <Link to="/kanban" className="text-blue-600 underline">Open</Link>
+                <button onClick={() => { setCreateType('board'); setShowModal(true) }}>Create</button>
               </div>
               <ul className="recent-list">
                 {boards.slice(0, 10).map(b => (
@@ -220,20 +226,21 @@ export default function DashboardPage(): JSX.Element {
       )}
       {showModal && (
         <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
-          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
-            <h2>Create {createType === 'map' ? 'Mind Map' : 'Todo'}</h2>
+          <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <span className="flare-line" aria-hidden="true"></span>
+            <h2 className="fade-item">Create {createType === 'map' ? 'Mind Map' : createType === 'todo' ? 'Todo' : 'Board'}</h2>
             <form onSubmit={handleCreate}>
               <div className="form-group">
-                <label htmlFor="title">Title</label>
-                <input id="title" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+                <label htmlFor="title" className="fade-item" style={{ animationDelay: '0.1s' }}>Title</label>
+                <input id="title" className="fade-item" style={{ animationDelay: '0.1s' }} value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
               </div>
               <div className="form-group">
-                <label htmlFor="desc">Description</label>
-                <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
+                <label htmlFor="desc" className="fade-item" style={{ animationDelay: '0.2s' }}>Description</label>
+                <textarea id="desc" className="fade-item" style={{ animationDelay: '0.2s' }} value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
               </div>
               <div className="form-actions">
-                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit">Create</button>
+                <button type="button" className="fade-item" style={{ animationDelay: '0.3s' }} onClick={() => setShowModal(false)}>Cancel</button>
+                <button type="submit" className="fade-item" style={{ animationDelay: '0.3s' }}>Create</button>
               </div>
             </form>
           </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1595,6 +1595,7 @@ hr {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  animation: fade-in 0.3s var(--transition-ease);
 }
 
 .modal {
@@ -1647,4 +1648,41 @@ hr {
 
 .tile-header button:hover {
   background-color: var(--color-warning);
+}
+
+/* Fancy modal styles */
+.fancy-modal {
+  position: relative;
+  animation: modal-pop 0.4s var(--transition-ease) both;
+  border: 2px solid var(--color-primary);
+}
+
+.fancy-modal .flare-line {
+  pointer-events: none;
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  border: 2px solid transparent;
+  animation: flare-line 1s forwards;
+}
+
+.fade-item {
+  opacity: 0;
+  animation: fade-item 0.5s forwards;
+}
+
+@keyframes modal-pop {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+@keyframes fade-item {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes flare-line {
+  0% { box-shadow: 0 0 0 0 var(--color-warning); }
+  80% { box-shadow: 0 0 6px 4px var(--color-warning); }
+  100% { box-shadow: 0 0 0 0 transparent; }
 }


### PR DESCRIPTION
## Summary
- extend dashboard modal with animations and brand flare
- allow creating kanban boards via dashboard
- enhance boards Netlify function to accept POST
- style fancy modal in SCSS

## Testing
- `npm test --silent` *(fails: cannot find package 'typescript' and node:test import issues)*

------
https://chatgpt.com/codex/tasks/task_e_687ffa4ff8d8832797a4c4f02eb2fdae