### PR TITLE
Enhance metrics layout

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -159,18 +159,64 @@ export default function DashboardPage(): JSX.Element {
             <div className="metric-card">
               <h3 className="metric-title">Mind Maps</h3>
               <div className="metric-value">{maps.length}</div>
-              <p>Today: {mapDay}</p>
-              <p>This Week: {mapWeek}</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{mapDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{mapWeek}</span>
+                </div>
+              </div>
             </div>
             <div className="metric-card">
               <h3 className="metric-title">Todos</h3>
               <div className="metric-value">{todos.length}</div>
-              <p>Added Today: {todoAddedDay} Completed: {todoDoneDay}</p>
-              <p>Added Week: {todoAddedWeek} Completed: {todoDoneWeek}</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today Added</span>
+                  <span className="value">{todoAddedDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Today Done</span>
+                  <span className="value">{todoDoneDay}</span>
+                </div>
+              </div>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Week Added</span>
+                  <span className="value">{todoAddedWeek}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week Done</span>
+                  <span className="value">{todoDoneWeek}</span>
+                </div>
+              </div>
             </div>
             <div className="metric-card">
               <h3 className="metric-title">Kanban Boards</h3>
               <div className="metric-value">{boards.length}</div>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{boardDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{boardWeek}</span>
+                </div>
+              </div>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Cards Added</span>
+                  <span className="value">0</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Completed</span>
+                  <span className="value">0</span>
+                </div>
+              </div>
               <Link to="/kanban" className="text-blue-600 underline">View Boards</Link>
             </div>
           </div>

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -282,22 +282,66 @@ export default function DashboardPage(): JSX.Element {
             <div className="metric-card">
               <h3 className="metric-title">Mind Maps</h3>
               <div className="metric-value">{maps.length}</div>
-              <p>Today: {mapDay} &middot; Week: {mapWeek}</p>
-              <p>Nodes: {nodesThisWeek} vs {nodesLastWeek}</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{mapDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{mapWeek}</span>
+                </div>
+              </div>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Nodes This Week</span>
+                  <span className="value">{nodesThisWeek}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Last Week</span>
+                  <span className="value">{nodesLastWeek}</span>
+                </div>
+              </div>
               <Sparkline data={nodeTrend} />
             </div>
             <div className="metric-card">
               <h3 className="metric-title">Todos</h3>
               <div className="metric-value">{todos.length}</div>
-              <p>Added Week: {todoAddedWeek}</p>
-              <p>Completed Week: {todoDoneWeek}</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Week Added</span>
+                  <span className="value">{todoAddedWeek}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week Done</span>
+                  <span className="value">{todoDoneWeek}</span>
+                </div>
+              </div>
               <Sparkline data={todoTrend} />
             </div>
             <div className="metric-card">
               <h3 className="metric-title">Kanban Boards</h3>
               <div className="metric-value">{boards.length}</div>
-              <p>Today: {boardDay} &middot; Week: {boardWeek}</p>
-              <p>Cards Added: 0 Completed: 0</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{boardDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{boardWeek}</span>
+                </div>
+              </div>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Cards Added</span>
+                  <span className="value">0</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Completed</span>
+                  <span className="value">0</span>
+                </div>
+              </div>
               <Sparkline data={boardTrend} />
             </div>
           </div>

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -127,7 +127,26 @@ export default function KanbanBoardsPage(): JSX.Element {
               <header className="tile-header"><h2>Metrics</h2></header>
               <section className="tile-body">
                 <p>Total: {boards.length}</p>
-                <p>Today: {boardDay} Week: {boardWeek}</p>
+                <div className="metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{boardDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{boardWeek}</span>
+                  </div>
+                </div>
+                <div className="metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Cards Added</span>
+                    <span className="value">0</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Completed</span>
+                    <span className="value">0</span>
+                  </div>
+                </div>
               </section>
             </div>
             {sorted.map(b => (

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -139,7 +139,16 @@ export default function MindmapsPage(): JSX.Element {
             <header className="tile-header"><h2>Metrics</h2></header>
             <section className="tile-body">
               <p>Total: {maps.length}</p>
-              <p>Today: {mapDay} Week: {mapWeek}</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{mapDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{mapWeek}</span>
+                </div>
+              </div>
             </section>
           </div>
 

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -127,7 +127,16 @@ export default function TodosPage(): JSX.Element {
               <header className="tile-header"><h2>Metrics</h2></header>
               <section className="tile-body">
                 <p>Total: {todos.length}</p>
-                <p>Added Today: {addedDay} Week: {addedWeek}</p>
+                <div className="metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{addedDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{addedWeek}</span>
+                  </div>
+                </div>
               </section>
             </div>
             {sorted.map(t => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1561,6 +1561,33 @@ hr {
   margin: 0 0 var(--spacing-xs);
 }
 
+.metric-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--spacing-sm);
+  width: 100%;
+  margin-top: var(--spacing-sm);
+}
+
+.metric-detail {
+  background: var(--color-surface);
+  border-radius: 8px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  text-align: center;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.metric-detail .label {
+  display: block;
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+}
+
+.metric-detail .value {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
 .metric-title {
   margin-bottom: var(--spacing-md);
   font-size: 1.1rem;


### PR DESCRIPTION
## Summary
- restyle metric cards with new grid layout
- add fancy metric sections on dashboard, maps, todos and kanban pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881df70d90c8327a7403aed6ebff0e2