### PR TITLE
Fix mind map creation

### DIFF
--- a/apiclient.ts
+++ b/apiclient.ts
@@ -12,12 +12,16 @@ export class ApiError extends Error {
 }
 
 async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
-  const { headers: customHeaders, ...rest } = options;
+  const { headers: customHeaders, credentials, ...rest } = options;
   const headers = new Headers(customHeaders);
   if (rest.body != null) {
     headers.set('Content-Type', 'application/json');
   }
-  const res = await fetch(url, { ...rest, headers });
+  const res = await fetch(url, {
+    ...rest,
+    headers,
+    credentials: credentials ?? 'include',
+  });
   let data: any = undefined;
   if (res.status !== 204) {
     const contentType = res.headers.get('content-type') || '';


### PR DESCRIPTION
## Summary
- handle auth cookies in API client by defaulting to `credentials: 'include'`

## Testing
- `npm test` *(fails: cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6880614f0f4c83278527f967d7ebc12d