### PR TITLE
Fix migration runner import

### DIFF
--- a/migrationrunner.ts
+++ b/migrationrunner.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { getClient } from './netlify/functions/db-client'
+import { getClient } from './netlify/functions/db-client.js'
 
 async function runMigrations() {
   const client = await getClient()


### PR DESCRIPTION
## Summary
- ensure `migrationrunner.ts` uses explicit `.js` extension for db-client import

## Testing
- `npm run compile:migrations` *(fails: Cannot find type definition file for '@netlify/functions', 'node')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688192f71c648327b7eb85e1d90405ca