### PR TITLE
Refine team members layout and add background to dashboards

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from './loadingskeleton'
+import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 interface MapItem {
   id: string
@@ -122,7 +124,10 @@ export default function DashboardPage(): JSX.Element {
   const todoDoneWeek = todos.filter(t => t.completed && new Date(t.updatedAt || t.updated_at || '').getTime() > weekAgo).length
 
   return (
-    <div className="dashboard-page">
+    <div className="dashboard-page relative overflow-hidden">
+      <MindmapArm side="left" />
+      <MindmapArm side="right" />
+      <FaintMindmapBackground className="mindmap-bg-small" />
       <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Dashboard</h1>
       {loading ? (
         <LoadingSkeleton count={3} />

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -80,7 +80,7 @@ export default function Kanban(): JSX.Element {
   return (
     <div className="kanban-demo-page">
       <section className="kanban-demo section reveal relative overflow-x-visible">
-        <FaintMindmapBackground />
+        <FaintMindmapBackground className="mindmap-bg-small" />
         <div className="container">
           <div className="max-w-2xl mx-auto mb-8 text-center">
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>

--- a/teammembers.tsx
+++ b/teammembers.tsx
@@ -59,27 +59,37 @@ export default function TeamMembers() {
     <section className="section relative overflow-hidden">
       <MindmapArm side="right" />
       <FaintMindmapBackground />
-      <h1>Team Members</h1>
       <div className="form-card text-center">
+        <h1 className="mb-4">Team Members</h1>
         {error && <div className="text-red-600 mb-2">{error}</div>}
-        <form onSubmit={addMember} className="mb-4 flex flex-col gap-2">
-          <input
-            type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            placeholder="Name"
-            className="form-input"
-            required
-          />
-          <input
-            type="email"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-            placeholder="Email"
-            className="form-input"
-            required
-          />
-          <button type="submit" className="btn self-center">
+        <form onSubmit={addMember} className="mb-4 space-y-4">
+          <div className="form-field text-left">
+            <label htmlFor="name" className="form-label">
+              Name
+            </label>
+            <input
+              id="name"
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="form-input"
+              required
+            />
+          </div>
+          <div className="form-field text-left">
+            <label htmlFor="email" className="form-label">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              className="form-input"
+              required
+            />
+          </div>
+          <button type="submit" className="btn w-full">
             Add
           </button>
         </form>

--- a/tododashboard.tsx
+++ b/tododashboard.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react'
 import LoadingSkeleton from './loadingskeleton'
+import FaintMindmapBackground from './FaintMindmapBackground'
+import MindmapArm from './MindmapArm'
 
 export default function TodoDashboard() {
   const [todos, setTodos] = useState<Todo[]>([])
@@ -90,8 +92,10 @@ export default function TodoDashboard() {
   })
 
   return (
-    <div className="todo-dashboard">
-  <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Todos</h1>
+    <div className="todo-dashboard relative overflow-hidden">
+      <MindmapArm side="left" />
+      <FaintMindmapBackground className="mindmap-bg-small" />
+      <h1 className="dashboard-title"><img src="./assets/logo.png" alt="MindXdo logo" className="dashboard-logo" /> Todos</h1>
       <div className="controls">
         <div className="filters">
           <button disabled={filter === 'all'} onClick={() => handleFilter('all')}>All</button>


### PR DESCRIPTION
## Summary
- restyle team members page with cleaner form layout
- include faint mind map background on dashboard pages
- adjust kanban demo background style

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_688033b991048327ad647fbe47674e29