### PR TITLE
Improve map fetching and navigation

### DIFF
--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -62,6 +62,21 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
 
     // ✅ Handle GET
     if (event.httpMethod === 'GET') {
+      const id = event.queryStringParameters?.id
+
+      if (id) {
+        const result = await client.query(
+          `SELECT id, title, description, created_at FROM mindmaps WHERE id = $1 AND user_id = $2`,
+          [id, userId]
+        )
+
+        if (result.rowCount === 0) {
+          return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found' }) }
+        }
+
+        return { statusCode: 200, headers, body: JSON.stringify({ map: result.rows[0] }) }
+      }
+
       const result = await client.query(
         `SELECT id, title, description, created_at FROM mindmaps
          WHERE user_id = $1

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -110,7 +110,7 @@ export default function DashboardPage(): JSX.Element {
         })
         const json = await res.json()
         if (json?.id) {
-          navigate(`/maps/${json.id}`)
+          setTimeout(() => navigate(`/maps/${json.id}`), 250)
         }
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/todos', {
@@ -156,7 +156,7 @@ export default function DashboardPage(): JSX.Element {
         })
         const json = await res.json()
         if (json?.id) {
-          navigate(`/maps/${json.id}`)
+          setTimeout(() => navigate(`/maps/${json.id}`), 250)
         }
       } else if (createType === 'todo') {
         await fetch('/.netlify/functions/ai-create-todo', {

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -34,7 +34,9 @@ export default function MapEditorPage(): JSX.Element {
           if (!ignore) setError(true)
           return
         }
+        console.log('Map fetch response:', res.status)
         const json = await res.json()
+        console.log('Map JSON:', json)
         if (!ignore) {
           console.log('[MapEditorPage] mindmap response:', json.map || json)
           setMindmap(json.map || json)

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -55,7 +55,7 @@ export default function MindmapsPage(): JSX.Element {
       setShowModal(false)
       setForm({ title: '', description: '' })
       if (json?.id) {
-        navigate(`/maps/${json.id}`)
+        setTimeout(() => navigate(`/maps/${json.id}`), 250)
       } else {
         fetchData()
       }
@@ -80,7 +80,7 @@ export default function MindmapsPage(): JSX.Element {
       setShowModal(false)
       setForm({ title: '', description: '' })
       if (json?.id) {
-        navigate(`/maps/${json.id}`)
+        setTimeout(() => navigate(`/maps/${json.id}`), 250)
       } else {
         fetchData()
       }


### PR DESCRIPTION
## Summary
- allow single map retrieval in mindmaps.ts via `?id=`
- delay navigation after creating a map
- log fetch status and body in MapEditorPage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881d460c8b48327bb2182fbf8b5ab1e