### PR TITLE
Fix db-client import paths

### DIFF
--- a/netlify/functions/mindmap.js
+++ b/netlify/functions/mindmap.js
@@ -1,4 +1,4 @@
-import { getClient } from './db-client.js'
+import { getClient } from './db-client'
 
 const UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89ABab][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/
 

--- a/netlify/functions/node.js
+++ b/netlify/functions/node.js
@@ -1,4 +1,4 @@
-import { getClient } from './db-client.js'
+import { getClient } from './db-client'
 
 const buildResponse = (statusCode, payload) => {
   const headers = {


### PR DESCRIPTION
## Summary
- drop `.js` extension in JS function imports
- keep db client file in `netlify/functions`

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_688151de12b4832787e855b5b56a4303