### PR TITLE
Ensure board descriptions stored

### DIFF
--- a/migrations/019_add_boards_description.sql
+++ b/migrations/019_add_boards_description.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'kanban_boards' AND column_name = 'description'
+  ) THEN
+    ALTER TABLE kanban_boards ADD COLUMN description TEXT;
+  END IF;
+END;
+$$;

--- a/netlify/functions/ai-create-board.ts
+++ b/netlify/functions/ai-create-board.ts
@@ -24,9 +24,9 @@ export const handler = async (
   try {
     await client.query('BEGIN')
     const res = await client.query(
-      `INSERT INTO kanban_boards(id, user_id, title, created_at)
-       VALUES ($1, $2, $3, NOW()) RETURNING id`,
-      [randomUUID(), data.userId ?? null, title.trim()]
+      `INSERT INTO kanban_boards(id, user_id, title, description, created_at)
+       VALUES ($1, $2, $3, $4, NOW()) RETURNING id`,
+      [randomUUID(), data.userId ?? null, title.trim(), description.trim() || null]
     )
     const boardId = res.rows[0].id
     if (prompt && typeof prompt === 'string' && prompt.trim()) {

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -102,9 +102,23 @@ export async function runMigrations(): Promise<void> {
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
         title TEXT NOT NULL,
+        description TEXT,
         created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
       );
+    `)
+
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'kanban_boards' AND column_name = 'description'
+        ) THEN
+          ALTER TABLE kanban_boards ADD COLUMN description TEXT;
+        END IF;
+      END;
+      $$;
     `)
 
     // Ensure description column exists on todos


### PR DESCRIPTION
## Summary
- include board description column in DB migrations
- support optional description in kanban board functions
- update base table setup

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_688145fa593083279825c95c03033a63