### PR TITLE
Fix quick create authentication

### DIFF
--- a/authFetch.ts
+++ b/authFetch.ts
@@ -9,5 +9,9 @@ export async function authFetch(
     const extra = new Headers(init.headers);
     extra.forEach((value, key) => headers.set(key, value));
   }
-  return fetch(input, { ...init, headers });
+  return fetch(input, {
+    ...init,
+    headers,
+    credentials: init.credentials ?? 'include',
+  });
 }


### PR DESCRIPTION
## Summary
- default `authFetch` to send cookies with requests

## Testing
- `npm test` *(fails: cannot find TypeScript module)*

------
https://chatgpt.com/codex/tasks/task_e_68805cc06d188327a6173ad7447df61d