### PR TITLE
Refine create tile appearance

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -175,7 +175,7 @@ export default function DashboardPage(): JSX.Element {
           </div>
           <div className="tiles-grid">
             <div className="tile">
-              <div className="tile-header">
+              <header className="tile-header">
                 <h2>Mind Maps</h2>
                 <button
                   className="btn-primary"
@@ -186,17 +186,19 @@ export default function DashboardPage(): JSX.Element {
                 >
                   Create
                 </button>
-              </div>
-              <ul>
-                {maps.map(m => (
-                  <li key={m.id}>
-                    <Link to={`/maps/${m.id}`}>{m.title || (m as any).data?.title || 'Untitled Map'}</Link>
-                  </li>
-                ))}
-              </ul>
+              </header>
+              <section className="tile-body">
+                <ul>
+                  {maps.map(m => (
+                    <li key={m.id}>
+                      <Link to={`/maps/${m.id}`}>{m.title || (m as any).data?.title || 'Untitled Map'}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
             </div>
             <div className="tile">
-              <div className="tile-header">
+              <header className="tile-header">
                 <h2>Todos</h2>
                 <button
                   className="btn-primary"
@@ -207,20 +209,26 @@ export default function DashboardPage(): JSX.Element {
                 >
                   Create
                 </button>
-              </div>
-              <ul>
-                {todos.map(t => (
-                  <li key={t.id}>
-                    {t.title || t.content}
-                    {t.mindmap_id && <span className="text-sm text-gray-500"> (Map: {t.mindmap_id})</span>}
-                    {t.completed && ' ✓'}
-                  </li>
-                ))}
-              </ul>
+              </header>
+              <section className="tile-body">
+                <ul>
+                  {todos.map(t => (
+                    <li key={t.id}>
+                      {t.title || t.content}
+                      {t.mindmap_id && <span className="text-sm text-gray-500"> (Map: {t.mindmap_id})</span>}
+                      {t.completed && ' ✓'}
+                    </li>
+                  ))}
+                </ul>
+              </section>
             </div>
             <div className="tile">
-              <h2>Kanban Boards</h2>
-              <Link to="/kanban" className="text-blue-600 underline">Open Kanban</Link>
+              <header className="tile-header">
+                <h2>Kanban Boards</h2>
+              </header>
+              <section className="tile-body">
+                <Link to="/kanban" className="text-blue-600 underline">Open Kanban</Link>
+              </section>
             </div>
           </div>
         </>

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -303,7 +303,7 @@ export default function DashboardPage(): JSX.Element {
           </div>
           <div className="tiles-grid">
             <div className="tile create-tile">
-              <div className="tile-header tile-header-center">
+              <header className="tile-header tile-header-center">
                 <h2>Mind Maps</h2>
                 <button
                   className="btn-primary"
@@ -315,8 +315,8 @@ export default function DashboardPage(): JSX.Element {
                   Create
                 </button>
                 <Link to="/mindmaps" className="tile-link">Open Mindmaps</Link>
-              </div>
-              <div className="tile-body">
+              </header>
+              <section className="tile-body">
                 <ul className="recent-list">
                   {recentMaps.map(m => (
                     <li key={m.id}>
@@ -324,10 +324,10 @@ export default function DashboardPage(): JSX.Element {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </section>
             </div>
             <div className="tile" onClick={handleTileClick}>
-              <div className="tile-header tile-header-center">
+              <header className="tile-header tile-header-center">
                 <h2>Todos</h2>
                 <button
                   className="btn-primary"
@@ -339,8 +339,8 @@ export default function DashboardPage(): JSX.Element {
                   Create
                 </button>
                 <Link to="/todos" className="tile-link">Open Todos</Link>
-              </div>
-              <div className="tile-body">
+              </header>
+              <section className="tile-body">
                 <ul className="recent-list">
                   {recentTodos.map(t => (
                     <li key={t.id}>
@@ -349,10 +349,10 @@ export default function DashboardPage(): JSX.Element {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </section>
             </div>
             <div className="tile" onClick={handleTileClick}>
-              <div className="tile-header tile-header-center">
+              <header className="tile-header tile-header-center">
                 <h2>Kanban Boards</h2>
                 <button
                   className="btn-primary"
@@ -364,8 +364,8 @@ export default function DashboardPage(): JSX.Element {
                   Create
                 </button>
                 <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
-              </div>
-              <div className="tile-body">
+              </header>
+              <section className="tile-body">
                 <ul className="recent-list">
                   {recentBoards.map(b => (
                     <li key={b.id}>
@@ -373,7 +373,7 @@ export default function DashboardPage(): JSX.Element {
                     </li>
                   ))}
                 </ul>
-              </div>
+              </section>
             </div>
           </div>
         </>

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -115,24 +115,24 @@ export default function KanbanBoardsPage(): JSX.Element {
         <> 
           <div className="four-col-grid">
             <div className="tile create-tile">
-              <div className="tile-header"><h2>Create Board</h2></div>
-              <div className="tile-body">
+              <header className="tile-header"><h2>Create Board</h2></header>
+              <section className="tile-body">
                 <p className="create-help">Click Create to manually add or use AI to get started.</p>
                 <button className="btn-primary" onClick={() => setShowModal(true)}>
                   Create
                 </button>
-              </div>
+              </section>
             </div>
             <div className="tile">
-              <div className="tile-header"><h2>Metrics</h2></div>
-              <div className="tile-body">
+              <header className="tile-header"><h2>Metrics</h2></header>
+              <section className="tile-body">
                 <p>Total: {boards.length}</p>
                 <p>Today: {boardDay} Week: {boardWeek}</p>
-              </div>
+              </section>
             </div>
             {sorted.map(b => (
               <div className="tile" key={b.id}>
-                <div className="tile-header">
+                <header className="tile-header">
                   <h2>{b.title || 'Board'}</h2>
                   <Link
                     to={`/kanban/${b.id}`}
@@ -145,10 +145,10 @@ export default function KanbanBoardsPage(): JSX.Element {
                   >
                     Open
                   </Link>
-                </div>
-                <div className="tile-body">
+                </header>
+                <section className="tile-body">
                   <p>Board details coming soon...</p>
-                </div>
+                </section>
               </div>
             ))}
             {Array.from({ length: 10 }).map((_v, i) => (

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -125,22 +125,22 @@ export default function MindmapsPage(): JSX.Element {
       ) : (
         <div className="four-col-grid">
           <div className="tile create-tile">
-            <div className="tile-header">
+            <header className="tile-header">
               <h2>Create Mind Map</h2>
-            </div>
-            <div className="tile-body">
+            </header>
+            <section className="tile-body">
               <p className="create-help">Click Create to manually add or use AI to get started.</p>
               <button className="btn-primary" onClick={() => setShowModal(true)}>
                 Create
               </button>
-            </div>
+            </section>
           </div>
           <div className="tile">
-            <div className="tile-header"><h2>Metrics</h2></div>
-            <div className="tile-body">
+            <header className="tile-header"><h2>Metrics</h2></header>
+            <section className="tile-body">
               <p>Total: {maps.length}</p>
               <p>Today: {mapDay} Week: {mapWeek}</p>
-            </div>
+            </section>
           </div>
 
           {sorted.length === 0 ? (
@@ -150,7 +150,7 @@ export default function MindmapsPage(): JSX.Element {
           ) : (
             sorted.map(m => (
               <div className="tile" key={m.id}>
-                <div className="tile-header">
+                <header className="tile-header">
                   <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
                   <Link
                     to={`/maps/${m.id}`}
@@ -163,10 +163,10 @@ export default function MindmapsPage(): JSX.Element {
                   >
                     Open
                   </Link>
-                </div>
-                <div className="tile-body">
+                </header>
+                <section className="tile-body">
                   <p>{m.data?.description || 'Map details coming soon...'}</p>
-                </div>
+                </section>
               </div>
             ))
           )}

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -115,24 +115,24 @@ export default function TodosPage(): JSX.Element {
         <> 
           <div className="four-col-grid">
             <div className="tile create-tile">
-              <div className="tile-header"><h2>Create Todo</h2></div>
-              <div className="tile-body">
+              <header className="tile-header"><h2>Create Todo</h2></header>
+              <section className="tile-body">
                 <p className="create-help">Click Create to manually add or use AI to get started.</p>
                 <button className="btn-primary" onClick={() => setShowModal(true)}>
                   Create
                 </button>
-              </div>
+              </section>
             </div>
             <div className="tile">
-              <div className="tile-header"><h2>Metrics</h2></div>
-              <div className="tile-body">
+              <header className="tile-header"><h2>Metrics</h2></header>
+              <section className="tile-body">
                 <p>Total: {todos.length}</p>
                 <p>Added Today: {addedDay} Week: {addedWeek}</p>
-              </div>
+              </section>
             </div>
             {sorted.map(t => (
               <div className="tile" key={t.id}>
-                <div className="tile-header">
+                <header className="tile-header">
                   <h2>{t.title || t.content}</h2>
                   <Link
                     to="/todo-demo"
@@ -145,10 +145,10 @@ export default function TodosPage(): JSX.Element {
                   >
                     Open
                   </Link>
-                </div>
-                <div className="tile-body">
+                </header>
+                <section className="tile-body">
                   <p>{t.content || 'Todo details coming soon...'}</p>
-                </div>
+                </section>
               </div>
             ))}
             {Array.from({ length: 10 }).map((_v, i) => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1650,8 +1650,8 @@ hr {
   justify-content: center;
   text-align: center;
   min-height: 150px;
-  background-color: #fff7ed;
-  border: 1px solid #f59e0b;
+  background: linear-gradient(135deg, #f8f8f8, #fff7ed);
+  border: 1px solid #fcd9ae;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 

--- a/teammembers.tsx
+++ b/teammembers.tsx
@@ -101,14 +101,16 @@ export default function TeamMembers() {
         <div className="four-col-grid mt-6">
           {members.map(m => (
             <div className="tile" key={m.id}>
-              <div className="tile-header">
+              <header className="tile-header">
                 <h2>{m.name || m.email}</h2>
                 <div className="tile-actions">
                   <button onClick={() => updateMember(m.id)}>Update</button>
                   <button onClick={() => removeMember(m.id)} className="tile-link">Delete</button>
                 </div>
-              </div>
-              {m.name && <p>{m.email}</p>}
+              </header>
+              <section className="tile-body">
+                {m.name && <p>{m.email}</p>}
+              </section>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- soften create tile background with a light silver-to-orange gradient
- add semantic `header` and `section` elements to tiles for better structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d33f2bec8327afc6fa8b8d006cfe