### PR TITLE
Add todo description migration

### DIFF
--- a/migrations/020_add_todos_description.sql
+++ b/migrations/020_add_todos_description.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'todos' AND column_name = 'description'
+  ) THEN
+    ALTER TABLE todos ADD COLUMN description TEXT;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add a migration that ensures the `todos` table has a `description` column

## Testing
- `npm test` *(fails: cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68814d4509548327ab72db4d1793d797