### PR TITLE
Align layout across canvas pages

### DIFF
--- a/TodoDetail.tsx
+++ b/TodoDetail.tsx
@@ -1,5 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
+import SidebarNav from './src/SidebarNav'
+import { authFetch } from './authFetch'
 
 interface Note {
   id: string
@@ -10,8 +12,26 @@ interface Note {
 
 export default function TodoDetail() {
   const { id } = useParams<{ id: string }>()
+  const [todo, setTodo] = useState<{ title?: string } | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [notes, setNotes] = useState<Note[]>([])
   const [text, setText] = useState('')
+
+  useEffect(() => {
+    if (!id) return
+    setLoading(true)
+    setError(null)
+    authFetch(`/.netlify/functions/todoid/${id}`)
+      .then(async res => {
+        if (!res.ok) throw new Error('Failed to load todo')
+        const json = await res.json()
+        setTodo(json)
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false))
+  }, [id])
+
   const addNote = () => {
     const t = text.trim()
     if (!t) return
@@ -22,19 +42,34 @@ export default function TodoDetail() {
     setText('')
   }
   return (
-    <div className="todo-detail">
-      <h1>Todo {id}</h1>
-      <ul className="notes-list">
-        {notes.map(n => (
-          <li key={n.id}>
-            <strong>{n.author}</strong>: {n.text} <em>{n.date}</em>
-          </li>
-        ))}
-      </ul>
-      <div className="note-form">
-        <input value={text} onChange={e => setText(e.target.value)} placeholder="Add note" />
-        <button onClick={addNote}>Add</button>
-      </div>
+    <div className="dashboard-layout">
+      <SidebarNav />
+      <main className="main-area todo-detail">
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p className="error">{error}</p>
+        ) : (
+          <>
+            <h1>{todo?.title || `Todo ${id}`}</h1>
+            <ul className="notes-list">
+              {notes.map(n => (
+                <li key={n.id}>
+                  <strong>{n.author}</strong>: {n.text} <em>{n.date}</em>
+                </li>
+              ))}
+            </ul>
+            <div className="note-form">
+              <input
+                value={text}
+                onChange={e => setText(e.target.value)}
+                placeholder="Add note"
+              />
+              <button onClick={addNote}>Add</button>
+            </div>
+          </>
+        )}
+      </main>
     </div>
   )
 }

--- a/src/KanbanBoardPage.tsx
+++ b/src/KanbanBoardPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import KanbanCanvas from '../KanbanCanvas'
 import { authFetch } from '../authFetch'
+import SidebarNav from './SidebarNav'
 
 interface BoardItem {
   id: string
@@ -33,9 +34,12 @@ export default function KanbanBoardPage(): JSX.Element {
   if (!boardId) return <div>No board specified</div>
 
   return (
-    <div className="kanban-board-page">
-      <h1>{board?.title || 'Kanban Board'}</h1>
-      <KanbanCanvas />
+    <div className="dashboard-layout">
+      <SidebarNav />
+      <main className="main-area kanban-board-page">
+        <h1>{board?.title || 'Kanban Board'}</h1>
+        <KanbanCanvas />
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- load todo by id and mirror map editor layout on TodoDetail
- wrap KanbanBoardPage in dashboard layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881d6dc09f08327a8057edc0a9817d6