### PR TITLE
Add team member placeholders

### DIFF
--- a/teammembers.tsx
+++ b/teammembers.tsx
@@ -113,6 +113,9 @@ export default function TeamMembers() {
               </section>
             </div>
           ))}
+          {Array.from({ length: Math.max(0, 3 - members.length) }).map((_, i) => (
+            <div className="tile ghost-tile" key={`ghost-${i}`}></div>
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add empty placeholder tiles to Team Members page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f3a4633c8327877a0ec3ce194302