### PR TITLE
Ensure quick create support for mindmaps

### DIFF
--- a/netlify/functions/mindmap.ts
+++ b/netlify/functions/mindmap.ts
@@ -79,7 +79,7 @@ export const handler = async (
             body: JSON.stringify({ error: "Missing request body" }),
           }
         }
-        let payload: unknown = {}
+        let payload: any = {}
         try {
           payload = JSON.parse(event.body || '{}')
         } catch {
@@ -87,6 +87,14 @@ export const handler = async (
             statusCode: 400,
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ error: "Invalid JSON body" }),
+          }
+        }
+        if (!payload.data && payload.title) {
+          payload = {
+            data: {
+              title: payload.title,
+              description: payload.description,
+            },
           }
         }
         let parsed


### PR DESCRIPTION
## Summary
- adjust mindmap Netlify function to accept body with `title` and `description` fields

## Testing
- `npm test --silent` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6881495d510c832788984a17297d64bf