### PR TITLE
Fix login token persistence

### DIFF
--- a/aboutmodulepage.tsx
+++ b/aboutmodulepage.tsx
@@ -22,11 +22,6 @@ const AboutModulePage: React.FC = () => {
 
     const fetchModule = async () => {
       try {
-        const token = localStorage.getItem('token')
-        if (!token) {
-          setLoading(false)
-          return
-        }
         const response = await authFetch(
           `/.netlify/functions/get-module?moduleId=${encodeURIComponent(moduleId)}`,
           { signal: controller.signal }

--- a/analytics.tsx
+++ b/analytics.tsx
@@ -50,11 +50,6 @@ export default function AnalyticsPage(): JSX.Element {
           start: dateRange.start.toISOString(),
           end: dateRange.end.toISOString(),
         })
-        const token = localStorage.getItem('token')
-        if (!token) {
-          setLoading(false)
-          return
-        }
         const res = await authFetch(`/.netlify/functions/analytics?${params.toString()}`, { signal })
         if (!res.ok) {
           const errText = await res.text()

--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -47,11 +47,6 @@ export default function DashboardPage(): JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        setLoading(false)
-        return
-      }
       const [mapsRes, todosRes, boardsRes] = await Promise.all([
         authFetch('/.netlify/functions/mindmaps', { credentials: 'include' }),
         authFetch('/.netlify/functions/todos', { credentials: 'include' }),

--- a/paymentpage.tsx
+++ b/paymentpage.tsx
@@ -20,8 +20,6 @@ const PaymentPage: React.FC = (): JSX.Element => {
     setError(null)
 
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch('/.netlify/functions/create-checkout-session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/savemapbutton.tsx
+++ b/savemapbutton.tsx
@@ -22,11 +22,6 @@ const SaveMapButton: React.FC<SaveMapButtonProps> = ({ serializeMap, mapId, onSa
     controllerRef.current = new AbortController()
     try {
       const payload = { id: mapId, data: serializeMap() }
-      const token = localStorage.getItem('token')
-      if (!token) {
-        setIsSaving(false)
-        return
-      }
       const response = await authFetch('/.netlify/functions/saveMap', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -56,11 +56,6 @@ export default function DashboardPage(): JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        setLoading(false)
-        return
-      }
       const [mapsRes, todosRes, boardsRes, nodesRes] = await Promise.all([
         authFetch('/.netlify/functions/mindmaps', { credentials: 'include' }),
         authFetch('/.netlify/functions/todos', { credentials: 'include' }),

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -30,11 +30,6 @@ export default function KanbanBoardsPage(): JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        setLoading(false)
-        return
-      }
       const res = await authFetch('/.netlify/functions/boards', { credentials: 'include' })
       const json = res.ok ? await res.json() : { boards: [] }
       const list: BoardItem[] = Array.isArray(json) ? json : json.boards || []

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -24,7 +24,11 @@ const LoginPage = () => {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.error || 'Login failed')
       }
-      await res.json().catch(() => ({}))
+      const data = await res.json().catch(() => ({}))
+      const token = (data as { token?: string }).token
+      if (token) {
+        localStorage.setItem('token', token)
+      }
       navigate('/dashboard')
     } catch (err: any) {
       setError(err?.message || 'An unexpected error occurred')

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -32,11 +32,6 @@ export default function TodosPage(): JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) {
-        setLoading(false)
-        return
-      }
       const res = await authFetch('/.netlify/functions/todos', { credentials: 'include' })
       const json = res.ok ? await res.json() : []
       const list: TodoItem[] = Array.isArray(json) ? json : []

--- a/teammembers.tsx
+++ b/teammembers.tsx
@@ -24,10 +24,8 @@ export default function TeamMembers() {
   }
 
   async function loadMembers() {
-    try {
-      const token = localStorage.getItem('token')
-      if (!token) return
-      const res = await authFetch('/.netlify/functions/team-members')
+      try {
+        const res = await authFetch('/.netlify/functions/team-members')
       if (!res.ok) throw new Error('Failed to load members')
       const data = await res.json()
       setMembers(data.members)
@@ -39,10 +37,8 @@ export default function TeamMembers() {
   async function addMember(e: React.FormEvent) {
     e.preventDefault()
     setError(null)
-    try {
-      const token = localStorage.getItem('token')
-      if (!token) return
-      const res = await authFetch('/.netlify/functions/team-members', {
+      try {
+        const res = await authFetch('/.netlify/functions/team-members', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, email }),

--- a/todoid.tsx
+++ b/todoid.tsx
@@ -1,8 +1,6 @@
 import { authFetch } from './authFetch'
 
 async function loadTodos(mindmapId: string, signal?: AbortSignal): Promise<Todo[]> {
-  const token = localStorage.getItem('token')
-  if (!token) return []
   const res = await authFetch(`/.netlify/functions/getTodos?mindmapId=${mindmapId}`, { signal })
   if (!res.ok) {
     const err = await res.text()
@@ -13,8 +11,6 @@ async function loadTodos(mindmapId: string, signal?: AbortSignal): Promise<Todo[
 }
 
 async function generateAIPrompt(prompt: string, signal?: AbortSignal): Promise<string> {
-  const token = localStorage.getItem('token')
-  if (!token) return ''
   const res = await authFetch(`/.netlify/functions/generateAIPrompt`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -87,8 +83,6 @@ export default function TodoPage({ mindmapId }: TodoPageProps) {
     const controller = new AbortController()
     abortControllers.current.push(controller)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch(`/.netlify/functions/createTodo`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -114,8 +108,6 @@ export default function TodoPage({ mindmapId }: TodoPageProps) {
     const controller = new AbortController()
     abortControllers.current.push(controller)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch(`/.netlify/functions/updateTodo`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -141,8 +133,6 @@ export default function TodoPage({ mindmapId }: TodoPageProps) {
     const controller = new AbortController()
     abortControllers.current.push(controller)
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch(`/.netlify/functions/deleteTodo`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },

--- a/todomanager.tsx
+++ b/todomanager.tsx
@@ -52,8 +52,6 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     const input: TodoInput = { title: newTitle.trim() }
     if (newDescription.trim()) input.description = newDescription.trim()
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch('/.netlify/functions/todos', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -83,8 +81,6 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     abortControllers.current.push(controller)
     if (isMounted.current) { setLoading(true); setError(null) }
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch(`/.netlify/functions/todos/${id}`, {
         method: 'DELETE',
         signal: controller.signal
@@ -114,8 +110,6 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     if (isMounted.current) { setLoading(true); setError(null) }
     const updatedCompleted = !todo.completed
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch(`/.netlify/functions/todos/${todo.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -160,8 +154,6 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     if (editValues.description.trim()) payload.description = editValues.description.trim()
     if (editValues.assigneeId !== undefined) payload.assignee_id = editValues.assigneeId
     try {
-      const token = localStorage.getItem('token')
-      if (!token) return
       const res = await authFetch(`/.netlify/functions/todos/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -191,10 +183,8 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     abortControllers.current.push(controller)
     if (isMounted.current) { setLoading(true); setError(null) }
     const ids = Array.from(selectedIds)
-    try {
-      const token = localStorage.getItem('token')
-      if (!token) return
-      const res = await authFetch('/.netlify/functions/todos/bulk', {
+      try {
+        const res = await authFetch('/.netlify/functions/todos/bulk', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids, action: bulkActionType }),


### PR DESCRIPTION
## Summary
- store JWT token after successful login
- remove token checks that prevented network requests when storage was empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881f70c6f608327865e57a03d49ad5d