### PR TITLE
Improve empty canvas prompts with modals

### DIFF
--- a/EmptyKanbanBoard.tsx
+++ b/EmptyKanbanBoard.tsx
@@ -4,10 +4,18 @@ export default function EmptyKanbanBoard() {
   const lanes = ['To Do', 'In Progress', 'Done']
 
   return (
-    <div className="kanban-board">
-      {lanes.map(lane => (
-        <KanbanLane key={lane} title={lane} cards={[]} />
-      ))}
-    </div>
+    <>
+      <div className="kanban-board">
+        {lanes.map(lane => (
+          <KanbanLane key={lane} title={lane} cards={[]} />
+        ))}
+      </div>
+      <div className="modal-overlay empty-canvas-modal">
+        <div className="modal">
+          <p>No cards yet. Click below to add your first card!</p>
+          <button className="btn-primary">Add Card</button>
+        </div>
+      </div>
+    </>
   )
 }

--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -13,7 +13,12 @@ export default function TodoCanvas({ todos }: { todos: any[] }): JSX.Element {
               <TodoPlaceholder key={i} />
             ))}
           </div>
-          <AddTodoButton />
+          <div className="modal-overlay empty-canvas-modal">
+            <div className="modal">
+              <p>No todos yet. Click below to add your first todo!</p>
+              <AddTodoButton />
+            </div>
+          </div>
         </>
       ) : (
         <div className="todo-list">

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -329,9 +329,9 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
             ))}
           </g>
           {safeNodes.length === 0 && safeEdges.length === 0 && (
-            <foreignObject x="0" y="0" width="100%" height="100%">
-              <div className="empty-map-message">
-                <p>No nodes yet. Click to start building your map!</p>
+            <div className="modal-overlay empty-canvas-modal">
+              <div className="modal">
+                <p>No nodes yet. Click below to start building your map!</p>
                 <button
                   type="button"
                   className="btn-primary"
@@ -340,7 +340,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   Add Node
                 </button>
               </div>
-            </foreignObject>
+            </div>
           )}
         </svg>
       </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1998,3 +1998,20 @@ hr {
   border-radius: 4px;
   cursor: pointer;
 }
+
+/* Empty canvas modal */
+.empty-canvas-modal .modal {
+  background: rgba(255, 255, 255, 0.95);
+  text-align: center;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme='dark'] .empty-canvas-modal .modal {
+  background: rgba(17, 24, 39, 0.95);
+}
+
+.empty-canvas-modal p {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- display a modal when a mindmap has no nodes
- overlay modal on empty todo canvas
- overlay modal on empty kanban board
- style new empty canvas modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e127f838832785bed3d890f03bd0