### PR TITLE
Add migration for description and config columns on mindmaps

### DIFF
--- a/migrations/021_add_description_to_mindmaps.sql
+++ b/migrations/021_add_description_to_mindmaps.sql
@@ -1,0 +1,18 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'mindmaps' AND column_name = 'description'
+  ) THEN
+    ALTER TABLE mindmaps ADD COLUMN description TEXT;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'mindmaps' AND column_name = 'config'
+  ) THEN
+    ALTER TABLE mindmaps ADD COLUMN config JSONB DEFAULT '{}'::jsonb;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add a new SQL migration to ensure the `mindmaps` table has `description` and `config` columns

## Testing
- `npm test`
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions')*
- `npm run migrate` *(fails: Cannot find module '/workspace/mindmapx/dist/netlify/functions/db-client')*

------
https://chatgpt.com/codex/tasks/task_e_688181d833608327a44b5c67725bd162