### PR TITLE
Improve dashboard modals and metrics

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -171,8 +171,8 @@ export default function DashboardPage(): JSX.Element {
                 <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
               </div>
               <div className="form-actions">
-                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit">Create</button>
+                <button type="button" className="btn-cancel" onClick={() => setShowModal(false)}>Cancel</button>
+                <button type="submit" className="btn-primary">Create</button>
               </div>
             </form>
           </div>

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -127,23 +127,34 @@ export default function DashboardPage(): JSX.Element {
   const boardDay = boards.filter(b => new Date(b.createdAt || b.created_at || '').getTime() > dayAgo).length
   const boardWeek = boards.filter(b => new Date(b.createdAt || b.created_at || '').getTime() > weekAgo).length
 
-  const sevenDayTotals = Array.from({ length: 7 }, (_v, i) => {
+  const mapTrend = Array.from({ length: 7 }, (_v, i) => {
     const start = new Date(now - (6 - i) * oneDay)
     start.setHours(0, 0, 0, 0)
     const end = start.getTime() + oneDay
-    const countMaps = maps.filter(m => {
+    return maps.filter(m => {
       const t = new Date(m.createdAt || m.created_at || '').getTime()
       return t >= start.getTime() && t < end
     }).length
-    const countTodos = todos.filter(t => {
+  })
+
+  const todoTrend = Array.from({ length: 7 }, (_v, i) => {
+    const start = new Date(now - (6 - i) * oneDay)
+    start.setHours(0, 0, 0, 0)
+    const end = start.getTime() + oneDay
+    return todos.filter(t => {
       const t1 = new Date(t.createdAt || t.created_at || '').getTime()
       return t1 >= start.getTime() && t1 < end
     }).length
-    const countBoards = boards.filter(b => {
+  })
+
+  const boardTrend = Array.from({ length: 7 }, (_v, i) => {
+    const start = new Date(now - (6 - i) * oneDay)
+    start.setHours(0, 0, 0, 0)
+    const end = start.getTime() + oneDay
+    return boards.filter(b => {
       const t2 = new Date(b.createdAt || b.created_at || '').getTime()
       return t2 >= start.getTime() && t2 < end
     }).length
-    return countMaps + countTodos + countBoards
   })
 
   return (
@@ -163,21 +174,20 @@ export default function DashboardPage(): JSX.Element {
               <h3 className="metric-title">Mind Maps</h3>
               <div className="metric-value">{maps.length}</div>
               <p>Today: {mapDay} &middot; Week: {mapWeek}</p>
+              <Sparkline data={mapTrend} />
             </div>
             <div className="metric-card">
               <h3 className="metric-title">Todos</h3>
               <div className="metric-value">{todos.length}</div>
               <p>Added Today: {todoAddedDay}</p>
               <p>Completed Today: {todoDoneDay}</p>
+              <Sparkline data={todoTrend} />
             </div>
             <div className="metric-card">
               <h3 className="metric-title">Kanban Boards</h3>
               <div className="metric-value">{boards.length}</div>
               <p>Today: {boardDay} &middot; Week: {boardWeek}</p>
-            </div>
-            <div className="metric-card">
-              <h3 className="metric-title">7 Day Activity</h3>
-              <Sparkline data={sevenDayTotals} />
+              <Sparkline data={boardTrend} />
             </div>
           </div>
           <div className="tiles-grid">
@@ -239,8 +249,8 @@ export default function DashboardPage(): JSX.Element {
                 <textarea id="desc" className="fade-item" style={{ animationDelay: '0.2s' }} value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
               </div>
               <div className="form-actions">
-                <button type="button" className="fade-item" style={{ animationDelay: '0.3s' }} onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit" className="fade-item" style={{ animationDelay: '0.3s' }}>Create</button>
+                <button type="button" className="btn-cancel fade-item" style={{ animationDelay: '0.3s' }} onClick={() => setShowModal(false)}>Cancel</button>
+                <button type="submit" className="btn-primary fade-item" style={{ animationDelay: '0.3s' }}>Create</button>
               </div>
             </form>
           </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1660,10 +1660,11 @@ hr {
 .fancy-modal .flare-line {
   pointer-events: none;
   position: absolute;
-  inset: -2px;
+  inset: 0;
   border-radius: inherit;
-  border: 2px solid transparent;
-  animation: flare-line 1s forwards;
+  border: 2px solid var(--color-warning);
+  transform: scale(0);
+  animation: draw-border 0.3s forwards;
 }
 
 .fade-item {
@@ -1681,8 +1682,34 @@ hr {
   to { opacity: 1; transform: translateY(0); }
 }
 
-@keyframes flare-line {
-  0% { box-shadow: 0 0 0 0 var(--color-warning); }
-  80% { box-shadow: 0 0 6px 4px var(--color-warning); }
-  100% { box-shadow: 0 0 0 0 transparent; }
+@keyframes draw-border {
+  from { transform: scale(0); }
+  to { transform: scale(1); }
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.form-actions button {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 4px;
+}
+
+.form-actions .btn-cancel {
+  background-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.form-actions .btn-primary {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  transition: background-color var(--transition-duration) var(--transition-ease);
+}
+
+.form-actions .btn-primary:hover {
+  background-color: var(--color-warning);
 }


### PR DESCRIPTION
## Summary
- animate modal borders with a quick draw effect
- style modal button area
- show 7‑day trends per mind map, todo and kanban board
- update buttons in the old dashboard file for consistency

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_687ffcbfb4b88327b8a04aefadeea427