### PR TITLE
Update cookie handling

### DIFF
--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -15,7 +15,7 @@ export function extractToken(event: HandlerEvent): string | null {
     return auth.slice(7)
   }
   const cookies = cookie.parse(event.headers.cookie || '')
-  return cookies.token || cookies.session || null
+  return cookies.session || null
 }
 
 export function verifySession(token: string): SessionPayload {

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -160,7 +160,7 @@ export const handler = async (
     )
 
     const cookieParts = [
-      `token=${token}`,
+      `session=${token}`,
       'HttpOnly',
       'Path=/',
       'SameSite=Lax'


### PR DESCRIPTION
## Summary
- read session cookie in auth extractor
- set the session cookie during login

## Testing
- `npm test` *(fails: Cannot find package 'typescript', SyntaxError: The requested module 'node:test' does not provide an export named 'expect')*

------
https://chatgpt.com/codex/tasks/task_e_68805a3e4d248327ad64ae8a429085bd