### PR TITLE
Add dedicated overview pages

### DIFF
--- a/mapid.tsx
+++ b/mapid.tsx
@@ -22,6 +22,10 @@ export default function MapPage({ mapId }: { mapId: string }): JSX.Element {
   const [loadTrigger, setLoadTrigger] = useState<number>(0)
 
   useEffect(() => {
+    localStorage.setItem(`mindmap_last_viewed_${mapId}`, Date.now().toString())
+  }, [mapId])
+
+  useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
     setLoadError(null)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,9 @@ import AboutPage from '../about'
 import MindmapDemo from '../mindmapdemo'
 import TodoDemo from '../tododemo'
 import Kanban from '../kanban'
+import MindmapsPage from '../MindmapsPage'
+import TodosPage from '../TodosPage'
+import KanbanBoardsPage from '../KanbanBoardsPage'
 import TeamMembers from '../teammembers'
 import ProfilePage from '../profile'
 import BillingPage from '../billing'
@@ -29,7 +32,10 @@ function AppRoutes() {
       <Route path="/about" element={<AboutPage />} />
       <Route path="/mindmap-demo" element={<MindmapDemo />} />
       <Route path="/todo-demo" element={<TodoDemo />} />
-      <Route path="/kanban" element={<Kanban />} />
+      <Route path="/kanban-demo" element={<Kanban />} />
+      <Route path="/mindmaps" element={<MindmapsPage />} />
+      <Route path="/todos" element={<TodosPage />} />
+      <Route path="/kanban" element={<KanbanBoardsPage />} />
       <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/privacy" element={<PrivacyPolicy />} />
       <Route path="/terms" element={<TermsOfService />} />

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import LoadingSkeleton from '../loadingskeleton'
+
+interface BoardItem {
+  id: string
+  title?: string
+  createdAt?: string
+  created_at?: string
+}
+
+const getLastViewed = (id: string): number => {
+  const v = localStorage.getItem(`board_last_viewed_${id}`)
+  return v ? parseInt(v, 10) : 0
+}
+
+export default function KanbanBoardsPage(): JSX.Element {
+  const [boards, setBoards] = useState<BoardItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [form, setForm] = useState({ title: '' })
+
+  const fetchData = async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/.netlify/functions/boards', { credentials: 'include' })
+      const json = res.ok ? await res.json() : { boards: [] }
+      const list: BoardItem[] = Array.isArray(json) ? json : json.boards || []
+      setBoards(list)
+    } catch (err: any) {
+      setError(err.message || 'Failed to load boards')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchData() }, [])
+
+  const handleCreate = async (e: FormEvent): Promise<void> => {
+    e.preventDefault()
+    try {
+      await fetch('/.netlify/functions/boards', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: form.title }),
+      })
+      setShowModal(false)
+      setForm({ title: '' })
+      fetchData()
+    } catch (err: any) {
+      alert(err.message || 'Creation failed')
+    }
+  }
+
+  const now = Date.now()
+  const oneDay = 24 * 60 * 60 * 1000
+  const oneWeek = 7 * oneDay
+  const dayAgo = now - oneDay
+  const weekAgo = now - oneWeek
+
+  const boardDay = boards.filter(b => new Date(b.createdAt || b.created_at || '').getTime() > dayAgo).length
+  const boardWeek = boards.filter(b => new Date(b.createdAt || b.created_at || '').getTime() > weekAgo).length
+
+  const sorted = [...boards].sort((a, b) => {
+    const av = getLastViewed(a.id)
+    const bv = getLastViewed(b.id)
+    if (av !== bv) return bv - av
+    const at = new Date(a.createdAt || a.created_at || '').getTime()
+    const bt = new Date(b.createdAt || b.created_at || '').getTime()
+    return bt - at
+  })
+
+  return (
+    <div className="list-page">
+      <h1>Kanban Boards</h1>
+      {loading ? (
+        <LoadingSkeleton count={3} />
+      ) : error ? (
+        <p className="error">{error}</p>
+      ) : (
+        <>
+          <div className="metrics-grid">
+            <div className="metric-card">
+              <h3>Total: {boards.length}</h3>
+              <p>Today: {boardDay} Week: {boardWeek}</p>
+            </div>
+            <div>
+              <button onClick={() => setShowModal(true)}>Create Board</button>
+            </div>
+          </div>
+          <ul className="tile-list">
+            {sorted.map(b => (
+              <li key={b.id}>
+                <Link
+                  to="/kanban"
+                  onClick={() => localStorage.setItem(`board_last_viewed_${b.id}`, Date.now().toString())}
+                >
+                  {b.title || 'Board'}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {showModal && (
+        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <h2>Create Board</h2>
+            <form onSubmit={handleCreate}>
+              <div className="form-group">
+                <label htmlFor="title">Title</label>
+                <input id="title" value={form.title} onChange={e => setForm({ title: e.target.value })} required />
+              </div>
+              <div className="form-actions">
+                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
+                <button type="submit">Create</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import LoadingSkeleton from '../loadingskeleton'
+
+interface MapItem {
+  id: string
+  title?: string
+  createdAt?: string
+  created_at?: string
+}
+
+const getLastViewed = (id: string): number => {
+  const v = localStorage.getItem(`mindmap_last_viewed_${id}`)
+  return v ? parseInt(v, 10) : 0
+}
+
+export default function MindmapsPage(): JSX.Element {
+  const [maps, setMaps] = useState<MapItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [form, setForm] = useState({ title: '', description: '' })
+
+  const fetchData = async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/.netlify/functions/index', { credentials: 'include' })
+      const data = res.ok ? await res.json() : []
+      setMaps(Array.isArray(data) ? data : [])
+    } catch (err: any) {
+      setError(err.message || 'Failed to load maps')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchData() }, [])
+
+  const handleCreate = async (e: FormEvent): Promise<void> => {
+    e.preventDefault()
+    try {
+      await fetch('/.netlify/functions/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      })
+      setShowModal(false)
+      setForm({ title: '', description: '' })
+      fetchData()
+    } catch (err: any) {
+      alert(err.message || 'Creation failed')
+    }
+  }
+
+  const now = Date.now()
+  const oneDay = 24 * 60 * 60 * 1000
+  const oneWeek = 7 * oneDay
+  const dayAgo = now - oneDay
+  const weekAgo = now - oneWeek
+
+  const mapDay = maps.filter(m => new Date(m.createdAt || m.created_at || '').getTime() > dayAgo).length
+  const mapWeek = maps.filter(m => new Date(m.createdAt || m.created_at || '').getTime() > weekAgo).length
+
+  const sorted = [...maps].sort((a, b) => {
+    const av = getLastViewed(a.id)
+    const bv = getLastViewed(b.id)
+    if (av !== bv) return bv - av
+    const at = new Date(a.createdAt || a.created_at || '').getTime()
+    const bt = new Date(b.createdAt || b.created_at || '').getTime()
+    return bt - at
+  })
+
+  return (
+    <div className="list-page">
+      <h1>Mind Maps</h1>
+      {loading ? (
+        <LoadingSkeleton count={3} />
+      ) : error ? (
+        <p className="error">{error}</p>
+      ) : (
+        <>
+          <div className="metrics-grid">
+            <div className="metric-card">
+              <h3>Total: {maps.length}</h3>
+              <p>Today: {mapDay} Week: {mapWeek}</p>
+            </div>
+            <div>
+              <button onClick={() => setShowModal(true)}>Create Map</button>
+            </div>
+          </div>
+          <ul className="tile-list">
+            {sorted.map(m => (
+              <li key={m.id}>
+                <Link
+                  to={`/maps/${m.id}`}
+                  onClick={() => localStorage.setItem(`mindmap_last_viewed_${m.id}`, Date.now().toString())}
+                >
+                  {m.title || 'Untitled Map'}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {showModal && (
+        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <h2>Create Mind Map</h2>
+            <form onSubmit={handleCreate}>
+              <div className="form-group">
+                <label htmlFor="title">Title</label>
+                <input id="title" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+              </div>
+              <div className="form-group">
+                <label htmlFor="desc">Description</label>
+                <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
+              </div>
+              <div className="form-actions">
+                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
+                <button type="submit">Create</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import LoadingSkeleton from '../loadingskeleton'
+
+interface TodoItem {
+  id: string
+  title?: string
+  content?: string
+  completed?: boolean
+  createdAt?: string
+  created_at?: string
+}
+
+const getLastViewed = (id: string): number => {
+  const v = localStorage.getItem(`todo_last_viewed_${id}`)
+  return v ? parseInt(v, 10) : 0
+}
+
+export default function TodosPage(): JSX.Element {
+  const [todos, setTodos] = useState<TodoItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showModal, setShowModal] = useState(false)
+  const [form, setForm] = useState({ title: '', description: '' })
+
+  const fetchData = async (): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/.netlify/functions/list', { credentials: 'include' })
+      const json = res.ok ? await res.json() : { data: { todos: [] } }
+      const list: TodoItem[] = Array.isArray(json) ? json : json.data?.todos || []
+      setTodos(list)
+    } catch (err: any) {
+      setError(err.message || 'Failed to load todos')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchData() }, [])
+
+  const handleCreate = async (e: FormEvent): Promise<void> => {
+    e.preventDefault()
+    try {
+      await fetch('/.netlify/functions/todos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: form.title, description: form.description }),
+      })
+      setShowModal(false)
+      setForm({ title: '', description: '' })
+      fetchData()
+    } catch (err: any) {
+      alert(err.message || 'Creation failed')
+    }
+  }
+
+  const now = Date.now()
+  const oneDay = 24 * 60 * 60 * 1000
+  const oneWeek = 7 * oneDay
+  const dayAgo = now - oneDay
+  const weekAgo = now - oneWeek
+
+  const addedDay = todos.filter(t => new Date(t.createdAt || t.created_at || '').getTime() > dayAgo).length
+  const addedWeek = todos.filter(t => new Date(t.createdAt || t.created_at || '').getTime() > weekAgo).length
+
+  const sorted = [...todos].sort((a, b) => {
+    const av = getLastViewed(a.id)
+    const bv = getLastViewed(b.id)
+    if (av !== bv) return bv - av
+    const at = new Date(a.createdAt || a.created_at || '').getTime()
+    const bt = new Date(b.createdAt || b.created_at || '').getTime()
+    return bt - at
+  })
+
+  return (
+    <div className="list-page">
+      <h1>Todos</h1>
+      {loading ? (
+        <LoadingSkeleton count={3} />
+      ) : error ? (
+        <p className="error">{error}</p>
+      ) : (
+        <>
+          <div className="metrics-grid">
+            <div className="metric-card">
+              <h3>Total: {todos.length}</h3>
+              <p>Added Today: {addedDay} Week: {addedWeek}</p>
+            </div>
+            <div>
+              <button onClick={() => setShowModal(true)}>Create Todo</button>
+            </div>
+          </div>
+          <ul className="tile-list">
+            {sorted.map(t => (
+              <li key={t.id}>
+                <Link
+                  to="/todo-demo"
+                  onClick={() => localStorage.setItem(`todo_last_viewed_${t.id}`, Date.now().toString())}
+                >
+                  {t.title || t.content}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {showModal && (
+        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <h2>Create Todo</h2>
+            <form onSubmit={handleCreate}>
+              <div className="form-group">
+                <label htmlFor="title">Title</label>
+                <input id="title" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+              </div>
+              <div className="form-group">
+                <label htmlFor="desc">Description</label>
+                <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
+              </div>
+              <div className="form-actions">
+                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
+                <button type="submit">Create</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/todoid.tsx
+++ b/todoid.tsx
@@ -40,6 +40,10 @@ export default function TodoPage({ mindmapId }: TodoPageProps) {
   const abortControllers = useRef<AbortController[]>([])
 
   useEffect(() => {
+    localStorage.setItem(`todo_last_viewed_${mindmapId}`, Date.now().toString())
+  }, [mindmapId])
+
+  useEffect(() => {
     const controller = new AbortController()
     abortControllers.current.push(controller)
     setLoading(true)


### PR DESCRIPTION
## Summary
- add pages to list mind maps, todos and kanban boards
- register routes to new pages
- track last viewed times for maps and todos

## Testing
- `npm test --silent` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_688003207c98832780c76336449ef7e9