### PR TITLE
Move mindmap endpoint & add todos API

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -45,7 +45,7 @@ export default function DashboardPage(): JSX.Element {
         return
       }
       const [mapsRes, todosRes] = await Promise.all([
-        authFetch('/.netlify/functions/index', { credentials: 'include' }),
+        authFetch('/.netlify/functions/mindmap', { credentials: 'include' }),
         authFetch('/.netlify/functions/list', { credentials: 'include' }),
       ])
       const mapsData = mapsRes.ok && mapsRes.headers.get('content-type')?.includes('application/json')
@@ -70,7 +70,7 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       if (createType === 'map') {
-        await fetch('/.netlify/functions/index', {
+        await fetch('/.netlify/functions/mindmap', {
           method: 'POST',
           credentials: 'include', // Required for session cookie
           headers: {

--- a/netlify/functions/mindmap.ts
+++ b/netlify/functions/mindmap.ts
@@ -55,7 +55,7 @@ export const handler = async (
       userId = session.userId
       if (!userId) throw new Error('Missing userId')
     } catch (err) {
-      console.error('Auth failure in index.ts:', err)
+      console.error('Auth failure in mindmap.ts:', err)
       return {
         statusCode: 401,
         headers: { 'Content-Type': 'application/json' },

--- a/netlify/functions/todos.ts
+++ b/netlify/functions/todos.ts
@@ -1,0 +1,103 @@
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import { getClient } from './db-client.js'
+import { extractToken, verifySession } from './auth.js'
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
+import { z, ZodError } from 'zod'
+
+const todoInputSchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+})
+
+async function getTodos(userId: string) {
+  const client = await getClient()
+  try {
+    const res = await client.query(
+      `SELECT id, user_id, title, description, completed, assignee_id, created_at, updated_at
+         FROM todos
+        WHERE user_id = $1 OR user_id IN (SELECT user_id FROM team_members WHERE member_id = $1)
+        ORDER BY created_at DESC`,
+      [userId]
+    )
+    return res.rows
+  } finally {
+    client.release()
+  }
+}
+
+async function createTodo(userId: string, data: { title: string; description?: string }) {
+  const client = await getClient()
+  try {
+    const res = await client.query(
+      `INSERT INTO todos (user_id, title, description, created_at, updated_at)
+       VALUES ($1, $2, $3, NOW(), NOW())
+       RETURNING id, user_id, title, description, completed, assignee_id, created_at, updated_at`,
+      [userId, data.title, data.description ?? null]
+    )
+    return res.rows[0]
+  } finally {
+    client.release()
+  }
+}
+
+export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    const token = extractToken(event)
+    if (!token) {
+      return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    let userId: string
+    try {
+      const session = verifySession(token)
+      userId = session.userId
+      if (!userId) throw new Error('Missing userId')
+    } catch (err) {
+      console.error('Auth failure in todos.ts:', err)
+      return { statusCode: 401, headers, body: JSON.stringify({ error: 'Invalid session' }) }
+    }
+
+    if (event.httpMethod === 'GET') {
+      const todos = await getTodos(userId)
+      return { statusCode: 200, headers, body: JSON.stringify(todos) }
+    }
+
+    if (event.httpMethod === 'POST') {
+      if (!event.body) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing request body' }) }
+      }
+      let raw: unknown
+      try {
+        raw = JSON.parse(event.body)
+      } catch {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid JSON body' }) }
+      }
+      let parsed
+      try {
+        parsed = todoInputSchema.parse(raw)
+      } catch (err) {
+        if (err instanceof ZodError) {
+          return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid todo data', details: err.errors }) }
+        }
+        throw err
+      }
+      const todo = await createTodo(userId, parsed)
+      return { statusCode: 201, headers, body: JSON.stringify(todo) }
+    }
+
+    if (event.httpMethod === 'OPTIONS') {
+      return { statusCode: 204, headers: { ...headers, 'Allow': 'GET,POST,OPTIONS' }, body: '' }
+    }
+
+    return { statusCode: 405, headers: { ...headers, Allow: 'GET,POST,OPTIONS' }, body: JSON.stringify({ error: 'Method not allowed' }) }
+  } catch (err: any) {
+    if (err instanceof JsonWebTokenError || err instanceof TokenExpiredError || err.message === 'Unauthorized') {
+      return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+    }
+    console.error('Unhandled error:', err)
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Internal Server Error' }) }
+  }
+}

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -62,7 +62,7 @@ export default function DashboardPage(): JSX.Element {
         return
       }
       const [mapsRes, todosRes, boardsRes, nodesRes] = await Promise.all([
-        authFetch('/.netlify/functions/index', { credentials: 'include' }),
+        authFetch('/.netlify/functions/mindmap', { credentials: 'include' }),
         authFetch('/.netlify/functions/list', { credentials: 'include' }),
         authFetch('/.netlify/functions/boards', { credentials: 'include' }),
         authFetch('/.netlify/functions/node', { credentials: 'include' }),
@@ -99,7 +99,7 @@ export default function DashboardPage(): JSX.Element {
     e.preventDefault()
     try {
       if (createType === 'map') {
-        const res = await fetch('/.netlify/functions/index', {
+        const res = await fetch('/.netlify/functions/mindmap', {
           method: 'POST',
           credentials: 'include', // Required for session cookie
           headers: {

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -36,7 +36,7 @@ export default function MindmapsPage(): JSX.Element {
         setLoading(false)
         return
       }
-      const res = await fetch('/.netlify/functions/index', {
+      const res = await fetch('/.netlify/functions/mindmap', {
         credentials: 'include',
         headers: authHeaders(),
       })
@@ -54,7 +54,7 @@ export default function MindmapsPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const res = await fetch('/.netlify/functions/index', {
+      const res = await fetch('/.netlify/functions/mindmap', {
         method: 'POST',
         credentials: 'include', // Required for session cookie
         headers: {


### PR DESCRIPTION
## Summary
- migrate `/index` logic into `mindmap.ts`
- add `todos.ts` Netlify function for listing/creating todos
- update dashboard and mindmaps pages to use `/mindmap` endpoint
- adjust legacy dashboard component as well
- remove old `index.ts`

## Testing
- `npm test` *(fails: cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68807b638a0c8327bb23c0114f328352