### PR TITLE
Center create buttons on dashboard tiles

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -99,13 +99,12 @@ export default function KanbanBoardsPage(): JSX.Element {
       ) : error ? (
         <p className="error">{error}</p>
       ) : (
-        <>
+        <> 
           <div className="four-col-grid">
-            <div className="tile">
-              <div className="tile-header">
-                <h2>Create Board</h2>
-                <button onClick={() => setShowModal(true)}>Create</button>
-              </div>
+            <div className="tile create-tile">
+              <h2>Create Board</h2>
+              <p className="create-help">Click Create to manually add or use AI to get started.</p>
+              <button onClick={() => setShowModal(true)}>Create</button>
             </div>
             <div className="tile">
               <h2 className="tile-header">Metrics</h2>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -103,11 +103,10 @@ export default function MindmapsPage(): JSX.Element {
         <p className="error">{error}</p>
       ) : (
         <div className="four-col-grid">
-          <div className="tile">
-            <div className="tile-header">
-              <h2>Create Mind Map</h2>
-              <button onClick={() => setShowModal(true)}>Create</button>
-            </div>
+          <div className="tile create-tile">
+            <h2>Create Mind Map</h2>
+            <p className="create-help">Click Create to manually add or use AI to get started.</p>
+            <button onClick={() => setShowModal(true)}>Create</button>
           </div>
           <div className="tile">
             <h2 className="tile-header">Metrics</h2>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -101,13 +101,12 @@ export default function TodosPage(): JSX.Element {
       ) : error ? (
         <p className="error">{error}</p>
       ) : (
-        <>
+        <> 
           <div className="four-col-grid">
-            <div className="tile">
-              <div className="tile-header">
-                <h2>Create Todo</h2>
-                <button onClick={() => setShowModal(true)}>Create</button>
-              </div>
+            <div className="tile create-tile">
+              <h2>Create Todo</h2>
+              <p className="create-help">Click Create to manually add or use AI to get started.</p>
+              <button onClick={() => setShowModal(true)}>Create</button>
             </div>
             <div className="tile">
               <h2 className="tile-header">Metrics</h2>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1633,6 +1633,25 @@ hr {
   margin-bottom: var(--spacing-xs);
 }
 
+/* style for create tiles */
+.create-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 150px;
+}
+
+.create-tile button {
+  margin-top: var(--spacing-md);
+}
+
+.create-help {
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
 .modal-overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary
- rework create tiles on Mindmaps, Todos and Kanban Boards pages
- center the create button and add helper text
- add `create-tile` styles

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_688031a015448327ae064a9ce18ba6ff