### PR TITLE
Implement authHeaders utility

### DIFF
--- a/authFetch.ts
+++ b/authFetch.ts
@@ -1,8 +1,13 @@
-export async function authFetch(input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
-  const headers = new Headers(init.headers || {});
-  if (token) {
-    headers.set('Authorization', `Bearer ${token}`);
+import { authHeaders } from './authHeaders';
+
+export async function authFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  const headers = new Headers(authHeaders());
+  if (init.headers) {
+    const extra = new Headers(init.headers);
+    extra.forEach((value, key) => headers.set(key, value));
   }
   return fetch(input, { ...init, headers });
 }

--- a/authHeaders.ts
+++ b/authHeaders.ts
@@ -1,0 +1,7 @@
+export function authHeaders(): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}

--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from './authFetch'
+import { authHeaders } from './authHeaders'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from './loadingskeleton'
 import FaintMindmapBackground from './FaintMindmapBackground'
@@ -76,19 +77,13 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         await fetch('/.netlify/functions/index', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
       } else {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       }
@@ -110,10 +105,7 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({
             title: form.title,
             description: form.description,
@@ -123,10 +115,7 @@ export default function DashboardPage(): JSX.Element {
       } else {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ prompt: form.description }),
         })
       }

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
+import { authHeaders } from '../authHeaders'
 import { Link, useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
@@ -105,10 +106,7 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/index', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
         const json = await res.json()
@@ -118,19 +116,13 @@ export default function DashboardPage(): JSX.Element {
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       } else {
         await fetch('/.netlify/functions/boards', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ title: form.title }),
         })
       }
@@ -152,10 +144,7 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({
             title: form.title,
             description: form.description,
@@ -169,19 +158,13 @@ export default function DashboardPage(): JSX.Element {
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ prompt: form.description }),
         })
       } else {
         await fetch('/.netlify/functions/boards', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: authHeaders(),
           body: JSON.stringify({ title: form.title }),
         })
       }

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
+import { authHeaders } from '../authHeaders'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
@@ -56,10 +57,7 @@ export default function KanbanBoardsPage(): JSX.Element {
       }
       await fetch('/.netlify/functions/boards', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)
@@ -79,10 +77,7 @@ export default function KanbanBoardsPage(): JSX.Element {
       }
       await fetch('/.netlify/functions/ai-create-board', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
+import { authHeaders } from '../authHeaders'
 import { Link, useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
@@ -37,9 +38,7 @@ export default function MindmapsPage(): JSX.Element {
       }
       const res = await fetch('/.netlify/functions/index', {
         credentials: 'include',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
       })
       const data = res.ok ? await res.json() : []
       setMaps(Array.isArray(data) ? data : [])
@@ -62,10 +61,7 @@ export default function MindmapsPage(): JSX.Element {
       }
       const res = await fetch('/.netlify/functions/index', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
         body: JSON.stringify({ data: { title: form.title, description: form.description } }),
       })
       const json = await res.json()
@@ -90,10 +86,7 @@ export default function MindmapsPage(): JSX.Element {
       }
       const res = await fetch('/.netlify/functions/ai-create-mindmap', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
         body: JSON.stringify({
           title: form.title,
           description: form.description,

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
+import { authHeaders } from '../authHeaders'
 import { Link } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
@@ -58,10 +59,7 @@ export default function TodosPage(): JSX.Element {
       }
       await fetch('/.netlify/functions/todos', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)
@@ -81,10 +79,7 @@ export default function TodosPage(): JSX.Element {
       }
       await fetch('/.netlify/functions/ai-create-todo', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: authHeaders(),
         body: JSON.stringify({ prompt: form.description }),
       })
       setShowModal(false)


### PR DESCRIPTION
## Summary
- extract `authHeaders` helper for reuse
- integrate helper into `authFetch`
- use `authHeaders` in dashboard and page components

## Testing
- `npm test` *(fails: Cannot find package 'typescript'; SyntaxError: The requested module 'node:test' does not provide an export named 'expect')*

------
https://chatgpt.com/codex/tasks/task_e_6880520b39a883279fdcf71157df194c