### PR TITLE
Improve workspace pages

### DIFF
--- a/account.tsx
+++ b/account.tsx
@@ -1,8 +1,10 @@
 import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 export default function AccountPage(): JSX.Element {
   return (
     <section className="section relative overflow-hidden">
+      <MindmapArm side="right" />
       <FaintMindmapBackground />
       <div className="form-card text-center space-y-4">
         <h1 className="text-2xl font-semibold mb-4">Account Settings</h1>

--- a/billing.tsx
+++ b/billing.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 interface BillingInfo {
   lastInvoiceDate: string
@@ -66,6 +67,7 @@ export default function BillingPage(): JSX.Element {
 
   return (
     <section className="section relative overflow-hidden">
+      <MindmapArm side="right" />
       <FaintMindmapBackground />
       <div className="form-card">
       <h1 className="text-2xl font-semibold mb-4">Billing Details</h1>

--- a/profile.tsx
+++ b/profile.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { ChangeEvent, FormEvent } from 'react'
+import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 interface Profile {
   name: string
@@ -55,16 +57,19 @@ export default function ProfilePage(): JSX.Element {
   }
 
   return (
-    <div className="profile-page container mx-auto p-6 max-w-lg">
-      <h1 className="text-2xl font-semibold mb-4">Update Profile</h1>
-      <img
-        src="./assets/profile-header.png"
-        alt="Profile header"
-        className="profile-image w-32 mx-auto mb-4"
-      />
-      {error && <div className="text-red-600 mb-4">{error}</div>}
-      {success && <div className="text-green-600 mb-4">Profile updated!</div>}
-      <form onSubmit={handleSubmit} className="space-y-4">
+    <section className="section relative overflow-hidden">
+      <MindmapArm side="right" />
+      <FaintMindmapBackground />
+      <div className="form-card text-center profile-page">
+        <h1 className="text-2xl font-semibold mb-4">Update Profile</h1>
+        <img
+          src="./assets/profile-header.png"
+          alt="Profile header"
+          className="profile-image w-32 mx-auto mb-4"
+        />
+        {error && <div className="text-red-600 mb-4">{error}</div>}
+        {success && <div className="text-green-600 mb-4">Profile updated!</div>}
+        <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label htmlFor="name" className="block mb-1">Name</label>
           <input
@@ -106,7 +111,8 @@ export default function ProfilePage(): JSX.Element {
         >
           {loading ? 'Saving...' : 'Save Profile'}
         </button>
-      </form>
-    </div>
+        </form>
+      </div>
+    </section>
   )
 }

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
+import FaintMindmapBackground from '../FaintMindmapBackground'
+import MindmapArm from '../MindmapArm'
 
 interface BoardItem {
   id: string
@@ -73,7 +75,9 @@ export default function KanbanBoardsPage(): JSX.Element {
   })
 
   return (
-    <div className="list-page">
+    <section className="section relative overflow-hidden list-page">
+      <MindmapArm side="left" />
+      <FaintMindmapBackground className="mindmap-bg-small" />
       <h1>Kanban Boards</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
@@ -86,22 +90,37 @@ export default function KanbanBoardsPage(): JSX.Element {
               <h3>Total: {boards.length}</h3>
               <p>Today: {boardDay} Week: {boardWeek}</p>
             </div>
-            <div>
-              <button onClick={() => setShowModal(true)}>Create Board</button>
+          </div>
+          <div className="tiles-grid">
+            <div className="tile">
+              <div className="tile-header">
+                <h2>Create Board</h2>
+                <button onClick={() => setShowModal(true)}>Create</button>
+              </div>
+            </div>
+            <div className="tile">
+              <div className="tile-header">
+                <h2>Your Boards</h2>
+              </div>
+              <ul className="recent-list">
+                {sorted.map(b => (
+                  <li key={b.id}>
+                    <Link
+                      to="/kanban"
+                      onClick={() =>
+                        localStorage.setItem(
+                          `board_last_viewed_${b.id}`,
+                          Date.now().toString()
+                        )
+                      }
+                    >
+                      {b.title || 'Board'}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
-          <ul className="tile-list">
-            {sorted.map(b => (
-              <li key={b.id}>
-                <Link
-                  to="/kanban"
-                  onClick={() => localStorage.setItem(`board_last_viewed_${b.id}`, Date.now().toString())}
-                >
-                  {b.title || 'Board'}
-                </Link>
-              </li>
-            ))}
-          </ul>
         </>
       )}
       {showModal && (
@@ -121,6 +140,6 @@ export default function KanbanBoardsPage(): JSX.Element {
           </div>
         </div>
       )}
-    </div>
+    </section>
   )
 }

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
+import FaintMindmapBackground from '../FaintMindmapBackground'
+import MindmapArm from '../MindmapArm'
 
 interface MapItem {
   id: string
@@ -72,7 +74,9 @@ export default function MindmapsPage(): JSX.Element {
   })
 
   return (
-    <div className="list-page">
+    <section className="section relative overflow-hidden list-page">
+      <MindmapArm side="left" />
+      <FaintMindmapBackground className="mindmap-bg-small" />
       <h1>Mind Maps</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
@@ -85,22 +89,37 @@ export default function MindmapsPage(): JSX.Element {
               <h3>Total: {maps.length}</h3>
               <p>Today: {mapDay} Week: {mapWeek}</p>
             </div>
-            <div>
-              <button onClick={() => setShowModal(true)}>Create Map</button>
+          </div>
+          <div className="tiles-grid">
+            <div className="tile">
+              <div className="tile-header">
+                <h2>Create Mind Map</h2>
+                <button onClick={() => setShowModal(true)}>Create</button>
+              </div>
+            </div>
+            <div className="tile">
+              <div className="tile-header">
+                <h2>Your Maps</h2>
+              </div>
+              <ul className="recent-list">
+                {sorted.map(m => (
+                  <li key={m.id}>
+                    <Link
+                      to={`/maps/${m.id}`}
+                      onClick={() =>
+                        localStorage.setItem(
+                          `mindmap_last_viewed_${m.id}`,
+                          Date.now().toString()
+                        )
+                      }
+                    >
+                      {m.title || 'Untitled Map'}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
-          <ul className="tile-list">
-            {sorted.map(m => (
-              <li key={m.id}>
-                <Link
-                  to={`/maps/${m.id}`}
-                  onClick={() => localStorage.setItem(`mindmap_last_viewed_${m.id}`, Date.now().toString())}
-                >
-                  {m.title || 'Untitled Map'}
-                </Link>
-              </li>
-            ))}
-          </ul>
         </>
       )}
       {showModal && (
@@ -110,11 +129,21 @@ export default function MindmapsPage(): JSX.Element {
             <form onSubmit={handleCreate}>
               <div className="form-group">
                 <label htmlFor="title">Title</label>
-                <input id="title" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+                <input
+                  id="title"
+                  value={form.title}
+                  onChange={e => setForm({ ...form, title: e.target.value })}
+                  required
+                />
               </div>
               <div className="form-group">
                 <label htmlFor="desc">Description</label>
-                <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
+                <textarea
+                  id="desc"
+                  value={form.description}
+                  onChange={e => setForm({ ...form, description: e.target.value })}
+                  rows={3}
+                />
               </div>
               <div className="form-actions">
                 <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
@@ -124,6 +153,6 @@ export default function MindmapsPage(): JSX.Element {
           </div>
         </div>
       )}
-    </div>
+    </section>
   )
 }

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
+import FaintMindmapBackground from '../FaintMindmapBackground'
+import MindmapArm from '../MindmapArm'
 
 interface TodoItem {
   id: string
@@ -75,7 +77,9 @@ export default function TodosPage(): JSX.Element {
   })
 
   return (
-    <div className="list-page">
+    <section className="section relative overflow-hidden list-page">
+      <MindmapArm side="left" />
+      <FaintMindmapBackground className="mindmap-bg-small" />
       <h1>Todos</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
@@ -88,22 +92,37 @@ export default function TodosPage(): JSX.Element {
               <h3>Total: {todos.length}</h3>
               <p>Added Today: {addedDay} Week: {addedWeek}</p>
             </div>
-            <div>
-              <button onClick={() => setShowModal(true)}>Create Todo</button>
+          </div>
+          <div className="tiles-grid">
+            <div className="tile">
+              <div className="tile-header">
+                <h2>Create Todo</h2>
+                <button onClick={() => setShowModal(true)}>Create</button>
+              </div>
+            </div>
+            <div className="tile">
+              <div className="tile-header">
+                <h2>Your Todos</h2>
+              </div>
+              <ul className="recent-list">
+                {sorted.map(t => (
+                  <li key={t.id}>
+                    <Link
+                      to="/todo-demo"
+                      onClick={() =>
+                        localStorage.setItem(
+                          `todo_last_viewed_${t.id}`,
+                          Date.now().toString()
+                        )
+                      }
+                    >
+                      {t.title || t.content}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </div>
           </div>
-          <ul className="tile-list">
-            {sorted.map(t => (
-              <li key={t.id}>
-                <Link
-                  to="/todo-demo"
-                  onClick={() => localStorage.setItem(`todo_last_viewed_${t.id}`, Date.now().toString())}
-                >
-                  {t.title || t.content}
-                </Link>
-              </li>
-            ))}
-          </ul>
         </>
       )}
       {showModal && (
@@ -127,6 +146,6 @@ export default function TodosPage(): JSX.Element {
           </div>
         </div>
       )}
-    </div>
+    </section>
   )
 }

--- a/teammembers.tsx
+++ b/teammembers.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 interface Member {
   id: string
@@ -46,35 +48,39 @@ export default function TeamMembers() {
   }, [])
 
   return (
-    <div className="max-w-md mx-auto p-4">
-      <h1 className="text-xl font-bold mb-4">Team Members</h1>
-      {error && <div className="text-red-600 mb-2">{error}</div>}
-      <form onSubmit={addMember} className="mb-4 flex flex-col gap-2">
-        <input
-          type="text"
-          value={name}
-          onChange={e => setName(e.target.value)}
-          placeholder="Name"
-          className="border px-2 py-1"
-          required
-        />
-        <input
-          type="email"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-          placeholder="Email"
-          className="border px-2 py-1"
-          required
-        />
-        <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded self-start">
-          Add
-        </button>
-      </form>
-      <ul className="list-disc pl-5">
-        {members.map(m => (
-          <li key={m.id}>{m.name ? `${m.name} <${m.email}>` : m.email}</li>
-        ))}
-      </ul>
-    </div>
+    <section className="section relative overflow-hidden">
+      <MindmapArm side="right" />
+      <FaintMindmapBackground />
+      <div className="form-card text-center">
+        <h1 className="text-xl font-bold mb-4">Team Members</h1>
+        {error && <div className="text-red-600 mb-2">{error}</div>}
+        <form onSubmit={addMember} className="mb-4 flex flex-col gap-2">
+          <input
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            placeholder="Name"
+            className="form-input"
+            required
+          />
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="Email"
+            className="form-input"
+            required
+          />
+          <button type="submit" className="btn self-center">
+            Add
+          </button>
+        </form>
+        <ul className="list-disc pl-5 text-left">
+          {members.map(m => (
+            <li key={m.id}>{m.name ? `${m.name} <${m.email}>` : m.email}</li>
+          ))}
+        </ul>
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- enhance list pages with MindmapArm art and tile layouts
- center team members form in a new card and use brand styles
- polish profile, billing and account pages with branding

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68802605fb108327bac8f4630a591ca8