### PR TITLE
Fix dashboard API mappings

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -46,15 +46,15 @@ export default function DashboardPage(): JSX.Element {
       }
       const [mapsRes, todosRes] = await Promise.all([
         authFetch('/.netlify/functions/mindmap', { credentials: 'include' }),
-        authFetch('/.netlify/functions/list', { credentials: 'include' }),
+        authFetch('/.netlify/functions/todos', { credentials: 'include' }),
       ])
       const mapsData = mapsRes.ok && mapsRes.headers.get('content-type')?.includes('application/json')
         ? await mapsRes.json()
         : []
       const todoJson = todosRes.ok && todosRes.headers.get('content-type')?.includes('application/json')
         ? await todosRes.json()
-        : { data: { todos: [] } }
-      const todoList: TodoItem[] = Array.isArray(todoJson) ? todoJson : todoJson.data?.todos || []
+        : []
+      const todoList: TodoItem[] = Array.isArray(todoJson) ? todoJson : []
       setMaps(Array.isArray(mapsData) ? mapsData : [])
       setTodos(todoList)
     } catch (err: any) {

--- a/nodetodolist.tsx
+++ b/nodetodolist.tsx
@@ -15,7 +15,7 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
     const fetchTodos = async () => {
       try {
         const res = await fetch(
-          `/api/todos?nodeId=${encodeURIComponent(nodeId)}`,
+          `/.netlify/functions/todos?nodeId=${encodeURIComponent(nodeId)}`,
           { signal: controller.signal }
         )
         if (!res.ok) throw new Error(`Error fetching todos: ${res.statusText}`)
@@ -38,7 +38,7 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
     if (!text) return
     setIsAdding(true)
     try {
-      const res = await fetch('/api/todos', {
+      const res = await fetch('/.netlify/functions/todos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -61,7 +61,7 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
     if (!prompt) return
     setIsGenerating(true)
     try {
-      const res = await fetch('/api/todos/generate', {
+      const res = await fetch('/.netlify/functions/ai-generate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -84,7 +84,7 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
     if (!text) return
     setIsEditingLoading(true)
     try {
-      const res = await fetch(`/api/todos/${id}`, {
+      const res = await fetch(`/.netlify/functions/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -105,7 +105,7 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
   const handleDeleteTodo = async (id: string) => {
     setDeletingIds(prev => [...prev, id])
     try {
-      const res = await fetch(`/api/todos/${id}`, { method: 'DELETE', credentials: 'include' })
+      const res = await fetch(`/.netlify/functions/todos/${id}`, { method: 'DELETE', credentials: 'include' })
       if (!res.ok) throw new Error(`Error deleting todo: ${res.statusText}`)
       setTodos(prev => prev.filter(t => t.id !== id))
     } catch (error: any) {
@@ -122,7 +122,7 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
     const newStatus = !todo.completed
     setTogglingIds(prev => [...prev, id])
     try {
-      const res = await fetch(`/api/todos/${id}`, {
+      const res = await fetch(`/.netlify/functions/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -63,7 +63,7 @@ export default function DashboardPage(): JSX.Element {
       }
       const [mapsRes, todosRes, boardsRes, nodesRes] = await Promise.all([
         authFetch('/.netlify/functions/mindmap', { credentials: 'include' }),
-        authFetch('/.netlify/functions/list', { credentials: 'include' }),
+        authFetch('/.netlify/functions/todos', { credentials: 'include' }),
         authFetch('/.netlify/functions/boards', { credentials: 'include' }),
         authFetch('/.netlify/functions/node', { credentials: 'include' }),
       ])
@@ -72,8 +72,8 @@ export default function DashboardPage(): JSX.Element {
         : []
       const todoJson = todosRes.ok && todosRes.headers.get('content-type')?.includes('application/json')
         ? await todosRes.json()
-        : { data: { todos: [] } }
-      const todoList: TodoItem[] = Array.isArray(todoJson) ? todoJson : todoJson.data?.todos || []
+        : []
+      const todoList: TodoItem[] = Array.isArray(todoJson) ? todoJson : []
       const boardsJson = boardsRes.ok && boardsRes.headers.get('content-type')?.includes('application/json')
         ? await boardsRes.json()
         : { boards: [] }

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -36,9 +36,9 @@ export default function TodosPage(): JSX.Element {
         setLoading(false)
         return
       }
-      const res = await authFetch('/.netlify/functions/list', { credentials: 'include' })
-      const json = res.ok ? await res.json() : { data: { todos: [] } }
-      const list: TodoItem[] = Array.isArray(json) ? json : json.data?.todos || []
+      const res = await authFetch('/.netlify/functions/todos', { credentials: 'include' })
+      const json = res.ok ? await res.json() : []
+      const list: TodoItem[] = Array.isArray(json) ? json : []
       setTodos(list)
     } catch (err: any) {
       setError(err.message || 'Failed to load todos')

--- a/tododashboard.tsx
+++ b/tododashboard.tsx
@@ -16,7 +16,7 @@ export default function TodoDashboard() {
     setError(null)
     setIsLoadingList(true)
     try {
-      const res = await fetch('/api/todos', { credentials: 'include' })
+      const res = await fetch('/.netlify/functions/todos', { credentials: 'include' })
       if (!res.ok) throw new Error('Failed to fetch todos')
       const data = await res.json()
       if (isMounted.current) setTodos(data.todos)
@@ -50,7 +50,7 @@ export default function TodoDashboard() {
     if (ids.length === 0) return
     setIsUpdatingBulk(true)
     try {
-      const res = await fetch('/api/todos/bulk-complete', {
+      const res = await fetch('/.netlify/functions/todos/bulk-complete', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -72,7 +72,7 @@ export default function TodoDashboard() {
     setError(null)
     setIsClearing(true)
     try {
-      const res = await fetch('/api/todos/completed', { method: 'DELETE', credentials: 'include' })
+      const res = await fetch('/.netlify/functions/todos/completed', { method: 'DELETE', credentials: 'include' })
       if (!res.ok) throw new Error('Clear completed failed')
       await loadTodos()
     } catch (err) {


### PR DESCRIPTION
## Summary
- ensure dashboard page fetches todos from `/.netlify/functions/todos`
- update Todos page to use the `todos` function
- point classic dashboard to new todos endpoint
- switch todo dashboard and node todo list components to use netlify functions

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68807ea7d7748327b2fa033d1d1624b9