### PR TITLE
Show tasks and boards as dashboard tiles

### DIFF
--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -144,7 +144,7 @@ export default function TodosPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{t.title || t.content}</h2>
                   <Link
-                    to="/todo-demo"
+                    to={`/todo/${t.id}`}
                     onClick={() =>
                       localStorage.setItem(
                         `todo_last_viewed_${t.id}`,


### PR DESCRIPTION
## Summary
- link Todo dashboard tiles to `/todo/:id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881ed50cce883279715c04d0cd83cc1