### PR TITLE
Fix layout for kanban demo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,7 @@ function AppLayout() {
     '/account'
   ]
   const isDashboard = dashboardPaths.some(path =>
-    location.pathname.startsWith(path)
+    location.pathname === path || location.pathname.startsWith(path + '/')
   )
 
   return isDashboard ? (


### PR DESCRIPTION
## Summary
- fix AppLayout dashboard detection so `/kanban-demo` uses marketing menu

## Testing
- `npm test` *(fails: cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68804e7756c48327901ea526ab798b68