### PR TITLE
Fix GET mindmap data response

### DIFF
--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -63,13 +63,21 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
     // ✅ Handle GET
     if (event.httpMethod === 'GET') {
       const result = await client.query(
-        `SELECT id, title, description, created_at FROM mindmaps
+        `SELECT id, title, description, created_at, data FROM mindmaps
          WHERE user_id = $1
          ORDER BY created_at DESC`,
         [userId]
       )
 
-      return { statusCode: 200, headers, body: JSON.stringify(result.rows) }
+      const maps = result.rows.map(row => ({
+        id: row.id,
+        title: row.title,
+        description: row.description,
+        created_at: row.created_at,
+        data: row.data ?? { nodes: [], edges: [] },
+      }))
+
+      return { statusCode: 200, headers, body: JSON.stringify(maps) }
     }
 
     // ❌ No other method allowed


### PR DESCRIPTION
## Summary
- return map data in the `/api/mindmaps` GET handler
- provide a `{nodes: [], edges: []}` fallback when the map has no data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881ae277d7c8327885a1f71a6a4149d