### PR TITLE
Add map editor and redirect after creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import MindmapsPage from './MindmapsPage'
 import TodosPage from './TodosPage'
 import KanbanBoardsPage from './KanbanBoardsPage'
 import ProjectWorkspace from '../ProjectWorkspace'
+import MapEditorPage from './MapEditorPage'
 import TodoDetail from '../TodoDetail'
 import TeamMembers from '../teammembers'
 import ProfilePage from '../profile'
@@ -38,6 +39,7 @@ function AppRoutes() {
       <Route path="/mindmaps" element={<MindmapsPage />} />
       <Route path="/todos" element={<TodosPage />} />
       <Route path="/kanban" element={<KanbanBoardsPage />} />
+      <Route path="/maps/:id" element={<MapEditorPage />} />
       <Route path="/workspace" element={<ProjectWorkspace />} />
       <Route path="/todo/:id" element={<TodoDetail />} />
       <Route path="/reset-password" element={<ResetPassword />} />

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
@@ -47,6 +47,7 @@ export default function DashboardPage(): JSX.Element {
   const [showModal, setShowModal] = useState(false)
   const [createType, setCreateType] = useState<'map' | 'todo' | 'board'>('map')
   const [form, setForm] = useState({ title: '', description: '' })
+  const navigate = useNavigate()
 
   const fetchData = async (): Promise<void> => {
     setLoading(true)
@@ -90,11 +91,15 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       if (createType === 'map') {
-        await fetch('/.netlify/functions/create', {
+        const res = await fetch('/.netlify/functions/create', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(form),
         })
+        const json = await res.json()
+        if (json?.mindMap?.id) {
+          navigate(`/maps/${json.mindMap.id}`)
+        }
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
@@ -119,7 +124,7 @@ export default function DashboardPage(): JSX.Element {
   const handleAiCreate = async (): Promise<void> => {
     try {
       if (createType === 'map') {
-        await fetch('/.netlify/functions/ai-create-mindmap', {
+        const res = await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -128,6 +133,10 @@ export default function DashboardPage(): JSX.Element {
             prompt: form.description,
           }),
         })
+        const json = await res.json()
+        if (json?.id) {
+          navigate(`/maps/${json.id}`)
+        }
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+interface NodeData {
+  id: string
+  content: string
+  parentId?: string
+}
+
+interface MapData {
+  id: string
+  title: string
+  nodes: NodeData[]
+}
+
+async function loadMap(id: string, signal?: AbortSignal): Promise<MapData> {
+  const res = await fetch(`/api/maps/${id}`, { signal })
+  if (!res.ok) throw new Error(`Failed to load map: ${res.status}`)
+  return res.json()
+}
+
+async function saveMap(map: MapData): Promise<void> {
+  const res = await fetch(`/api/maps/${map.id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(map),
+  })
+  if (!res.ok) throw new Error(`Failed to save map: ${res.status}`)
+}
+
+export default function MapEditorPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>()
+  const mapId = id || ''
+  const [map, setMap] = useState<MapData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [trigger, setTrigger] = useState(0)
+
+  useEffect(() => {
+    if (!mapId) return
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+    loadMap(mapId, controller.signal)
+      .then(data => setMap(data))
+      .catch(err => { if (err.name !== 'AbortError') setError(err.message) })
+      .finally(() => setLoading(false))
+    return () => controller.abort()
+  }, [mapId, trigger])
+
+  const reload = useCallback(() => setTrigger(t => t + 1), [])
+
+  const addNode = useCallback((parentId?: string) => {
+    setMap(prev => {
+      if (!prev) return prev
+      const newNode: NodeData = { id: crypto.randomUUID(), content: '', parentId }
+      return { ...prev, nodes: [...prev.nodes, newNode] }
+    })
+  }, [])
+
+  const updateNode = useCallback((node: NodeData) => {
+    setMap(prev => {
+      if (!prev) return prev
+      return { ...prev, nodes: prev.nodes.map(n => (n.id === node.id ? node : n)) }
+    })
+  }, [])
+
+  const deleteNode = useCallback((nodeId: string) => {
+    setMap(prev => {
+      if (!prev) return prev
+      return { ...prev, nodes: prev.nodes.filter(n => n.id !== nodeId) }
+    })
+  }, [])
+
+  const save = useCallback(async () => {
+    if (!map) return
+    setSaving(true)
+    setError(null)
+    try {
+      await saveMap(map)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setSaving(false)
+    }
+  }, [map])
+
+  if (!mapId) return <div>No map specified</div>
+  if (loading) return <div>Loading map...</div>
+  if (!map) return (
+    <div>
+      <p>Error loading map: {error}</p>
+      <button onClick={reload}>Retry</button>
+    </div>
+  )
+
+  return (
+    <div>
+      {error && <p>Error: {error}</p>}
+      <div>
+        <label>
+          Title:{' '}
+          <input
+            type="text"
+            value={map.title}
+            onChange={e => setMap(prev => prev ? { ...prev, title: e.target.value } : prev)}
+            disabled={saving}
+          />
+        </label>
+      </div>
+      <button onClick={() => addNode()} disabled={saving}>Add Root Node</button>
+      <ul>
+        {map.nodes.map(node => (
+          <li key={node.id}>
+            <input
+              type="text"
+              value={node.content}
+              onChange={e => updateNode({ ...node, content: e.target.value })}
+              disabled={saving}
+            />
+            <button onClick={() => addNode(node.id)} disabled={saving}>Add Child</button>
+            <button onClick={() => deleteNode(node.id)} disabled={saving}>Delete</button>
+          </li>
+        ))}
+      </ul>
+      <button onClick={save} disabled={saving}>{saving ? 'Saving...' : 'Save Map'}</button>
+    </div>
+  )
+}

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
@@ -22,6 +22,7 @@ export default function MindmapsPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
   const [form, setForm] = useState({ title: '', description: '' })
+  const navigate = useNavigate()
 
   const fetchData = async (): Promise<void> => {
     setLoading(true)
@@ -42,14 +43,19 @@ export default function MindmapsPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      await fetch('/.netlify/functions/create', {
+      const res = await fetch('/.netlify/functions/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form),
       })
+      const json = await res.json()
       setShowModal(false)
       setForm({ title: '', description: '' })
-      fetchData()
+      if (json?.mindMap?.id) {
+        navigate(`/maps/${json.mindMap.id}`)
+      } else {
+        fetchData()
+      }
     } catch (err: any) {
       alert(err.message || 'Creation failed')
     }
@@ -57,7 +63,7 @@ export default function MindmapsPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      await fetch('/.netlify/functions/ai-create-mindmap', {
+      const res = await fetch('/.netlify/functions/ai-create-mindmap', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -66,9 +72,14 @@ export default function MindmapsPage(): JSX.Element {
           prompt: form.description,
         }),
       })
+      const json = await res.json()
       setShowModal(false)
       setForm({ title: '', description: '' })
-      fetchData()
+      if (json?.id) {
+        navigate(`/maps/${json.id}`)
+      } else {
+        fetchData()
+      }
     } catch (err: any) {
       alert(err.message || 'AI creation failed')
     }


### PR DESCRIPTION
## Summary
- create `MapEditorPage` for editing mind maps
- add route `/maps/:id` to open the new editor
- redirect to the editor after creating a map on Dashboard and Mindmaps pages

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6880380f45108327b957f4b07d26b844