### PR TITLE
Fix map POST schema

### DIFF
--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -60,7 +60,7 @@ export default function MindmapsPage(): JSX.Element {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ title: form.title, description: form.description }),
+        body: JSON.stringify({ data: { title: form.title, description: form.description } }),
       })
       const json = await res.json()
       setShowModal(false)


### PR DESCRIPTION
## Summary
- ensure map POST requests from MindmapsPage use the `data` wrapper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68817d78841c8327a1770a8ad35e2692