### PR TITLE
Add logo headers to list pages

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -75,10 +75,10 @@ export default function KanbanBoardsPage(): JSX.Element {
   })
 
   return (
-    <section className="section relative overflow-hidden list-page">
+    <div className="dashboard-page relative overflow-hidden list-page">
       <MindmapArm side="left" />
       <FaintMindmapBackground className="mindmap-bg-small" />
-      <h1>Kanban Boards</h1>
+      <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Kanban Boards</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
       ) : error ? (
@@ -140,6 +140,6 @@ export default function KanbanBoardsPage(): JSX.Element {
           </div>
         </div>
       )}
-    </section>
+    </div>
   )
 }

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -74,10 +74,10 @@ export default function MindmapsPage(): JSX.Element {
   })
 
   return (
-    <section className="section relative overflow-hidden list-page">
+    <div className="dashboard-page relative overflow-hidden list-page">
       <MindmapArm side="left" />
       <FaintMindmapBackground className="mindmap-bg-small" />
-      <h1>Mind Maps</h1>
+      <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Mind Maps</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
       ) : error ? (
@@ -153,6 +153,6 @@ export default function MindmapsPage(): JSX.Element {
           </div>
         </div>
       )}
-    </section>
+    </div>
   )
 }

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -77,10 +77,10 @@ export default function TodosPage(): JSX.Element {
   })
 
   return (
-    <section className="section relative overflow-hidden list-page">
+    <div className="dashboard-page relative overflow-hidden list-page">
       <MindmapArm side="left" />
       <FaintMindmapBackground className="mindmap-bg-small" />
-      <h1>Todos</h1>
+      <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Todos</h1>
       {loading ? (
         <LoadingSkeleton count={3} />
       ) : error ? (
@@ -146,6 +146,6 @@ export default function TodosPage(): JSX.Element {
           </div>
         </div>
       )}
-    </section>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- add logo header like dashboard
- use `dashboard-page` container for mindmap, todo, and kanban pages

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68802e87c1408327b8a31f61930242f0