### PR TITLE
Fix missing auth header for map fetch

### DIFF
--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -35,7 +35,12 @@ export default function MindmapsPage(): JSX.Element {
         setLoading(false)
         return
       }
-      const res = await authFetch('/.netlify/functions/index', { credentials: 'include' })
+      const res = await fetch('/.netlify/functions/index', {
+        credentials: 'include',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
       const data = res.ok ? await res.json() : []
       setMaps(Array.isArray(data) ? data : [])
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- include `Authorization` header when retrieving mindmaps

## Testing
- `npm test` *(fails: cannot find module 'typescript' and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68805063c3bc8327b8118ea1e8f188d6