### PR TITLE
Adjust auth cookie

### DIFF
--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -1,5 +1,6 @@
 import type { HandlerEvent } from '@netlify/functions'
 import jwt from 'jsonwebtoken'
+import cookie from 'cookie'
 
 export interface SessionPayload {
   userId: string
@@ -13,12 +14,8 @@ export function extractToken(event: HandlerEvent): string | null {
   if (auth && auth.startsWith('Bearer ')) {
     return auth.slice(7)
   }
-  const cookie = event.headers.cookie || event.headers.Cookie
-  if (cookie) {
-    const match = cookie.match(/session=([^;]+)/)
-    if (match) return match[1]
-  }
-  return null
+  const cookies = cookie.parse(event.headers.cookie || '')
+  return cookies.token || cookies.session || null
 }
 
 export function verifySession(token: string): SessionPayload {

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -160,11 +160,10 @@ export const handler = async (
     )
 
     const cookieParts = [
-      `session=${token}`,
+      `token=${token}`,
       'HttpOnly',
       'Path=/',
-      'SameSite=Lax',
-      'Max-Age=3600'
+      'SameSite=Lax'
     ]
 
     if (process.env.NODE_ENV === 'production') {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^16.0.3",
     "framer-motion": "^10.16.1",
     "jsonwebtoken": "^9.0.0",
+    "cookie": "^0.5.0",
     "openai": "^4.5.0",
     "pg": "^8.10.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- set `token` cookie with HttpOnly, Path=/ and SameSite
- parse cookies using `cookie` library
- add `cookie` dependency

## Testing
- `npm test` *(fails: cannot find package 'typescript' and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_688057d3aac4832783287961e068e46c