### PR TITLE
Fix unmatched closing brace in global.scss

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1952,7 +1952,6 @@ hr {
   margin: 0.5rem 0;
   width: 100%;
 }
-}
 
 .todo-placeholder-list {
   width: 100%;


### PR DESCRIPTION
## Summary
- remove extraneous closing brace causing build failure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881fc70034883278459b7ef9b67368b