### PR TITLE
Enhance dashboard tiles

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -302,7 +302,7 @@ export default function DashboardPage(): JSX.Element {
             </div>
           </div>
           <div className="tiles-grid">
-            <div className="tile">
+            <div className="tile create-tile">
               <div className="tile-header tile-header-center">
                 <h2>Mind Maps</h2>
                 <button
@@ -316,13 +316,15 @@ export default function DashboardPage(): JSX.Element {
                 </button>
                 <Link to="/mindmaps" className="tile-link">Open Mindmaps</Link>
               </div>
-              <ul className="recent-list">
-                {recentMaps.map(m => (
-                  <li key={m.id}>
-                    <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
-                  </li>
-                ))}
-              </ul>
+              <div className="tile-body">
+                <ul className="recent-list">
+                  {recentMaps.map(m => (
+                    <li key={m.id}>
+                      <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
             <div className="tile" onClick={handleTileClick}>
               <div className="tile-header tile-header-center">
@@ -338,14 +340,16 @@ export default function DashboardPage(): JSX.Element {
                 </button>
                 <Link to="/todos" className="tile-link">Open Todos</Link>
               </div>
-              <ul className="recent-list">
-                {recentTodos.map(t => (
-                  <li key={t.id}>
-                    <Link to="/todo-demo">{t.title || t.content}</Link>
-                    {t.completed && ' ✓'}
-                  </li>
-                ))}
-              </ul>
+              <div className="tile-body">
+                <ul className="recent-list">
+                  {recentTodos.map(t => (
+                    <li key={t.id}>
+                      <Link to="/todo-demo">{t.title || t.content}</Link>
+                      {t.completed && ' ✓'}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
             <div className="tile" onClick={handleTileClick}>
               <div className="tile-header tile-header-center">
@@ -361,13 +365,15 @@ export default function DashboardPage(): JSX.Element {
                 </button>
                 <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
               </div>
-              <ul className="recent-list">
-                {recentBoards.map(b => (
-                  <li key={b.id}>
-                    <Link to={`/kanban/${b.id}`}>{b.title || 'Board'}</Link>
-                  </li>
-                ))}
-              </ul>
+              <div className="tile-body">
+                <ul className="recent-list">
+                  {recentBoards.map(b => (
+                    <li key={b.id}>
+                      <Link to={`/kanban/${b.id}`}>{b.title || 'Board'}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             </div>
           </div>
         </>

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -115,16 +115,20 @@ export default function KanbanBoardsPage(): JSX.Element {
         <> 
           <div className="four-col-grid">
             <div className="tile create-tile">
-              <h2>Create Board</h2>
-              <p className="create-help">Click Create to manually add or use AI to get started.</p>
-              <button className="btn-primary" onClick={() => setShowModal(true)}>
-                Create
-              </button>
+              <div className="tile-header"><h2>Create Board</h2></div>
+              <div className="tile-body">
+                <p className="create-help">Click Create to manually add or use AI to get started.</p>
+                <button className="btn-primary" onClick={() => setShowModal(true)}>
+                  Create
+                </button>
+              </div>
             </div>
             <div className="tile">
-              <h2 className="tile-header">Metrics</h2>
-              <p>Total: {boards.length}</p>
-              <p>Today: {boardDay} Week: {boardWeek}</p>
+              <div className="tile-header"><h2>Metrics</h2></div>
+              <div className="tile-body">
+                <p>Total: {boards.length}</p>
+                <p>Today: {boardDay} Week: {boardWeek}</p>
+              </div>
             </div>
             {sorted.map(b => (
               <div className="tile" key={b.id}>
@@ -142,7 +146,13 @@ export default function KanbanBoardsPage(): JSX.Element {
                     Open
                   </Link>
                 </div>
+                <div className="tile-body">
+                  <p>Board details coming soon...</p>
+                </div>
               </div>
+            ))}
+            {Array.from({ length: 10 }).map((_v, i) => (
+              <div className="tile ghost-tile" key={`ghost-${i}`}></div>
             ))}
           </div>
         </>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -125,16 +125,22 @@ export default function MindmapsPage(): JSX.Element {
       ) : (
         <div className="four-col-grid">
           <div className="tile create-tile">
-            <h2>Create Mind Map</h2>
-            <p className="create-help">Click Create to manually add or use AI to get started.</p>
-            <button className="btn-primary" onClick={() => setShowModal(true)}>
-              Create
-            </button>
+            <div className="tile-header">
+              <h2>Create Mind Map</h2>
+            </div>
+            <div className="tile-body">
+              <p className="create-help">Click Create to manually add or use AI to get started.</p>
+              <button className="btn-primary" onClick={() => setShowModal(true)}>
+                Create
+              </button>
+            </div>
           </div>
           <div className="tile">
-            <h2 className="tile-header">Metrics</h2>
-            <p>Total: {maps.length}</p>
-            <p>Today: {mapDay} Week: {mapWeek}</p>
+            <div className="tile-header"><h2>Metrics</h2></div>
+            <div className="tile-body">
+              <p>Total: {maps.length}</p>
+              <p>Today: {mapDay} Week: {mapWeek}</p>
+            </div>
           </div>
 
           {sorted.length === 0 ? (
@@ -158,9 +164,15 @@ export default function MindmapsPage(): JSX.Element {
                     Open
                   </Link>
                 </div>
+                <div className="tile-body">
+                  <p>{m.data?.description || 'Map details coming soon...'}</p>
+                </div>
               </div>
             ))
           )}
+          {Array.from({ length: 10 }).map((_v, i) => (
+            <div className="tile ghost-tile" key={`ghost-${i}`}></div>
+          ))}
         </div>
       )}
       {showModal && (

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -115,16 +115,20 @@ export default function TodosPage(): JSX.Element {
         <> 
           <div className="four-col-grid">
             <div className="tile create-tile">
-              <h2>Create Todo</h2>
-              <p className="create-help">Click Create to manually add or use AI to get started.</p>
-              <button className="btn-primary" onClick={() => setShowModal(true)}>
-                Create
-              </button>
+              <div className="tile-header"><h2>Create Todo</h2></div>
+              <div className="tile-body">
+                <p className="create-help">Click Create to manually add or use AI to get started.</p>
+                <button className="btn-primary" onClick={() => setShowModal(true)}>
+                  Create
+                </button>
+              </div>
             </div>
             <div className="tile">
-              <h2 className="tile-header">Metrics</h2>
-              <p>Total: {todos.length}</p>
-              <p>Added Today: {addedDay} Week: {addedWeek}</p>
+              <div className="tile-header"><h2>Metrics</h2></div>
+              <div className="tile-body">
+                <p>Total: {todos.length}</p>
+                <p>Added Today: {addedDay} Week: {addedWeek}</p>
+              </div>
             </div>
             {sorted.map(t => (
               <div className="tile" key={t.id}>
@@ -142,7 +146,13 @@ export default function TodosPage(): JSX.Element {
                     Open
                   </Link>
                 </div>
+                <div className="tile-body">
+                  <p>{t.content || 'Todo details coming soon...'}</p>
+                </div>
               </div>
+            ))}
+            {Array.from({ length: 10 }).map((_v, i) => (
+              <div className="tile ghost-tile" key={`ghost-${i}`}></div>
             ))}
           </div>
         </>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1597,11 +1597,14 @@ hr {
 }
 
 .tile {
-  background-color: var(--color-bg-alt);
+  background: linear-gradient(135deg, var(--color-bg), var(--color-bg-alt));
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 12px;
   padding: var(--spacing-lg);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }
 
 .tile-header {
@@ -1609,6 +1612,12 @@ hr {
   justify-content: space-between;
   align-items: center;
   margin-bottom: var(--spacing-md);
+}
+
+.tile-body {
+  flex-grow: 1;
+  font-size: 0.9rem;
+  color: var(--color-text);
 }
 
 .tile-actions {
@@ -1641,6 +1650,9 @@ hr {
   justify-content: center;
   text-align: center;
   min-height: 150px;
+  background-color: #fff7ed;
+  border: 1px solid #f59e0b;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 
 .create-tile button {
@@ -1656,6 +1668,13 @@ hr {
 
 .create-tile button:hover {
   background-color: var(--color-warning);
+}
+
+.ghost-tile {
+  border: 2px dashed var(--color-border);
+  background-color: transparent;
+  min-height: 120px;
+  opacity: 0.5;
 }
 
 .tile-header-center {


### PR DESCRIPTION
## Summary
- style tile component with futuristic gradient
- highlight the create-tile with light orange background
- add ghost placeholder tiles across mindmaps, todos and kanban boards
- rework markup so tiles have header and body sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881cbb85a90832791dd58285129f6a7