### PR TITLE
Fix map viewer with defensive checks

### DIFF
--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -6,8 +6,15 @@ import { authFetch } from '../authFetch'
 
 interface Mindmap {
   id: string
-  title: string
+  title?: string
   description?: string
+  nodes?: unknown[]
+  edges?: unknown[]
+  data?: {
+    nodes?: unknown[]
+    edges?: unknown[]
+    [key: string]: any
+  }
   config?: object
 }
 
@@ -20,7 +27,7 @@ export default function MapEditorPage(): JSX.Element {
     if (!id) return
     let ignore = false
 
-    authFetch(`/.netlify/functions/mindmaps?id=${id}`)
+    authFetch(`/api/maps/${id}`)
       .then(async res => {
         if (!res.ok) {
           if (!ignore) setError(true)
@@ -41,11 +48,24 @@ export default function MapEditorPage(): JSX.Element {
   if (error) return <div>Error loading map. Failed to load map: 404</div>
   if (!mindmap) return <div>Loading mind map...</div>
 
+  const nodes = Array.isArray(mindmap.nodes)
+    ? mindmap.nodes
+    : Array.isArray(mindmap.data?.nodes)
+      ? (mindmap.data?.nodes as unknown[])
+      : []
+  const edges = Array.isArray(mindmap.edges)
+    ? mindmap.edges
+    : Array.isArray(mindmap.data?.edges)
+      ? (mindmap.data?.edges as unknown[])
+      : []
+
+  console.log('mapData:', mindmap)
+
   return (
     <div className="dashboard-layout">
       <SidebarNav />
       <main className="main-area">
-        <MindmapCanvas mindmap={mindmap} />
+        <MindmapCanvas nodes={nodes} edges={edges} />
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary
- fetch map data from `/api/maps/:id`
- handle missing nodes/edges before rendering
- render `MindmapCanvas` with parsed data
- log loaded map for debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a9be29a48327b7aca187cbf034fb