### PR TITLE
Fix mindmap canvas fallback

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 
 const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
-  ({ nodes: propNodes, edges: propEdges, width, height }, ref) => {
+  ({ nodes: propNodes = [], edges: propEdges = [], width, height }, ref) => {
     const [nodes, setNodes] = useState<NodeData[]>(() => propNodes)
     const [edges, setEdges] = useState<EdgeData[]>(() => propEdges)
     const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 })

--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -63,7 +63,7 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
     // ✅ Handle GET
     if (event.httpMethod === 'GET') {
       const result = await client.query(
-        `SELECT id, title, description, created_at, data FROM mindmaps
+        `SELECT id, title, description, created_at FROM mindmaps
          WHERE user_id = $1
          ORDER BY created_at DESC`,
         [userId]
@@ -74,7 +74,6 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
         title: row.title,
         description: row.description,
         created_at: row.created_at,
-        data: row.data ?? { nodes: [], edges: [] },
       }))
 
       return { statusCode: 200, headers, body: JSON.stringify(maps) }

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -10,11 +10,6 @@ interface Mindmap {
   description?: string
   nodes?: unknown[]
   edges?: unknown[]
-  data?: {
-    nodes?: unknown[]
-    edges?: unknown[]
-    [key: string]: any
-  }
   config?: object
 }
 
@@ -48,16 +43,12 @@ export default function MapEditorPage(): JSX.Element {
   if (error) return <div>Error loading map. Failed to load map: 404</div>
   if (!mindmap) return <div>Loading mind map...</div>
 
-  const nodes = Array.isArray(mindmap?.nodes)
-    ? mindmap.nodes
-    : Array.isArray(mindmap?.data?.nodes)
-      ? mindmap.data.nodes
-      : []
-  const edges = Array.isArray(mindmap?.edges)
-    ? mindmap.edges
-    : Array.isArray(mindmap?.data?.edges)
-      ? mindmap.data.edges
-      : []
+  const nodes = Array.isArray(mindmap?.nodes) ? mindmap.nodes : []
+  const edges = Array.isArray(mindmap?.edges) ? mindmap.edges : []
+
+  if (nodes.length === 0 && edges.length === 0) {
+    console.log('[mindmap] No nodes or edges found, rendering empty canvas')
+  }
 
   console.log('mapData:', mindmap)
 


### PR DESCRIPTION
## Summary
- normalize mindmap listing API and drop `data` column references
- remove unused `data` prop handling in `MapEditorPage`
- default empty arrays in `MindmapCanvas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881c518f94c83279057b1c861756517