### PR TITLE
Fix migrate script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This project uses Netlify Functions and a Neon database. SQL migration files are
    ```bash
    npm install --include=dev
    ```
-2. Run database migrations (requires a configured Neon connection):
+2. Run database migrations (requires a configured Neon connection). This command
+   automatically compiles the migration scripts before executing them:
    ```bash
    npm run migrate
    ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "compile:migrations": "tsc -p tsconfig.migrations.json",
-    "migrate": "node dist/runmigrations.js",
+    "migrate": "npm run compile:migrations && node dist/runmigrations.js",
     "test": "node --test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- compile migration helpers before running database migrations
- document that `npm run migrate` automatically compiles scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688185ca60a08327ad5493eb863855f4