### PR TITLE
Improve dashboard headers

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -96,7 +96,7 @@ export default function DashboardPage(): JSX.Element {
 
   return (
     <div className="dashboard-page">
-      <h1 className="dashboard-title">Dashboard</h1>
+      <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Dashboard</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
       ) : error ? (

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -235,7 +235,7 @@ export default function DashboardPage(): JSX.Element {
       <FaintMindmapBackground className="mindmap-bg-small" />
       <MindmapArm side="left" />
       <MindmapArm side="right" />
-      <h1 className="dashboard-title">Dashboard</h1>
+      <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Dashboard</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
       ) : error ? (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1518,8 +1518,23 @@ hr {
 }
 
 .dashboard-title {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-sm);
   margin-bottom: var(--spacing-xl);
+}
+.dashboard-title .dashboard-logo {
+  height: 60px;
+  vertical-align: middle;
+}
+@media (max-width: 640px) {
+  .dashboard-title {
+    flex-direction: column;
+  }
+  .dashboard-title .dashboard-logo {
+    margin-bottom: var(--spacing-sm);
+  }
 }
 
 .metrics-grid {

--- a/tododashboard.tsx
+++ b/tododashboard.tsx
@@ -91,6 +91,7 @@ export default function TodoDashboard() {
 
   return (
     <div className="todo-dashboard">
+  <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Todos</h1>
       <div className="controls">
         <div className="filters">
           <button disabled={filter === 'all'} onClick={() => handleFilter('all')}>All</button>


### PR DESCRIPTION
## Summary
- center the dashboard title on each dashboard page
- add logo left of dashboard title
- keep todo dashboard consistent
- style dashboard titles for logos

## Testing
- `npm test` *(fails: testCodeFailure)*

------
https://chatgpt.com/codex/tasks/task_e_68802b6415c4832787692eee859653d4