### PR TITLE
Unify dashboard modals

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -159,20 +159,25 @@ export default function DashboardPage(): JSX.Element {
       )}
       {showModal && (
         <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
-          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
-            <h2>Create {createType === 'map' ? 'Mind Map' : 'Todo'}</h2>
+          <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <span className="flare-line" aria-hidden="true"></span>
+            <h2 className="fade-item">Create {createType === 'map' ? 'Mind Map' : 'Todo'}</h2>
             <form onSubmit={handleCreate}>
-              <div className="form-group">
-                <label htmlFor="title">Title</label>
-                <input id="title" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+              <div className="form-field fade-item" style={{ animationDelay: '0.1s' }}>
+                <label htmlFor="title" className="form-label">Title</label>
+                <input id="title" className="form-input" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
               </div>
-              <div className="form-group">
-                <label htmlFor="desc">Description</label>
-                <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
+              <div className="form-field fade-item" style={{ animationDelay: '0.2s' }}>
+                <label htmlFor="desc" className="form-label">Description</label>
+                <textarea id="desc" className="form-input" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
               </div>
               <div className="form-actions">
-                <button type="button" className="btn-cancel" onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit" className="btn-primary">Create</button>
+                <button type="button" className="btn-cancel fade-item" style={{ animationDelay: '0.3s' }} onClick={() => setShowModal(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary fade-item" style={{ animationDelay: '0.3s' }}>
+                  Create
+                </button>
               </div>
             </form>
           </div>

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -120,16 +120,21 @@ export default function KanbanBoardsPage(): JSX.Element {
       )}
       {showModal && (
         <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
-          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
-            <h2>Create Board</h2>
+          <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <span className="flare-line" aria-hidden="true"></span>
+            <h2 className="fade-item">Create Board</h2>
             <form onSubmit={handleCreate}>
-              <div className="form-group">
-                <label htmlFor="title">Title</label>
-                <input id="title" value={form.title} onChange={e => setForm({ title: e.target.value })} required />
+              <div className="form-field fade-item" style={{ animationDelay: '0.1s' }}>
+                <label htmlFor="title" className="form-label">Title</label>
+                <input id="title" className="form-input" value={form.title} onChange={e => setForm({ title: e.target.value })} required />
               </div>
               <div className="form-actions">
-                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit">Create</button>
+                <button type="button" className="btn-cancel fade-item" style={{ animationDelay: '0.2s' }} onClick={() => setShowModal(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary fade-item" style={{ animationDelay: '0.2s' }}>
+                  Create
+                </button>
               </div>
             </form>
           </div>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -117,30 +117,37 @@ export default function MindmapsPage(): JSX.Element {
       )}
       {showModal && (
         <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
-          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
-            <h2>Create Mind Map</h2>
+          <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <span className="flare-line" aria-hidden="true"></span>
+            <h2 className="fade-item">Create Mind Map</h2>
             <form onSubmit={handleCreate}>
-              <div className="form-group">
-                <label htmlFor="title">Title</label>
+              <div className="form-field fade-item" style={{ animationDelay: '0.1s' }}>
+                <label htmlFor="title" className="form-label">Title</label>
                 <input
                   id="title"
+                  className="form-input"
                   value={form.title}
                   onChange={e => setForm({ ...form, title: e.target.value })}
                   required
                 />
               </div>
-              <div className="form-group">
-                <label htmlFor="desc">Description</label>
+              <div className="form-field fade-item" style={{ animationDelay: '0.2s' }}>
+                <label htmlFor="desc" className="form-label">Description</label>
                 <textarea
                   id="desc"
+                  className="form-input"
                   value={form.description}
                   onChange={e => setForm({ ...form, description: e.target.value })}
                   rows={3}
                 />
               </div>
               <div className="form-actions">
-                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit">Create</button>
+                <button type="button" className="btn-cancel fade-item" style={{ animationDelay: '0.3s' }} onClick={() => setShowModal(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary fade-item" style={{ animationDelay: '0.3s' }}>
+                  Create
+                </button>
               </div>
             </form>
           </div>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -122,20 +122,25 @@ export default function TodosPage(): JSX.Element {
       )}
       {showModal && (
         <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
-          <div className="modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
-            <h2>Create Todo</h2>
+          <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+            <span className="flare-line" aria-hidden="true"></span>
+            <h2 className="fade-item">Create Todo</h2>
             <form onSubmit={handleCreate}>
-              <div className="form-group">
-                <label htmlFor="title">Title</label>
-                <input id="title" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
+              <div className="form-field fade-item" style={{ animationDelay: '0.1s' }}>
+                <label htmlFor="title" className="form-label">Title</label>
+                <input id="title" className="form-input" value={form.title} onChange={e => setForm({ ...form, title: e.target.value })} required />
               </div>
-              <div className="form-group">
-                <label htmlFor="desc">Description</label>
-                <textarea id="desc" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
+              <div className="form-field fade-item" style={{ animationDelay: '0.2s' }}>
+                <label htmlFor="desc" className="form-label">Description</label>
+                <textarea id="desc" className="form-input" value={form.description} onChange={e => setForm({ ...form, description: e.target.value })} rows={3} />
               </div>
               <div className="form-actions">
-                <button type="button" onClick={() => setShowModal(false)}>Cancel</button>
-                <button type="submit">Create</button>
+                <button type="button" className="btn-cancel fade-item" style={{ animationDelay: '0.3s' }} onClick={() => setShowModal(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="btn-primary fade-item" style={{ animationDelay: '0.3s' }}>
+                  Create
+                </button>
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Summary
- restyle modal components across dashboard pages to use the same `fancy-modal` markup

## Testing
- `npm test --silent` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68802cfc9cec8327b9c43ca5b061f2e9