### PR TITLE
Increase margin on dashboard tiles

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1726,7 +1726,7 @@ hr {
 }
 
 .tile-header-center .tile-link {
-  margin-top: var(--spacing-xs);
+  margin-top: 50px;
   font-size: 0.85rem;
   color: var(--color-primary);
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- update dashboard tile link margin to 50px

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881e939a18c832793fe85e961d6cc4e