### PR TITLE
Fix link to Kanban demo in header

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -22,7 +22,7 @@ const Header = (): JSX.Element => {
     { label: 'About', route: '/about' },
     { label: 'Mindmap', route: '/mindmap-demo' },
     { label: 'Todo', route: '/todo-demo' },
-    { label: 'KanBan', route: '/kanban' },
+    { label: 'KanBan', route: '/kanban-demo' },
     { label: 'Purchase', route: '/purchase' },
   ]
 


### PR DESCRIPTION
## Summary
- update header navigation to point the Kanban menu item at `/kanban-demo`

## Testing
- `npm test` *(fails: Cannot find package 'typescript' and node:test does not provide expect)*

------
https://chatgpt.com/codex/tasks/task_e_68804968285c83279d3f14393797f5cb