### PR TITLE
Refine dashboard create tiles

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -303,7 +303,7 @@ export default function DashboardPage(): JSX.Element {
                 </ul>
               </section>
             </div>
-            <div className="tile" onClick={handleTileClick}>
+            <div className="tile create-tile" onClick={handleTileClick}>
               <header className="tile-header tile-header-center">
                 <h2>Todos</h2>
                 <button
@@ -328,7 +328,7 @@ export default function DashboardPage(): JSX.Element {
                 </ul>
               </section>
             </div>
-            <div className="tile" onClick={handleTileClick}>
+            <div className="tile create-tile" onClick={handleTileClick}>
               <header className="tile-header tile-header-center">
                 <h2>Kanban Boards</h2>
                 <button

--- a/src/global.scss
+++ b/src/global.scss
@@ -1618,6 +1618,7 @@ hr {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
 }
 
 /* 4 column layout used on list pages */
@@ -1636,9 +1637,9 @@ hr {
 .tile {
   background-color: var(--color-bg-alt);
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: 12px;
   padding: var(--spacing-lg);
-  box-shadow: none;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1687,14 +1688,14 @@ hr {
   justify-content: center;
   text-align: center;
   min-height: 150px;
-  background-color: var(--color-bg-alt);
-  border: 1px solid var(--color-border);
-  box-shadow: none;
+  background-color: #fff7ed;
+  border: 1px solid var(--color-warning);
+  box-shadow: 0 2px 6px rgba(245, 158, 11, 0.2);
 }
 
 .create-tile button {
   margin-top: var(--spacing-md);
-  background-color: var(--color-primary);
+  background-color: var(--color-warning);
   color: var(--color-text-inverse);
   border: none;
   border-radius: 4px;
@@ -1703,7 +1704,7 @@ hr {
 }
 
 .create-tile button:hover {
-  background-color: var(--color-warning);
+  background-color: #f97316;
 }
 
 .ghost-tile {


### PR DESCRIPTION
## Summary
- convert all dashboard tiles to `create-tile`
- add spacing between tiles and metrics
- modernize tile appearance with soft orange styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e88064c88327a6ad23601efa391c