### PR TITLE
Style create buttons

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -157,7 +157,15 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile">
               <div className="tile-header">
                 <h2>Mind Maps</h2>
-                <button onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
+                <button
+                  className="btn-primary"
+                  onClick={() => {
+                    setCreateType('map')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
               </div>
               <ul>
                 {maps.map(m => (
@@ -170,7 +178,15 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile">
               <div className="tile-header">
                 <h2>Todos</h2>
-                <button onClick={() => { setCreateType('todo'); setShowModal(true) }}>Create</button>
+                <button
+                  className="btn-primary"
+                  onClick={() => {
+                    setCreateType('todo')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
               </div>
               <ul>
                 {todos.map(t => (

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -278,7 +278,15 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile" onClick={handleTileClick}>
               <div className="tile-header tile-header-center">
                 <h2>Mind Maps</h2>
-                <button onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
+                <button
+                  className="btn-primary"
+                  onClick={() => {
+                    setCreateType('map')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
                 <Link to="/mindmaps" className="tile-link">Open Mind Maps</Link>
               </div>
               <ul className="recent-list">
@@ -292,7 +300,15 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile" onClick={handleTileClick}>
               <div className="tile-header tile-header-center">
                 <h2>Todos</h2>
-                <button onClick={() => { setCreateType('todo'); setShowModal(true) }}>Create</button>
+                <button
+                  className="btn-primary"
+                  onClick={() => {
+                    setCreateType('todo')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
                 <Link to="/todos" className="tile-link">Open Todos</Link>
               </div>
               <ul className="recent-list">
@@ -307,7 +323,15 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile" onClick={handleTileClick}>
               <div className="tile-header tile-header-center">
                 <h2>Kanban Boards</h2>
-                <button onClick={() => { setCreateType('board'); setShowModal(true) }}>Create</button>
+                <button
+                  className="btn-primary"
+                  onClick={() => {
+                    setCreateType('board')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
                 <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
               </div>
               <ul className="recent-list">

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -104,7 +104,9 @@ export default function KanbanBoardsPage(): JSX.Element {
             <div className="tile create-tile">
               <h2>Create Board</h2>
               <p className="create-help">Click Create to manually add or use AI to get started.</p>
-              <button onClick={() => setShowModal(true)}>Create</button>
+              <button className="btn-primary" onClick={() => setShowModal(true)}>
+                Create
+              </button>
             </div>
             <div className="tile">
               <h2 className="tile-header">Metrics</h2>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -117,7 +117,9 @@ export default function MindmapsPage(): JSX.Element {
           <div className="tile create-tile">
             <h2>Create Mind Map</h2>
             <p className="create-help">Click Create to manually add or use AI to get started.</p>
-            <button onClick={() => setShowModal(true)}>Create</button>
+            <button className="btn-primary" onClick={() => setShowModal(true)}>
+              Create
+            </button>
           </div>
           <div className="tile">
             <h2 className="tile-header">Metrics</h2>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -106,7 +106,9 @@ export default function TodosPage(): JSX.Element {
             <div className="tile create-tile">
               <h2>Create Todo</h2>
               <p className="create-help">Click Create to manually add or use AI to get started.</p>
-              <button onClick={() => setShowModal(true)}>Create</button>
+              <button className="btn-primary" onClick={() => setShowModal(true)}>
+                Create
+              </button>
             </div>
             <div className="tile">
               <h2 className="tile-header">Metrics</h2>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1730,6 +1730,20 @@ hr {
   border-radius: 8px;
 }
 
+.btn-primary {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-duration) var(--transition-ease);
+}
+
+.btn-primary:hover {
+  background-color: var(--color-warning);
+}
+
 .tile-header button {
   background-color: var(--color-primary);
   color: var(--color-text-inverse);


### PR DESCRIPTION
## Summary
- add generic `.btn-primary` button style
- style dashboard create buttons
- style mindmaps, todos and kanban "Create" buttons

## Testing
- `npm test` *(fails: testCodeFailure)*

------
https://chatgpt.com/codex/tasks/task_e_68803ad4fc9483278f102f84e32c80b0