### PR TITLE
Add kanban boards migration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,32 @@ OPENAI_DEFAULT_MODEL=gpt-4o-mini
 ```
 
 These are used by serverless functions to generate mind maps and todo lists.
+
+## Kanban Boards Table
+
+If you see errors mentioning `kanban_boards` when starting the API, create the table manually in your Neon database:
+
+```sql
+CREATE TABLE IF NOT EXISTS kanban_boards (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION trigger_set_boards_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_kanban_boards_updated_at ON kanban_boards;
+CREATE TRIGGER set_kanban_boards_updated_at
+BEFORE UPDATE ON kanban_boards
+FOR EACH ROW EXECUTE PROCEDURE trigger_set_boards_updated_at();
+
+CREATE INDEX IF NOT EXISTS idx_kanban_boards_user_id ON kanban_boards(user_id);
+```

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -121,6 +121,23 @@ export async function runMigrations(): Promise<void> {
       $$;
     `)
 
+    await client.query(`
+      CREATE OR REPLACE FUNCTION trigger_set_boards_updated_at()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        NEW.updated_at = now();
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      DROP TRIGGER IF EXISTS set_kanban_boards_updated_at ON kanban_boards;
+      CREATE TRIGGER set_kanban_boards_updated_at
+      BEFORE UPDATE ON kanban_boards
+      FOR EACH ROW EXECUTE PROCEDURE trigger_set_boards_updated_at();
+
+      CREATE INDEX IF NOT EXISTS idx_kanban_boards_user_id ON kanban_boards(user_id);
+    `)
+
     // Ensure description column exists on todos
     await client.query(`
       DO $$


### PR DESCRIPTION
## Summary
- document how to manually create the `kanban_boards` table
- create trigger and index for `kanban_boards` during migrations

## Testing
- `npm test` *(fails: Cannot find package 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68814dcbdf388327aee4af27bfe27c69