### PR TITLE
Improve dashboard layout

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -284,25 +284,36 @@ export default function DashboardPage(): JSX.Element {
         <p className="error">{error}</p>
       ) : (
         <>
+          <div className="create-row">
+            <div className="tile create-tile tile-header-center">
+              <h2>Create Map</h2>
+              <button className="btn-primary btn-wide" onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
+            </div>
+            <div className="tile create-tile tile-header-center">
+              <h2>Create Todo</h2>
+              <button className="btn-primary btn-wide" onClick={() => { setCreateType('todo'); setShowModal(true) }}>Create</button>
+            </div>
+            <div className="tile create-tile tile-header-center">
+              <h2>Create Board</h2>
+              <button className="btn-primary btn-wide" onClick={() => { setCreateType('board'); setShowModal(true) }}>Create</button>
+            </div>
+          </div>
           <div className="dashboard-grid">
             <DashboardTile
               icon={<span role="img" aria-label="Mindmap">🧠</span>}
               title="Mind Maps"
-              onCreate={() => { setCreateType('map'); setShowModal(true) }}
               items={mapItems}
               moreLink="/mindmaps"
             />
             <DashboardTile
               icon={<span role="img" aria-label="Todos">✅</span>}
               title="Todos"
-              onCreate={() => { setCreateType('todo'); setShowModal(true) }}
               items={todoItems}
               moreLink="/todos"
             />
             <DashboardTile
               icon={<span role="img" aria-label="Kanban">📋</span>}
               title="Kanban Boards"
-              onCreate={() => { setCreateType('board'); setShowModal(true) }}
               items={boardItems}
               moreLink="/kanban"
             />

--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -19,7 +19,7 @@ export default function DashboardTile({ icon, title, items = [], onCreate, moreL
   return (
     <div className="card">
       <header className="card-header">
-        {icon}
+        {icon && <span className="dashboard-icon">{icon}</span>}
         {title}
       </header>
       <div className="card-body">

--- a/src/global.scss
+++ b/src/global.scss
@@ -1627,6 +1627,13 @@ hr {
   margin-bottom: var(--spacing-xl);
 }
 
+.create-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
+}
+
 @media (min-width: 768px) {
   .tiles-grid {
     grid-template-columns: repeat(3, 1fr);
@@ -1655,6 +1662,7 @@ hr {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  aspect-ratio: 1;
 }
 
 .tile-header {
@@ -1700,6 +1708,7 @@ hr {
   justify-content: center;
   text-align: center;
   min-height: 150px;
+  aspect-ratio: 1;
   background-color: #fff7ed;
   border: 1px solid var(--color-warning);
   box-shadow: 0 2px 6px rgba(245, 158, 11, 0.2);
@@ -2092,6 +2101,7 @@ hr {
   transition: transform var(--transition-duration) var(--transition-ease);
   display: flex;
   flex-direction: column;
+  aspect-ratio: 1;
 }
 
 .card:hover {
@@ -2107,6 +2117,11 @@ hr {
   gap: 0.5rem;
   margin-bottom: 1rem;
   color: var(--color-primary);
+}
+
+.dashboard-icon {
+  font-size: 2rem;
+  filter: grayscale(100%);
 }
 
 .card-body {


### PR DESCRIPTION
## Summary
- redesign dashboard card headers and icons
- add create tile row
- ensure all tiles are square

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882134768408327961bc29bb13b1d85