### PR TITLE
Fix mindmap creation redirect

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -9,6 +9,7 @@ interface MapItem {
   title?: string
   createdAt?: string
   created_at?: string
+  data?: { title?: string; [key: string]: any }
 }
 
 interface TodoItem {
@@ -62,10 +63,10 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       if (createType === 'map') {
-        await fetch('/.netlify/functions/create', {
+        await fetch('/.netlify/functions/index', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(form),
+          body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
       } else {
         await fetch('/.netlify/functions/todos', {
@@ -170,7 +171,7 @@ export default function DashboardPage(): JSX.Element {
               <ul>
                 {maps.map(m => (
                   <li key={m.id}>
-                    <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
+                    <Link to={`/maps/${m.id}`}>{m.title || (m as any).data?.title || 'Untitled Map'}</Link>
                   </li>
                 ))}
               </ul>

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -10,6 +10,7 @@ interface MapItem {
   title?: string
   createdAt?: string
   created_at?: string
+  data?: { title?: string; [key: string]: any }
 }
 
 interface TodoItem {
@@ -91,14 +92,14 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       if (createType === 'map') {
-        const res = await fetch('/.netlify/functions/create', {
+        const res = await fetch('/.netlify/functions/index', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(form),
+          body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
         const json = await res.json()
-        if (json?.mindMap?.id) {
-          navigate(`/maps/${json.mindMap.id}`)
+        if (json?.id) {
+          navigate(`/maps/${json.id}`)
         }
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
@@ -292,7 +293,7 @@ export default function DashboardPage(): JSX.Element {
               <ul className="recent-list">
                 {recentMaps.map(m => (
                   <li key={m.id}>
-                    <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
+                    <Link to={`/maps/${m.id}`}>{m.title || (m as any).data?.title || 'Untitled Map'}</Link>
                   </li>
                 ))}
               </ul>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -9,6 +9,7 @@ interface MapItem {
   title?: string
   createdAt?: string
   created_at?: string
+  data?: { title?: string; [key: string]: any }
 }
 
 const getLastViewed = (id: string): number => {
@@ -43,16 +44,16 @@ export default function MindmapsPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const res = await fetch('/.netlify/functions/create', {
+      const res = await fetch('/.netlify/functions/index', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(form),
+        body: JSON.stringify({ data: { title: form.title, description: form.description } }),
       })
       const json = await res.json()
       setShowModal(false)
       setForm({ title: '', description: '' })
-      if (json?.mindMap?.id) {
-        navigate(`/maps/${json.mindMap.id}`)
+      if (json?.id) {
+        navigate(`/maps/${json.id}`)
       } else {
         fetchData()
       }
@@ -129,7 +130,7 @@ export default function MindmapsPage(): JSX.Element {
           {sorted.map(m => (
             <div className="tile" key={m.id}>
               <div className="tile-header">
-                <h2>{m.title || 'Untitled Map'}</h2>
+                <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
                 <Link
                   to={`/maps/${m.id}`}
                   onClick={() =>


### PR DESCRIPTION
## Summary
- ensure map creation posts to index endpoint
- support map data titles when listing maps

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68803bfc6d708327a2fabd284eb2101d