### PR TITLE
Fix mindmaps id default in runMigrations

### DIFF
--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -26,7 +26,7 @@ export async function runMigrations(): Promise<void> {
     // reference them do not fail on a fresh database.
     await client.query(`
       CREATE TABLE IF NOT EXISTS mindmaps (
-        id          UUID PRIMARY KEY,
+        id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         title       TEXT NOT NULL,
         created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()


### PR DESCRIPTION
## Summary
- ensure `id` column in `runmigrations.ts` has `DEFAULT gen_random_uuid()`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68819d174cf48327b2398b40710c98c7