### PR TITLE
Fix empty canvas modal overlay

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -328,21 +328,21 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
               </g>
             ))}
           </g>
-          {safeNodes.length === 0 && safeEdges.length === 0 && (
-            <div className="modal-overlay empty-canvas-modal">
-              <div className="modal">
-                <p>No nodes yet. Click below to start building your map!</p>
-                <button
-                  type="button"
-                  className="btn-primary"
-                  onClick={() => onAddNode && onAddNode()}
-                >
-                  Add Node
-                </button>
-              </div>
-            </div>
-          )}
         </svg>
+        {safeNodes.length === 0 && safeEdges.length === 0 && (
+          <div className="modal-overlay empty-canvas-modal">
+            <div className="modal">
+              <p>No nodes yet. Click below to start building your map!</p>
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={() => onAddNode && onAddNode()}
+              >
+                Add Node
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- fix overlay for empty mindmap canvas by placing it outside the SVG

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e40a1df08327b118b92d76b560c9