### PR TITLE
Fix null-safe defaults for mindmap data

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -226,7 +226,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           <g
             transform={`translate(${transform.x},${transform.y}) scale(${transform.k})`}
           >
-            {edges.map(edge => {
+            {(edges || []).map(edge => {
               const from = nodeMap.get(edge.from)
               const to = nodeMap.get(edge.to)
               if (!from || !to) return null
@@ -242,7 +242,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 />
               )
             })}
-            {nodes.map(node => (
+            {(nodes || []).map(node => (
               <g key={node.id} transform={`translate(${node.x},${node.y})`}>
                 <circle
                   r={20 / transform.k}

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -48,15 +48,15 @@ export default function MapEditorPage(): JSX.Element {
   if (error) return <div>Error loading map. Failed to load map: 404</div>
   if (!mindmap) return <div>Loading mind map...</div>
 
-  const nodes = Array.isArray(mindmap.nodes)
+  const nodes = Array.isArray(mindmap?.nodes)
     ? mindmap.nodes
-    : Array.isArray(mindmap.data?.nodes)
-      ? (mindmap.data?.nodes as unknown[])
+    : Array.isArray(mindmap?.data?.nodes)
+      ? mindmap.data.nodes
       : []
-  const edges = Array.isArray(mindmap.edges)
+  const edges = Array.isArray(mindmap?.edges)
     ? mindmap.edges
-    : Array.isArray(mindmap.data?.edges)
-      ? (mindmap.data?.edges as unknown[])
+    : Array.isArray(mindmap?.data?.edges)
+      ? mindmap.data.edges
       : []
 
   console.log('mapData:', mindmap)


### PR DESCRIPTION
## Summary
- guard against missing data in `MapEditorPage`
- make `MindmapCanvas` handle undefined node/edge arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881ad7c287c8327ae6cb97648c756a6