### PR TITLE
Fix base path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This project uses Netlify Functions and a Neon database. SQL migration files are
   npm run build
 ```
 
+If your site is served from a subdirectory (for example
+`https://example.com/mindmapx/`), set the `BASE_PATH` environment variable to
+that subpath when building. Vite will use this value for asset URLs and the
+React router will use it as its basename.
+
 Netlify automatically compiles the TypeScript functions in
 `netlify/functions/` during deployment.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ function AppRoutes() {
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Header />
       <ScrollToTop />
       <AppRoutes />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const base = process.env.BASE_PATH || '/'
+
 export default defineConfig({
   plugins: [react()],
-  base: '/', // ✅ use '/' unless you're deploying under a subpath
+  base,
   build: {
     rollupOptions: {
       external: ['immutable'],


### PR DESCRIPTION
## Summary
- make Vite base configurable with `BASE_PATH`
- pass `import.meta.env.BASE_URL` to `BrowserRouter`
- document how to set `BASE_PATH` for subdirectory deployments

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6880181f2f9c8327b5d1b6544ff88c49