### PR TITLE
Add kanban board display and canvas page

### DIFF
--- a/migrations/018_create_kanban_boards.sql
+++ b/migrations/018_create_kanban_boards.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS kanban_boards (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION trigger_set_boards_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_kanban_boards_updated_at ON kanban_boards;
+CREATE TRIGGER set_kanban_boards_updated_at
+BEFORE UPDATE ON kanban_boards
+FOR EACH ROW EXECUTE PROCEDURE trigger_set_boards_updated_at();
+
+CREATE INDEX IF NOT EXISTS idx_kanban_boards_user_id ON kanban_boards(user_id);

--- a/netlify/functions/boards.ts
+++ b/netlify/functions/boards.ts
@@ -1,41 +1,85 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import { getClient } from './db-client.js'
+import { extractToken, verifySession } from './auth.js'
 
-let boards = [
-  { id: 'demo1', title: 'Board 1', created_at: new Date().toISOString() }
-]
+const headers: Record<string, string> = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization'
+}
 
 export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {
-  if (event.httpMethod === 'POST') {
-    try {
-      const data = JSON.parse(event.body || '{}') as { title?: string }
-      const newBoard = {
-        id: Date.now().toString(),
-        title: data.title || 'Untitled Board',
-        created_at: new Date().toISOString()
-      }
-      boards.push(newBoard)
-      return {
-        statusCode: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*'
-        },
-        body: JSON.stringify(newBoard)
-      }
-    } catch {
-      return { statusCode: 400, body: 'Invalid body' }
-    }
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers, body: '' }
   }
 
-  return {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*'
-    },
-    body: JSON.stringify({ boards })
+  const token = extractToken(event)
+  if (!token) {
+    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+  }
+
+  let userId: string
+  try {
+    const session = verifySession(token) as { userId: string }
+    userId = session.userId
+  } catch {
+    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Invalid token' }) }
+  }
+
+  const client = await getClient()
+
+  try {
+    if (event.httpMethod === 'POST') {
+      let data: { title?: string }
+      try {
+        data = JSON.parse(event.body || '{}')
+      } catch {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid body' }) }
+      }
+      const title = (data.title || '').trim()
+      if (!title) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing title' }) }
+      }
+      const result = await client.query(
+        'INSERT INTO kanban_boards (user_id, title, created_at, updated_at) VALUES ($1,$2,NOW(),NOW()) RETURNING id, title, created_at',
+        [userId, title]
+      )
+      return { statusCode: 200, headers, body: JSON.stringify(result.rows[0]) }
+    }
+
+    if (event.httpMethod === 'GET') {
+      const id = event.queryStringParameters?.id
+      if (id) {
+        const { rows } = await client.query(
+          'SELECT id, title, created_at FROM kanban_boards WHERE id = $1 AND (user_id = $2 OR user_id IN (SELECT user_id FROM team_members WHERE member_id = $2))',
+          [id, userId]
+        )
+        const board = rows[0]
+        if (!board) {
+          return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found' }) }
+        }
+        return { statusCode: 200, headers, body: JSON.stringify({ board }) }
+      }
+
+      const { rows } = await client.query(
+        `SELECT id, title, created_at
+           FROM kanban_boards
+          WHERE user_id = $1 OR user_id IN (SELECT user_id FROM team_members WHERE member_id = $1)
+          ORDER BY created_at DESC`,
+        [userId]
+      )
+      return { statusCode: 200, headers, body: JSON.stringify({ boards: rows }) }
+    }
+
+    return { statusCode: 405, headers: { ...headers, Allow: 'GET,POST,OPTIONS' }, body: JSON.stringify({ error: 'Method Not Allowed' }) }
+  } catch (err) {
+    console.error(err)
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Server error' }) }
+  } finally {
+    client.release()
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Kanban from '../kanban'
 import MindmapsPage from './MindmapsPage'
 import TodosPage from './TodosPage'
 import KanbanBoardsPage from './KanbanBoardsPage'
+import KanbanBoardPage from './KanbanBoardPage'
 import ProjectWorkspace from '../ProjectWorkspace'
 import MapEditorPage from './MapEditorPage'
 import TodoDetail from '../TodoDetail'
@@ -39,6 +40,7 @@ function AppRoutes() {
       <Route path="/mindmaps" element={<MindmapsPage />} />
       <Route path="/todos" element={<TodosPage />} />
       <Route path="/kanban" element={<KanbanBoardsPage />} />
+      <Route path="/kanban/:id" element={<KanbanBoardPage />} />
       <Route path="/maps/:id" element={<MapEditorPage />} />
       <Route path="/workspace" element={<ProjectWorkspace />} />
       <Route path="/todo/:id" element={<TodoDetail />} />

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -363,7 +363,7 @@ export default function DashboardPage(): JSX.Element {
               <ul className="recent-list">
                 {recentBoards.map(b => (
                   <li key={b.id}>
-                    <Link to="/kanban">{b.title || 'Board'}</Link>
+                    <Link to={`/kanban/${b.id}`}>{b.title || 'Board'}</Link>
                   </li>
                 ))}
               </ul>

--- a/src/KanbanBoardPage.tsx
+++ b/src/KanbanBoardPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import KanbanCanvas from '../KanbanCanvas'
+import { authFetch } from '../authFetch'
+
+interface BoardItem {
+  id: string
+  title?: string
+  created_at?: string
+}
+
+export default function KanbanBoardPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>()
+  const boardId = id || ''
+  const [board, setBoard] = useState<BoardItem | null>(null)
+
+  useEffect(() => {
+    if (!boardId) return
+    let ignore = false
+    authFetch(`/.netlify/functions/boards?id=${boardId}`)
+      .then(async res => {
+        if (!ignore && res.ok) {
+          const json = await res.json()
+          setBoard(json.board || null)
+        }
+      })
+      .catch(() => {})
+    return () => {
+      ignore = true
+    }
+  }, [boardId])
+
+  if (!boardId) return <div>No board specified</div>
+
+  return (
+    <div className="kanban-board-page">
+      <h1>{board?.title || 'Kanban Board'}</h1>
+      <KanbanCanvas />
+    </div>
+  )
+}

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -131,7 +131,7 @@ export default function KanbanBoardsPage(): JSX.Element {
                 <div className="tile-header">
                   <h2>{b.title || 'Board'}</h2>
                   <Link
-                    to="/kanban"
+                    to={`/kanban/${b.id}`}
                     onClick={() =>
                       localStorage.setItem(
                         `board_last_viewed_${b.id}`,


### PR DESCRIPTION
## Summary
- create kanban_boards table migration
- read boards from database in API
- add page to view a single kanban board with KanbanCanvas
- link to board pages from dashboard and board list
- register new board page route

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_6880779374088327bc18ad460b1e7d91