### PR TITLE
Ensure mindmap table has title and description

### DIFF
--- a/migrations/016_add_mindmap_title_description.sql
+++ b/migrations/016_add_mindmap_title_description.sql
@@ -1,0 +1,18 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'mindmaps' AND column_name = 'title'
+  ) THEN
+    ALTER TABLE mindmaps ADD COLUMN title TEXT;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'mindmaps' AND column_name = 'description'
+  ) THEN
+    ALTER TABLE mindmaps ADD COLUMN description TEXT;
+  END IF;
+END;
+$$;

--- a/netlify/functions/index.ts
+++ b/netlify/functions/index.ts
@@ -1,15 +1,9 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { getClient } from './db-client.js'
 import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
-import { z, ZodError } from 'zod'
+import { ZodError } from 'zod'
 import { extractToken, verifySession } from './auth.js'
-
-const mapInputSchema = z.object({
-  data: z.object({
-    title: z.string(),
-    description: z.string().optional(),
-  }),
-})
+import { mapInputSchema } from './validationschemas.js'
 
 
 async function getMaps(userId: string) {

--- a/netlify/functions/validationschemas.ts
+++ b/netlify/functions/validationschemas.ts
@@ -4,3 +4,10 @@ export const createMindMapSchema = z.object({
   title: z.string().trim().min(1).max(255),
   description: z.string().trim().min(1).max(255).optional()
 })
+
+export const mapInputSchema = z.object({
+  data: z.object({
+    title: z.string().min(1),
+    description: z.string().optional().default(''),
+  }),
+})

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -49,6 +49,26 @@ export async function runMigrations(): Promise<void> {
       $$;
     `)
 
+    // Ensure title and description columns exist for map metadata
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'mindmaps' AND column_name = 'title'
+        ) THEN
+          ALTER TABLE mindmaps ADD COLUMN title TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'mindmaps' AND column_name = 'description'
+        ) THEN
+          ALTER TABLE mindmaps ADD COLUMN description TEXT;
+        END IF;
+      END;
+      $$;
+    `)
+
     // Ensure the owner_id column exists for older migrations that
     // still reference this column when creating indexes or constraints.
     await client.query(`


### PR DESCRIPTION
## Summary
- add migration to ensure `title` and `description` columns exist
- keep migrations runner resilient by adding column checks
- export `mapInputSchema` in `validationschemas.ts`
- use the shared schema in `functions/index.ts`

## Testing
- `npm test` *(fails: cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_688071225a9c83278c87d29c81c4e251