### PR TITLE
Fix credentials for creation endpoints

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -72,15 +72,19 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         await fetch('/.netlify/functions/index', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
       } else {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       }
@@ -97,8 +101,10 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({
             title: form.title,
             description: form.description,
@@ -108,8 +114,10 @@ export default function DashboardPage(): JSX.Element {
       } else {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ prompt: form.description }),
         })
       }

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -101,8 +101,10 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/index', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ data: { title: form.title, description: form.description } }),
         })
         const json = await res.json()
@@ -112,15 +114,19 @@ export default function DashboardPage(): JSX.Element {
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
       } else {
         await fetch('/.netlify/functions/boards', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ title: form.title }),
         })
       }
@@ -137,8 +143,10 @@ export default function DashboardPage(): JSX.Element {
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/ai-create-mindmap', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({
             title: form.title,
             description: form.description,
@@ -152,15 +160,19 @@ export default function DashboardPage(): JSX.Element {
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/ai-create-todo', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ prompt: form.description }),
         })
       } else {
         await fetch('/.netlify/functions/boards', {
           method: 'POST',
-          credentials: 'include',
-          headers: authHeaders(),
+          credentials: 'include', // Required for session cookie
+          headers: {
+            'Content-Type': 'application/json',
+          },
           body: JSON.stringify({ title: form.title }),
         })
       }

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -52,8 +52,10 @@ export default function KanbanBoardsPage(): JSX.Element {
     try {
       await fetch('/.netlify/functions/boards', {
         method: 'POST',
-        credentials: 'include',
-        headers: authHeaders(),
+        credentials: 'include', // Required for session cookie
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)
@@ -68,8 +70,10 @@ export default function KanbanBoardsPage(): JSX.Element {
     try {
       await fetch('/.netlify/functions/ai-create-board', {
         method: 'POST',
-        credentials: 'include',
-        headers: authHeaders(),
+        credentials: 'include', // Required for session cookie
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -56,8 +56,10 @@ export default function MindmapsPage(): JSX.Element {
     try {
       const res = await fetch('/.netlify/functions/index', {
         method: 'POST',
-        credentials: 'include',
-        headers: authHeaders(),
+        credentials: 'include', // Required for session cookie
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ data: { title: form.title, description: form.description } }),
       })
       const json = await res.json()

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -54,8 +54,10 @@ export default function TodosPage(): JSX.Element {
     try {
       await fetch('/.netlify/functions/todos', {
         method: 'POST',
-        credentials: 'include',
-        headers: authHeaders(),
+        credentials: 'include', // Required for session cookie
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
       setShowModal(false)


### PR DESCRIPTION
## Summary
- ensure mind map, todo, and Kanban creation requests send cookies

## Testing
- `npm test --silent` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68806464598c8327811aa8d3c809d864