### PR TITLE
Add empty map hint

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -272,6 +272,11 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
               </g>
             ))}
           </g>
+          {safeNodes.length === 0 && safeEdges.length === 0 && (
+            <text x={100} y={100} fill="#aaa">
+              No nodes yet. Click to start building your map!
+            </text>
+          )}
         </svg>
       </div>
     )


### PR DESCRIPTION
## Summary
- display a helpful message when no nodes or edges exist in `MindmapCanvas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881cfc532e48327b26c4027d4d021a8