### PR TITLE
Fix quick create auth header

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -69,17 +69,26 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
       if (createType === 'map') {
-        await authFetch('/.netlify/functions/index', {
+        await fetch('/.netlify/functions/index', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
       } else {
-        await authFetch('/.netlify/functions/todos', {
+        await fetch('/.netlify/functions/todos', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       }
@@ -94,11 +103,17 @@ export default function DashboardPage(): JSX.Element {
   const handleAiCreate = async (): Promise<void> => {
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
       if (createType === 'map') {
-        await authFetch('/.netlify/functions/ai-create-mindmap', {
+        await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({
             title: form.title,
             description: form.description,
@@ -106,9 +121,12 @@ export default function DashboardPage(): JSX.Element {
           }),
         })
       } else {
-        await authFetch('/.netlify/functions/ai-create-todo', {
+        await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ prompt: form.description }),
         })
       }

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -98,11 +98,17 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
       if (createType === 'map') {
-        const res = await authFetch('/.netlify/functions/index', {
+        const res = await fetch('/.netlify/functions/index', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
         const json = await res.json()
@@ -110,15 +116,21 @@ export default function DashboardPage(): JSX.Element {
           navigate(`/maps/${json.id}`)
         }
       } else if (createType === 'todo') {
-        await authFetch('/.netlify/functions/todos', {
+        await fetch('/.netlify/functions/todos', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       } else {
-        await authFetch('/.netlify/functions/boards', {
+        await fetch('/.netlify/functions/boards', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ title: form.title }),
         })
       }
@@ -133,11 +145,17 @@ export default function DashboardPage(): JSX.Element {
   const handleAiCreate = async (): Promise<void> => {
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
       if (createType === 'map') {
-        const res = await authFetch('/.netlify/functions/ai-create-mindmap', {
+        const res = await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({
             title: form.title,
             description: form.description,
@@ -149,15 +167,21 @@ export default function DashboardPage(): JSX.Element {
           navigate(`/maps/${json.id}`)
         }
       } else if (createType === 'todo') {
-        await authFetch('/.netlify/functions/ai-create-todo', {
+        await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ prompt: form.description }),
         })
       } else {
-        await authFetch('/.netlify/functions/boards', {
+        await fetch('/.netlify/functions/boards', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
           body: JSON.stringify({ title: form.title }),
         })
       }

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -50,10 +50,16 @@ export default function KanbanBoardsPage(): JSX.Element {
     e.preventDefault()
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
-      await authFetch('/.netlify/functions/boards', {
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
+      await fetch('/.netlify/functions/boards', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)
@@ -67,10 +73,16 @@ export default function KanbanBoardsPage(): JSX.Element {
   const handleAiCreate = async (): Promise<void> => {
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
-      await authFetch('/.netlify/functions/ai-create-board', {
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
+      await fetch('/.netlify/functions/ai-create-board', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -51,10 +51,16 @@ export default function MindmapsPage(): JSX.Element {
     e.preventDefault()
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
-      const res = await authFetch('/.netlify/functions/index', {
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
+      const res = await fetch('/.netlify/functions/index', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ data: { title: form.title, description: form.description } }),
       })
       const json = await res.json()
@@ -73,10 +79,16 @@ export default function MindmapsPage(): JSX.Element {
   const handleAiCreate = async (): Promise<void> => {
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
-      const res = await authFetch('/.netlify/functions/ai-create-mindmap', {
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
+      const res = await fetch('/.netlify/functions/ai-create-mindmap', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({
           title: form.title,
           description: form.description,

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -52,10 +52,16 @@ export default function TodosPage(): JSX.Element {
     e.preventDefault()
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
-      await authFetch('/.netlify/functions/todos', {
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
+      await fetch('/.netlify/functions/todos', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)
@@ -69,10 +75,16 @@ export default function TodosPage(): JSX.Element {
   const handleAiCreate = async (): Promise<void> => {
     try {
       const token = localStorage.getItem('token')
-      if (!token) return
-      await authFetch('/.netlify/functions/ai-create-todo', {
+      if (!token) {
+        console.warn('No token found in localStorage — cannot create mindmap.')
+        return
+      }
+      await fetch('/.netlify/functions/ai-create-todo', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ prompt: form.description }),
       })
       setShowModal(false)


### PR DESCRIPTION
## Summary
- ensure create actions include `Authorization` header

## Testing
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68804b7a7a308327b79701fc2da4d1a2