### PR TITLE
Add new project canvas components

### DIFF
--- a/KanbanCanvas.tsx
+++ b/KanbanCanvas.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+
+interface Card { id: string; title: string }
+interface Lane { id: string; title: string; cards: Card[] }
+
+export default function KanbanCanvas() {
+  const [lanes, setLanes] = useState<Lane[]>([
+    { id: 'todo', title: 'To Do', cards: [] },
+    { id: 'doing', title: 'In Progress', cards: [] },
+    { id: 'done', title: 'Done', cards: [] }
+  ])
+  const [newCardTitle, setNewCardTitle] = useState('')
+  const [activeLane, setActiveLane] = useState('todo')
+
+  const addCard = () => {
+    const t = newCardTitle.trim()
+    if (!t) return
+    setLanes(prev =>
+      prev.map(l =>
+        l.id === activeLane
+          ? { ...l, cards: [...l.cards, { id: Date.now().toString(), title: t }] }
+          : l
+      )
+    )
+    setNewCardTitle('')
+  }
+
+  return (
+    <div className="kanban-canvas">
+      <div className="card-form">
+        <select value={activeLane} onChange={e => setActiveLane(e.target.value)}>
+          {lanes.map(l => (
+            <option key={l.id} value={l.id}>{l.title}</option>
+          ))}
+        </select>
+        <input
+          value={newCardTitle}
+          onChange={e => setNewCardTitle(e.target.value)}
+          placeholder="Card title"
+        />
+        <button onClick={addCard}>+</button>
+      </div>
+      <div className="kanban-board">
+        {lanes.map(lane => (
+          <div key={lane.id} className="kanban-lane">
+            <h3 className="lane-title">{lane.title}</h3>
+            {lane.cards.map(c => (
+              <div key={c.id} className="kanban-card">{c.title}</div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/ProjectWorkspace.tsx
+++ b/ProjectWorkspace.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import MindmapCanvas from './mindmapcanvas'
+import TodoCanvas from './TodoCanvas'
+import KanbanCanvas from './KanbanCanvas'
+
+const initialNodes = [
+  { id: '1', x: 100, y: 100, label: 'Idea' },
+  { id: '2', x: 300, y: 200, label: 'Task' }
+]
+const initialEdges = [{ id: 'e1', from: '1', to: '2' }]
+
+export default function ProjectWorkspace() {
+  const [tab, setTab] = useState<'mindmap' | 'todo' | 'kanban'>('mindmap')
+
+  return (
+    <div className="workspace-page">
+      <div className="tabs">
+        <button onClick={() => setTab('mindmap')}>Mind Map</button>
+        <button onClick={() => setTab('todo')}>Todos</button>
+        <button onClick={() => setTab('kanban')}>Kanban</button>
+      </div>
+      {tab === 'mindmap' && (
+        <MindmapCanvas nodes={initialNodes} edges={initialEdges} width={600} height={400} />
+      )}
+      {tab === 'todo' && <TodoCanvas />}
+      {tab === 'kanban' && <KanbanCanvas />}
+    </div>
+  )
+}

--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+interface Note {
+  id: string
+  text: string
+  author: string
+  date: string
+}
+
+interface Todo {
+  id: string
+  title: string
+  assignee?: string
+  notes: Note[]
+}
+
+export default function TodoCanvas() {
+  const [todos, setTodos] = useState<Todo[]>([])
+  const [title, setTitle] = useState('')
+  const [assignee, setAssignee] = useState('')
+
+  const addTodo = () => {
+    const t = title.trim()
+    if (!t) return
+    const newTodo: Todo = {
+      id: Date.now().toString(),
+      title: t,
+      assignee: assignee.trim() || undefined,
+      notes: []
+    }
+    setTodos(prev => [...prev, newTodo])
+    setTitle('')
+    setAssignee('')
+  }
+
+  const removeTodo = (id: string) => {
+    setTodos(prev => prev.filter(t => t.id !== id))
+  }
+
+  return (
+    <div className="todo-canvas">
+      <div className="todo-form">
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Todo title"
+        />
+        <input
+          value={assignee}
+          onChange={e => setAssignee(e.target.value)}
+          placeholder="Assignee"
+        />
+        <button onClick={addTodo}>Add</button>
+      </div>
+      <ul className="todo-list">
+        {todos.map(t => (
+          <li key={t.id} className="todo-item">
+            <Link to={`/todo/${t.id}`}>{t.title}</Link>
+            {t.assignee && <span className="assignee"> - {t.assignee}</span>}
+            <button onClick={() => removeTodo(t.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/TodoDetail.tsx
+++ b/TodoDetail.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+interface Note {
+  id: string
+  text: string
+  author: string
+  date: string
+}
+
+export default function TodoDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [notes, setNotes] = useState<Note[]>([])
+  const [text, setText] = useState('')
+  const addNote = () => {
+    const t = text.trim()
+    if (!t) return
+    setNotes(prev => [
+      ...prev,
+      { id: Date.now().toString(), text: t, author: 'me', date: new Date().toISOString() }
+    ])
+    setText('')
+  }
+  return (
+    <div className="todo-detail">
+      <h1>Todo {id}</h1>
+      <ul className="notes-list">
+        {notes.map(n => (
+          <li key={n.id}>
+            <strong>{n.author}</strong>: {n.text} <em>{n.date}</em>
+          </li>
+        ))}
+      </ul>
+      <div className="note-form">
+        <input value={text} onChange={e => setText(e.target.value)} placeholder="Add note" />
+        <button onClick={addNote}>Add</button>
+      </div>
+    </div>
+  )
+}

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -202,6 +202,17 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
         >
+          <defs>
+            <pattern
+              id="dot-grid"
+              width="50"
+              height="50"
+              patternUnits="userSpaceOnUse"
+            >
+              <circle cx="1" cy="1" r="1" fill="#ccc" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#dot-grid)" />
           <g
             transform={`translate(${transform.x},${transform.y}) scale(${transform.k})`}
           >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import Kanban from '../kanban'
 import MindmapsPage from '../MindmapsPage'
 import TodosPage from '../TodosPage'
 import KanbanBoardsPage from '../KanbanBoardsPage'
+import ProjectWorkspace from '../ProjectWorkspace'
+import TodoDetail from '../TodoDetail'
 import TeamMembers from '../teammembers'
 import ProfilePage from '../profile'
 import BillingPage from '../billing'
@@ -36,6 +38,8 @@ function AppRoutes() {
       <Route path="/mindmaps" element={<MindmapsPage />} />
       <Route path="/todos" element={<TodosPage />} />
       <Route path="/kanban" element={<KanbanBoardsPage />} />
+      <Route path="/workspace" element={<ProjectWorkspace />} />
+      <Route path="/todo/:id" element={<TodoDetail />} />
       <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/privacy" element={<PrivacyPolicy />} />
       <Route path="/terms" element={<TermsOfService />} />
@@ -54,7 +58,7 @@ function AppRoutes() {
 
 function RouterContent() {
   const location = useLocation()
-  const internal = /^\/(dashboard|mindmaps|todos|kanban|team-members|profile|billing|account)/.test(location.pathname)
+  const internal = /^\/(dashboard|mindmaps|todos|kanban|workspace|team-members|profile|billing|account)/.test(location.pathname)
 
   return internal ? (
     <div className="app-layout">

--- a/src/global.scss
+++ b/src/global.scss
@@ -1736,3 +1736,31 @@ hr {
 .form-actions .btn-ai:hover {
   opacity: 0.9;
 }
+
+.workspace-page .tabs {
+  margin-bottom: var(--spacing-lg);
+}
+
+.workspace-page .tabs button {
+  margin-right: var(--spacing-sm);
+}
+
+.todo-canvas .todo-form input {
+  margin-right: 4px;
+}
+
+.kanban-canvas .card-form {
+  margin-bottom: var(--spacing-sm);
+}
+
+.kanban-canvas .kanban-board {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-sm);
+}
+
+.kanban-canvas .kanban-lane {
+  background: var(--color-surface);
+  padding: var(--spacing-sm);
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- enhance `MindmapCanvas` with a dotted grid background
- create `TodoCanvas` for CRUD task management
- create `KanbanCanvas` with add-card capability
- add `TodoDetail` page for note timelines
- create `ProjectWorkspace` page hosting the canvases
- route `/workspace` and `/todo/:id` in the app
- style the new canvases

## Testing
- `npm test` *(fails: validateEnv.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_688005a67e1883279066db76c09d4e16