### PR TITLE
Fix dashboard layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import Homepage from '../homepage'
 import AboutPage from '../about'
 import MindmapDemo from '../mindmapdemo'
@@ -25,6 +25,7 @@ import NotFound from './NotFound'
 import Header from './header'
 import Footer from './footer'
 import ScrollToTop from './ScrollToTop'
+import SidebarNav from './SidebarNav'
 
 function AppRoutes() {
   return (
@@ -55,13 +56,31 @@ function AppRoutes() {
   )
 }
 
+function AppLayout() {
+  const location = useLocation()
+  const isDashboard = location.pathname.startsWith('/dashboard')
+
+  return isDashboard ? (
+    <div className="app-layout">
+      <SidebarNav />
+      <div className="app-content">
+        <AppRoutes />
+      </div>
+    </div>
+  ) : (
+    <>
+      <Header />
+      <AppRoutes />
+      <Footer />
+    </>
+  )
+}
+
 export default function App() {
   return (
     <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <Header />
       <ScrollToTop />
-      <AppRoutes />
-      <Footer />
+      <AppLayout />
     </BrowserRouter>
   )
 }


### PR DESCRIPTION
## Summary
- add SidebarNav import
- conditionally load sidebar layout on `/dashboard`
- hide marketing header/footer for dashboard

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68801d5e5c348327a16c20d9c2f68c78