### PR TITLE
Center dashboard create buttons

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -267,12 +267,10 @@ export default function DashboardPage(): JSX.Element {
           </div>
           <div className="tiles-grid">
             <div className="tile" onClick={handleTileClick}>
-              <div className="tile-header">
+              <div className="tile-header tile-header-center">
                 <h2>Mind Maps</h2>
-                <div className="tile-actions">
-                  <button onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
-                  <Link to="/mindmaps" className="tile-link">Open Mind Maps</Link>
-                </div>
+                <button onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
+                <Link to="/mindmaps" className="tile-link">Open Mind Maps</Link>
               </div>
               <ul className="recent-list">
                 {recentMaps.map(m => (
@@ -283,12 +281,10 @@ export default function DashboardPage(): JSX.Element {
               </ul>
             </div>
             <div className="tile" onClick={handleTileClick}>
-              <div className="tile-header">
+              <div className="tile-header tile-header-center">
                 <h2>Todos</h2>
-                <div className="tile-actions">
-                  <button onClick={() => { setCreateType('todo'); setShowModal(true) }}>Create</button>
-                  <Link to="/todos" className="tile-link">Open Todos</Link>
-                </div>
+                <button onClick={() => { setCreateType('todo'); setShowModal(true) }}>Create</button>
+                <Link to="/todos" className="tile-link">Open Todos</Link>
               </div>
               <ul className="recent-list">
                 {recentTodos.map(t => (
@@ -300,12 +296,10 @@ export default function DashboardPage(): JSX.Element {
               </ul>
             </div>
             <div className="tile" onClick={handleTileClick}>
-              <div className="tile-header">
+              <div className="tile-header tile-header-center">
                 <h2>Kanban Boards</h2>
-                <div className="tile-actions">
-                  <button onClick={() => { setCreateType('board'); setShowModal(true) }}>Create</button>
-                  <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
-                </div>
+                <button onClick={() => { setCreateType('board'); setShowModal(true) }}>Create</button>
+                <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
               </div>
               <ul className="recent-list">
                 {recentBoards.map(b => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1645,6 +1645,35 @@ hr {
 
 .create-tile button {
   margin-top: var(--spacing-md);
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-duration) var(--transition-ease);
+}
+
+.create-tile button:hover {
+  background-color: var(--color-warning);
+}
+
+.tile-header-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.tile-header-center button {
+  margin-top: var(--spacing-sm);
+}
+
+.tile-header-center .tile-link {
+  margin-top: var(--spacing-xs);
+  font-size: 0.85rem;
+  color: var(--color-primary);
+  text-decoration: underline;
 }
 
 .create-help {


### PR DESCRIPTION
## Summary
- style create tile buttons like dashboard blue buttons
- center dashboard tile header controls and move link below

## Testing
- `npm test` *(fails: testCodeFailure)*

------
https://chatgpt.com/codex/tasks/task_e_688035a8e860832793b7ae68e7f6b0d9