### PR TITLE
Fix quick create token check

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -69,20 +69,17 @@ export default function DashboardPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       if (createType === 'map') {
         await fetch('/.netlify/functions/index', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
       } else {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
@@ -97,14 +94,10 @@ export default function DashboardPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       if (createType === 'map') {
         await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({
             title: form.title,
@@ -115,6 +108,7 @@ export default function DashboardPage(): JSX.Element {
       } else {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ prompt: form.description }),
         })

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -98,14 +98,10 @@ export default function DashboardPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/index', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
@@ -116,12 +112,14 @@ export default function DashboardPage(): JSX.Element {
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       } else {
         await fetch('/.netlify/functions/boards', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ title: form.title }),
         })
@@ -136,14 +134,10 @@ export default function DashboardPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({
             title: form.title,
@@ -158,12 +152,14 @@ export default function DashboardPage(): JSX.Element {
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ prompt: form.description }),
         })
       } else {
         await fetch('/.netlify/functions/boards', {
           method: 'POST',
+          credentials: 'include',
           headers: authHeaders(),
           body: JSON.stringify({ title: form.title }),
         })

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -50,13 +50,9 @@ export default function KanbanBoardsPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       await fetch('/.netlify/functions/boards', {
         method: 'POST',
+        credentials: 'include',
         headers: authHeaders(),
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
@@ -70,13 +66,9 @@ export default function KanbanBoardsPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       await fetch('/.netlify/functions/ai-create-board', {
         method: 'POST',
+        credentials: 'include',
         headers: authHeaders(),
         body: JSON.stringify({ title: form.title, description: form.description }),
       })

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -54,13 +54,9 @@ export default function MindmapsPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       const res = await fetch('/.netlify/functions/index', {
         method: 'POST',
+        credentials: 'include',
         headers: authHeaders(),
         body: JSON.stringify({ data: { title: form.title, description: form.description } }),
       })
@@ -79,13 +75,9 @@ export default function MindmapsPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       const res = await fetch('/.netlify/functions/ai-create-mindmap', {
         method: 'POST',
+        credentials: 'include',
         headers: authHeaders(),
         body: JSON.stringify({
           title: form.title,

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -52,13 +52,9 @@ export default function TodosPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       await fetch('/.netlify/functions/todos', {
         method: 'POST',
+        credentials: 'include',
         headers: authHeaders(),
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
@@ -72,13 +68,9 @@ export default function TodosPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        console.warn('No token found in localStorage — cannot create mindmap.')
-        return
-      }
       await fetch('/.netlify/functions/ai-create-todo', {
         method: 'POST',
+        credentials: 'include',
         headers: authHeaders(),
         body: JSON.stringify({ prompt: form.description }),
       })


### PR DESCRIPTION
## Summary
- avoid early return when no token found for map/todo/board creation
- use `credentials: 'include'` so the session cookie works without localStorage

## Testing
- `npm test` *(fails: cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_688054539f248327b99681a9b64ebfc7