### PR TITLE
Fix dashboard mindmaps fetch

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -98,9 +98,20 @@ export default function DashboardPage(): JSX.Element {
 
   useEffect(() => {
     authFetch('/.netlify/functions/mindmaps')
-      .then(res => res.json())
+      .then(async res => {
+        try {
+          const json = await res.json()
+          if (Array.isArray(json)) return json
+          if (Array.isArray((json as any).maps)) return (json as any).maps
+          return []
+        } catch {
+          return []
+        }
+      })
       .then(setRecentMindmaps)
-      .catch(() => {})
+      .catch(() => {
+        setRecentMindmaps([])
+      })
   }, [])
 
   const handleCreate = async (e: FormEvent): Promise<void> => {


### PR DESCRIPTION
## Summary
- ensure dashboard handles unexpected API responses when fetching recent mindmaps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881af504c7883279cbad4eac72afdcf