### PR TITLE
Fix null map data handling

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -10,8 +10,11 @@ import {
 
 const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
   ({ nodes: propNodes = [], edges: propEdges = [], width, height }, ref) => {
-    const [nodes, setNodes] = useState<NodeData[]>(() => propNodes)
-    const [edges, setEdges] = useState<EdgeData[]>(() => propEdges)
+    const safePropNodes = Array.isArray(propNodes) ? propNodes : []
+    const safePropEdges = Array.isArray(propEdges) ? propEdges : []
+
+    const [nodes, setNodes] = useState<NodeData[]>(() => safePropNodes)
+    const [edges, setEdges] = useState<EdgeData[]>(() => safePropEdges)
     const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 })
     const svgRef = useRef<SVGSVGElement | null>(null)
     const draggingRef = useRef(false)
@@ -62,6 +65,9 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       nodes.forEach(n => map.set(n.id, n))
       return map
     }, [nodes])
+
+    const safeNodes = Array.isArray(nodes) ? nodes : []
+    const safeEdges = Array.isArray(edges) ? edges : []
 
     const handleMouseMove = useCallback(
       (e: MouseEvent) => {
@@ -226,7 +232,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           <g
             transform={`translate(${transform.x},${transform.y}) scale(${transform.k})`}
           >
-            {(edges || []).map(edge => {
+            {safeEdges.map(edge => {
               const from = nodeMap.get(edge.from)
               const to = nodeMap.get(edge.to)
               if (!from || !to) return null
@@ -242,7 +248,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 />
               )
             })}
-            {(nodes || []).map(node => (
+            {safeNodes.map(node => (
               <g key={node.id} transform={`translate(${node.x},${node.y})`}>
                 <circle
                   r={20 / transform.k}

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -43,8 +43,17 @@ export default function MapEditorPage(): JSX.Element {
   if (error) return <div>Error loading map. Failed to load map: 404</div>
   if (!mindmap) return <div>Loading mind map...</div>
 
-  const nodes = Array.isArray(mindmap?.nodes) ? mindmap.nodes : []
-  const edges = Array.isArray(mindmap?.edges) ? mindmap.edges : []
+  const nodes = Array.isArray(mindmap?.nodes)
+    ? mindmap.nodes
+    : Array.isArray(mindmap?.data?.nodes)
+      ? mindmap.data.nodes
+      : []
+
+  const edges = Array.isArray(mindmap?.edges)
+    ? mindmap.edges
+    : Array.isArray(mindmap?.data?.edges)
+      ? mindmap.data.edges
+      : []
 
   if (nodes.length === 0 && edges.length === 0) {
     console.log('[mindmap] No nodes or edges found, rendering empty canvas')


### PR DESCRIPTION
## Summary
- keep node & edge lists from being null when loading maps
- harden MindmapCanvas against invalid props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881c708c0008327b28eaae075669c78