### PR TITLE
Remove aria-hidden from modal overlays

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -360,7 +360,7 @@ export default function DashboardPage(): JSX.Element {
         </>
       )}
       {showModal && (
-        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+        <div className="modal-overlay" onClick={() => setShowModal(false)}>
           <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
             <span className="flare-line" aria-hidden="true"></span>
             <h2 className="fade-item">Create {createType === 'map' ? 'Mind Map' : createType === 'todo' ? 'Todo' : 'Board'}</h2>

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -144,7 +144,7 @@ export default function KanbanBoardsPage(): JSX.Element {
         </>
       )}
       {showModal && (
-        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+        <div className="modal-overlay" onClick={() => setShowModal(false)}>
           <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
             <span className="flare-line" aria-hidden="true"></span>
             <h2 className="fade-item">Create Board</h2>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -160,7 +160,7 @@ export default function MindmapsPage(): JSX.Element {
         </div>
       )}
       {showModal && (
-        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+        <div className="modal-overlay" onClick={() => setShowModal(false)}>
           <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
             <span className="flare-line" aria-hidden="true"></span>
             <h2 className="fade-item">Create Mind Map</h2>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -146,7 +146,7 @@ export default function TodosPage(): JSX.Element {
         </>
       )}
       {showModal && (
-        <div className="modal-overlay" onClick={() => setShowModal(false)} aria-hidden="true">
+        <div className="modal-overlay" onClick={() => setShowModal(false)}>
           <div className="modal fancy-modal" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
             <span className="flare-line" aria-hidden="true"></span>
             <h2 className="fade-item">Create Todo</h2>


### PR DESCRIPTION
## Summary
- fix accessibility issue that prevented quick create modal fields from focusing by removing `aria-hidden` from modal overlay elements

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68805678299883279978765a053191f0