### PR TITLE
Fix empty canvas overlay position

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1743,7 +1743,7 @@ hr {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 1300;
   animation: fade-in 0.3s var(--transition-ease);
 }
 
@@ -2009,6 +2009,12 @@ hr {
   padding: 2rem;
   border-radius: 8px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+.empty-canvas-modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 [data-theme='dark'] .empty-canvas-modal .modal {


### PR DESCRIPTION
## Summary
- keep empty canvas modal centered
- bump overlay z-index to ensure visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e71471708327b834fc52cd28f8f0