### PR TITLE
Add canvas routes for Todos and enhance board creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ProjectWorkspace from '../ProjectWorkspace'
 import MapEditorPage from './MapEditorPage'
 import TodoEditorPage from './TodoEditorPage'
 import TodoDetail from '../TodoDetail'
+import TodosCanvasPage from './TodosCanvasPage'
 import TeamMembers from '../teammembers'
 import ProfilePage from '../profile'
 import BillingPage from '../billing'
@@ -45,6 +46,7 @@ function AppRoutes() {
       <Route path="/maps/:id" element={<MapEditorPage />} />
       <Route path="/workspace" element={<ProjectWorkspace />} />
       <Route path="/todo/:id" element={<TodoDetail />} />
+      <Route path="/todos/:id" element={<TodosCanvasPage />} />
       <Route path="/todo-canvas" element={<TodoEditorPage />} />
       <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/privacy" element={<PrivacyPolicy />} />

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
 import { authHeaders } from '../authHeaders'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
@@ -24,6 +24,7 @@ export default function KanbanBoardsPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
   const [form, setForm] = useState({ title: '', description: '' })
+  const navigate = useNavigate()
 
   const fetchData = async (): Promise<void> => {
     setLoading(true)
@@ -50,7 +51,7 @@ export default function KanbanBoardsPage(): JSX.Element {
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      await fetch('/.netlify/functions/boards', {
+      const res = await fetch('/.netlify/functions/boards', {
         method: 'POST',
         credentials: 'include', // Required for session cookie
         headers: {
@@ -58,9 +59,14 @@ export default function KanbanBoardsPage(): JSX.Element {
         },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
+      const json = await res.json()
       setShowModal(false)
       setForm({ title: '', description: '' })
-      fetchData()
+      if (json?.id) {
+        navigate(`/kanban/${json.id}`)
+      } else {
+        fetchData()
+      }
     } catch (err: any) {
       alert(err.message || 'Creation failed')
     }
@@ -68,7 +74,7 @@ export default function KanbanBoardsPage(): JSX.Element {
 
   const handleAiCreate = async (): Promise<void> => {
     try {
-      await fetch('/.netlify/functions/ai-create-board', {
+      const res = await fetch('/.netlify/functions/ai-create-board', {
         method: 'POST',
         credentials: 'include', // Required for session cookie
         headers: {
@@ -76,9 +82,14 @@ export default function KanbanBoardsPage(): JSX.Element {
         },
         body: JSON.stringify({ title: form.title, description: form.description }),
       })
+      const json = await res.json()
       setShowModal(false)
       setForm({ title: '', description: '' })
-      fetchData()
+      if (json?.id) {
+        navigate(`/kanban/${json.id}`)
+      } else {
+        fetchData()
+      }
     } catch (err: any) {
       alert(err.message || 'AI creation failed')
     }

--- a/src/TodosCanvasPage.tsx
+++ b/src/TodosCanvasPage.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import TodoCanvas from '../TodoCanvas'
+import { authFetch } from '../authFetch'
+import SidebarNav from './SidebarNav'
+
+export default function TodosCanvasPage(): JSX.Element {
+  const { id } = useParams<{ id: string }>()
+  const [todo, setTodo] = useState<any | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+    authFetch(`/.netlify/functions/todoid/${id}`)
+      .then(res => res.json())
+      .then(data => setTodo(data))
+      .catch(() => setTodo(null))
+  }, [id])
+
+  return (
+    <div className="dashboard-layout">
+      <SidebarNav />
+      <main className="main-area">
+        <TodoCanvas todos={todo ? [todo] : []} />
+      </main>
+    </div>
+  )
+}

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -65,7 +65,7 @@ export default function TodosPage(): JSX.Element {
       setShowModal(false)
       setForm({ title: '', description: '' })
       if (json?.id) {
-        setTimeout(() => navigate(`/todo/${json.id}`), 250)
+        setTimeout(() => navigate(`/todos/${json.id}`), 250)
       } else {
         fetchData()
       }
@@ -86,7 +86,7 @@ export default function TodosPage(): JSX.Element {
       setShowModal(false)
       setForm({ title: '', description: '' })
       if (json?.id) {
-        setTimeout(() => navigate(`/todo/${json.id}`), 250)
+        setTimeout(() => navigate(`/todos/${json.id}`), 250)
       } else {
         fetchData()
       }
@@ -155,7 +155,7 @@ export default function TodosPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{t.title || t.content}</h2>
                   <Link
-                    to={`/todo/${t.id}`}
+                    to={`/todos/${t.id}`}
                     onClick={() =>
                       localStorage.setItem(
                         `todo_last_viewed_${t.id}`,


### PR DESCRIPTION
## Summary
- redirect todo creation and links to `/todos/:id`
- navigate to new kanban boards after creation or AI creation
- add `TodosCanvasPage` for `/todos/:id`
- update router with new canvas page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f1fa6aa083278f38c3208f504b32