### PR TITLE
Improve dashboard layout and buttons

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -278,6 +278,81 @@ export default function DashboardPage(): JSX.Element {
         <p className="error">{error}</p>
       ) : (
         <>
+          <div className="tiles-grid">
+            <div className="tile create-tile">
+              <header className="tile-header tile-header-center">
+                <h2>Mind Maps</h2>
+                <button
+                  className="btn-primary btn-wide"
+                  onClick={() => {
+                    setCreateType('map')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
+                <Link to="/mindmaps" className="tile-link">Open Mindmaps</Link>
+              </header>
+              <section className="tile-body">
+                <ul className="recent-list">
+                  {recentMaps.map(m => (
+                    <li key={m.id}>
+                      <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </div>
+            <div className="tile" onClick={handleTileClick}>
+              <header className="tile-header tile-header-center">
+                <h2>Todos</h2>
+                <button
+                  className="btn-primary btn-wide"
+                  onClick={() => {
+                    setCreateType('todo')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
+                <Link to="/todos" className="tile-link">Open Todos</Link>
+              </header>
+              <section className="tile-body">
+                <ul className="recent-list">
+                  {recentTodos.map(t => (
+                    <li key={t.id}>
+                      <Link to="/todo-demo">{t.title || t.content}</Link>
+                      {t.completed && ' ✓'}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </div>
+            <div className="tile" onClick={handleTileClick}>
+              <header className="tile-header tile-header-center">
+                <h2>Kanban Boards</h2>
+                <button
+                  className="btn-primary btn-wide"
+                  onClick={() => {
+                    setCreateType('board')
+                    setShowModal(true)
+                  }}
+                >
+                  Create
+                </button>
+                <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
+              </header>
+              <section className="tile-body">
+                <ul className="recent-list">
+                  {recentBoards.map(b => (
+                    <li key={b.id}>
+                      <Link to={`/kanban/${b.id}`}>{b.title || 'Board'}</Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </div>
+          </div>
           <div className="metrics-grid">
             <div className="metric-card">
               <h3 className="metric-title">Mind Maps</h3>
@@ -323,81 +398,6 @@ export default function DashboardPage(): JSX.Element {
                 </div>
               </div>
               <Sparkline data={boardTrend} />
-            </div>
-          </div>
-          <div className="tiles-grid">
-            <div className="tile create-tile">
-              <header className="tile-header tile-header-center">
-                <h2>Mind Maps</h2>
-                <button
-                  className="btn-primary"
-                  onClick={() => {
-                    setCreateType('map')
-                    setShowModal(true)
-                  }}
-                >
-                  Create
-                </button>
-                <Link to="/mindmaps" className="tile-link">Open Mindmaps</Link>
-              </header>
-              <section className="tile-body">
-                <ul className="recent-list">
-                  {recentMaps.map(m => (
-                    <li key={m.id}>
-                      <Link to={`/maps/${m.id}`}>{m.title || 'Untitled Map'}</Link>
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            </div>
-            <div className="tile" onClick={handleTileClick}>
-              <header className="tile-header tile-header-center">
-                <h2>Todos</h2>
-                <button
-                  className="btn-primary"
-                  onClick={() => {
-                    setCreateType('todo')
-                    setShowModal(true)
-                  }}
-                >
-                  Create
-                </button>
-                <Link to="/todos" className="tile-link">Open Todos</Link>
-              </header>
-              <section className="tile-body">
-                <ul className="recent-list">
-                  {recentTodos.map(t => (
-                    <li key={t.id}>
-                      <Link to="/todo-demo">{t.title || t.content}</Link>
-                      {t.completed && ' ✓'}
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            </div>
-            <div className="tile" onClick={handleTileClick}>
-              <header className="tile-header tile-header-center">
-                <h2>Kanban Boards</h2>
-                <button
-                  className="btn-primary"
-                  onClick={() => {
-                    setCreateType('board')
-                    setShowModal(true)
-                  }}
-                >
-                  Create
-                </button>
-                <Link to="/kanban" className="tile-link">Open Kanban Boards</Link>
-              </header>
-              <section className="tile-body">
-                <ul className="recent-list">
-                  {recentBoards.map(b => (
-                    <li key={b.id}>
-                      <Link to={`/kanban/${b.id}`}>{b.title || 'Board'}</Link>
-                    </li>
-                  ))}
-                </ul>
-              </section>
             </div>
           </div>
         </>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1634,11 +1634,11 @@ hr {
 }
 
 .tile {
-  background: linear-gradient(135deg, var(--color-bg), var(--color-bg-alt));
+  background-color: var(--color-bg-alt);
   border: 1px solid var(--color-border);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: var(--spacing-lg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: none;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1687,9 +1687,9 @@ hr {
   justify-content: center;
   text-align: center;
   min-height: 150px;
-  background: linear-gradient(135deg, #f8f8f8, #fff7ed);
-  border: 1px solid #fcd9ae;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  background-color: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  box-shadow: none;
 }
 
 .create-tile button {
@@ -1698,7 +1698,6 @@ hr {
   color: var(--color-text-inverse);
   border: none;
   border-radius: 4px;
-  padding: var(--spacing-xs) var(--spacing-sm);
   cursor: pointer;
   transition: background-color var(--transition-duration) var(--transition-ease);
 }
@@ -1796,6 +1795,11 @@ hr {
   transition: background-color var(--transition-duration) var(--transition-ease);
 }
 
+.btn-wide {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: 1rem;
+}
+
 .btn-primary:hover {
   background-color: var(--color-warning);
 }
@@ -1822,7 +1826,6 @@ hr {
   color: var(--color-text-inverse);
   border: none;
   border-radius: 4px;
-  padding: var(--spacing-xs) var(--spacing-sm);
   cursor: pointer;
   transition: background-color var(--transition-duration) var(--transition-ease);
 }


### PR DESCRIPTION
## Summary
- move create tiles above dashboard metrics
- enlarge create buttons with new `.btn-wide` style
- flatten tile styles for a modern look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e5ef85288327a021e5b82c872e34