### PR TITLE
Fix mindmap data column

### DIFF
--- a/migrations/023_add_data_to_mindmaps.sql
+++ b/migrations/023_add_data_to_mindmaps.sql
@@ -1,0 +1,11 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'mindmaps' AND column_name = 'data'
+  ) THEN
+    ALTER TABLE mindmaps ADD COLUMN data JSONB DEFAULT '{}'::jsonb;
+  END IF;
+END;
+$$;

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -86,6 +86,19 @@ export async function runMigrations(): Promise<void> {
     `)
 
     await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'mindmaps' AND column_name = 'data'
+        ) THEN
+          ALTER TABLE mindmaps ADD COLUMN data JSONB DEFAULT '{}'::jsonb;
+        END IF;
+      END;
+      $$;
+    `)
+
+    await client.query(`
       CREATE TABLE IF NOT EXISTS nodes (
         id          UUID PRIMARY KEY,
         mindmap_id  UUID NOT NULL REFERENCES mindmaps(id),


### PR DESCRIPTION
## Summary
- add migration to include `data` column on `mindmaps`
- ensure `runmigrations.ts` adds the column on fresh databases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881ba3b64a08327a64be15110c8f896