### PR TITLE
Show maps on dashboard

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -45,7 +45,6 @@ export default function DashboardPage(): JSX.Element {
   const [todos, setTodos] = useState<TodoItem[]>([])
   const [boards, setBoards] = useState<BoardItem[]>([])
   const [nodes, setNodes] = useState<NodeItem[]>([])
-  const [recentMindmaps, setRecentMindmaps] = useState<MapItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
@@ -96,23 +95,6 @@ export default function DashboardPage(): JSX.Element {
 
   useEffect(() => { fetchData() }, [])
 
-  useEffect(() => {
-    authFetch('/.netlify/functions/mindmaps')
-      .then(async res => {
-        try {
-          const json = await res.json()
-          if (Array.isArray(json)) return json
-          if (Array.isArray((json as any).maps)) return (json as any).maps
-          return []
-        } catch {
-          return []
-        }
-      })
-      .then(setRecentMindmaps)
-      .catch(() => {
-        setRecentMindmaps([])
-      })
-  }, [])
 
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
@@ -280,6 +262,7 @@ export default function DashboardPage(): JSX.Element {
     return bTime - aTime
   }
 
+  const recentMaps = [...maps].sort(dateSort).slice(0, 5)
   const recentTodos = [...todos].sort(dateSort).slice(0, 10)
   const recentBoards = [...boards].sort(dateSort).slice(0, 10)
 
@@ -334,7 +317,7 @@ export default function DashboardPage(): JSX.Element {
                 <Link to="/mindmaps" className="tile-link">Open Mindmaps</Link>
               </div>
               <ul className="recent-list">
-                {recentMindmaps.slice(0, 5).map(m => (
+                {recentMaps.map(m => (
                   <li key={m.id}>
                     <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
                   </li>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -137,24 +137,30 @@ export default function MindmapsPage(): JSX.Element {
             <p>Today: {mapDay} Week: {mapWeek}</p>
           </div>
 
-          {sorted.map(m => (
-            <div className="tile" key={m.id}>
-              <div className="tile-header">
-                <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
-                <Link
-                  to={`/maps/${m.id}`}
-                  onClick={() =>
-                    localStorage.setItem(
-                      `mindmap_last_viewed_${m.id}`,
-                      Date.now().toString()
-                    )
-                  }
-                >
-                  Open
-                </Link>
-              </div>
+          {sorted.length === 0 ? (
+            <div className="tile empty">
+              <p>No mind maps found.</p>
             </div>
-          ))}
+          ) : (
+            sorted.map(m => (
+              <div className="tile" key={m.id}>
+                <div className="tile-header">
+                  <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
+                  <Link
+                    to={`/maps/${m.id}`}
+                    onClick={() =>
+                      localStorage.setItem(
+                        `mindmap_last_viewed_${m.id}`,
+                        Date.now().toString()
+                      )
+                    }
+                  >
+                    Open
+                  </Link>
+                </div>
+              </div>
+            ))
+          )}
         </div>
       )}
       {showModal && (


### PR DESCRIPTION
## Summary
- display mindmaps list directly in DashboardPage
- show notice when no mindmaps are available in MindmapsPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881b0b47c9083278ce0071cef767cdb