### PR TITLE
Implement simple Kanban canvas

### DIFF
--- a/EmptyKanbanBoard.tsx
+++ b/EmptyKanbanBoard.tsx
@@ -1,0 +1,13 @@
+import KanbanLane from './KanbanLane'
+
+export default function EmptyKanbanBoard() {
+  const lanes = ['To Do', 'In Progress', 'Done']
+
+  return (
+    <div className="kanban-board">
+      {lanes.map(lane => (
+        <KanbanLane key={lane} title={lane} cards={[]} />
+      ))}
+    </div>
+  )
+}

--- a/KanbanCanvas.tsx
+++ b/KanbanCanvas.tsx
@@ -1,55 +1,18 @@
-import { useState } from 'react'
+import KanbanLane from './KanbanLane'
+import EmptyKanbanBoard from './EmptyKanbanBoard'
 
-interface Card { id: string; title: string }
-interface Lane { id: string; title: string; cards: Card[] }
+export default function KanbanCanvas({ boardData }: { boardData?: any }) {
+  const hasCards = boardData?.lanes?.some((lane: any) => lane.cards?.length > 0)
 
-export default function KanbanCanvas() {
-  const [lanes, setLanes] = useState<Lane[]>([
-    { id: 'todo', title: 'To Do', cards: [] },
-    { id: 'doing', title: 'In Progress', cards: [] },
-    { id: 'done', title: 'Done', cards: [] }
-  ])
-  const [newCardTitle, setNewCardTitle] = useState('')
-  const [activeLane, setActiveLane] = useState('todo')
-
-  const addCard = () => {
-    const t = newCardTitle.trim()
-    if (!t) return
-    setLanes(prev =>
-      prev.map(l =>
-        l.id === activeLane
-          ? { ...l, cards: [...l.cards, { id: Date.now().toString(), title: t }] }
-          : l
-      )
-    )
-    setNewCardTitle('')
+  if (!hasCards) {
+    return <EmptyKanbanBoard />
   }
 
   return (
-    <div className="kanban-canvas">
-      <div className="card-form">
-        <select value={activeLane} onChange={e => setActiveLane(e.target.value)}>
-          {lanes.map(l => (
-            <option key={l.id} value={l.id}>{l.title}</option>
-          ))}
-        </select>
-        <input
-          value={newCardTitle}
-          onChange={e => setNewCardTitle(e.target.value)}
-          placeholder="Card title"
-        />
-        <button onClick={addCard}>+</button>
-      </div>
-      <div className="kanban-board">
-        {lanes.map(lane => (
-          <div key={lane.id} className="kanban-lane">
-            <h3 className="lane-title">{lane.title}</h3>
-            {lane.cards.map(c => (
-              <div key={c.id} className="kanban-card">{c.title}</div>
-            ))}
-          </div>
-        ))}
-      </div>
+    <div className="kanban-board">
+      {boardData.lanes.map((lane: any) => (
+        <KanbanLane key={lane.id} title={lane.title} cards={lane.cards} />
+      ))}
     </div>
   )
 }

--- a/KanbanCard.tsx
+++ b/KanbanCard.tsx
@@ -1,0 +1,7 @@
+export default function KanbanCard({ title }: { title?: string }) {
+  return (
+    <div className="kanban-card">
+      {title || 'New Card'}
+    </div>
+  )
+}

--- a/KanbanLane.tsx
+++ b/KanbanLane.tsx
@@ -1,0 +1,15 @@
+import KanbanCard from './KanbanCard'
+
+export default function KanbanLane({ title, cards = [] }: { title: string; cards?: string[] }) {
+  return (
+    <div className="kanban-lane">
+      <h3 className="lane-title">{title}</h3>
+      {cards.length === 0 ? (
+        <KanbanCard title="(Empty)" />
+      ) : (
+        cards.map((card, i) => <KanbanCard key={i} title={card} />)
+      )}
+      <button className="btn-secondary">Add Card</button>
+    </div>
+  )
+}

--- a/src/KanbanBoardPage.tsx
+++ b/src/KanbanBoardPage.tsx
@@ -12,33 +12,24 @@ interface BoardItem {
 
 export default function KanbanBoardPage(): JSX.Element {
   const { id } = useParams<{ id: string }>()
-  const boardId = id || ''
-  const [board, setBoard] = useState<BoardItem | null>(null)
+  const [boardData, setBoardData] = useState<any>(null)
 
   useEffect(() => {
-    if (!boardId) return
-    let ignore = false
-    authFetch(`/.netlify/functions/boards?id=${boardId}`)
-      .then(async res => {
-        if (!ignore && res.ok) {
-          const json = await res.json()
-          setBoard(json.board || null)
-        }
+    if (!id) return
+    authFetch(`/.netlify/functions/boards?id=${id}`)
+      .then(res => res.json())
+      .then(data => setBoardData(data))
+      .catch(err => {
+        console.error('Error loading kanban board', err)
+        setBoardData(null)
       })
-      .catch(() => {})
-    return () => {
-      ignore = true
-    }
-  }, [boardId])
-
-  if (!boardId) return <div>No board specified</div>
+  }, [id])
 
   return (
     <div className="dashboard-layout">
       <SidebarNav />
-      <main className="main-area kanban-board-page">
-        <h1>{board?.title || 'Kanban Board'}</h1>
-        <KanbanCanvas />
+      <main className="main-area">
+        <KanbanCanvas boardData={boardData} />
       </main>
     </div>
   )

--- a/src/global.scss
+++ b/src/global.scss
@@ -1930,3 +1930,44 @@ hr {
 .add-todo-button-wrapper {
   margin-top: 2rem;
 }
+
+/* Kanban Canvas */
+.kanban-board {
+  display: flex;
+  gap: 1.5rem;
+  padding: 2rem;
+  overflow-x: auto;
+}
+
+.kanban-lane {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  min-width: 250px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kanban-card {
+  background: #ffedd5;
+  padding: 0.75rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.lane-title {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.btn-secondary {
+  background: #f97316;
+  color: #fff;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create new `KanbanCard`, `KanbanLane`, and `EmptyKanbanBoard` components
- rework `KanbanCanvas` to show placeholder lanes when no cards present
- update `KanbanBoardPage` to fetch board info and render canvas
- add basic Kanban styles

## Testing
- `npm test`
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6881dd5ddfe0832791061407f8e90ea0