### PR TITLE
Use sidebar layout across account pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,19 @@ function AppRoutes() {
 
 function AppLayout() {
   const location = useLocation()
-  const isDashboard = location.pathname.startsWith('/dashboard')
+  const dashboardPaths = [
+    '/dashboard',
+    '/mindmaps',
+    '/todos',
+    '/kanban',
+    '/team-members',
+    '/profile',
+    '/billing',
+    '/account'
+  ]
+  const isDashboard = dashboardPaths.some(path =>
+    location.pathname.startsWith(path)
+  )
 
   return isDashboard ? (
     <div className="app-layout">


### PR DESCRIPTION
## Summary
- load the dashboard sidebar menu for all authenticated sections

## Testing
- `npm test --silent` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68801f9066908327b70cd1008061fcab