### PR TITLE
Update dashboard layout

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -284,7 +284,73 @@ export default function DashboardPage(): JSX.Element {
         <p className="error">{error}</p>
       ) : (
         <>
-          <div className="create-row">
+          <div className="dashboard-grid">
+            <DashboardTile
+              icon={<span role="img" aria-label="Mindmap">🧠</span>}
+              title="Mind Maps"
+              items={mapItems}
+              moreLink="/mindmaps"
+              metrics={(
+                <>
+                  <div className="metric-value">{maps.length}</div>
+                  <div className="metric-detail-grid">
+                    <div className="metric-detail">
+                      <span className="label">Nodes This Week</span>
+                      <span className="value">{nodesThisWeek}</span>
+                    </div>
+                    <div className="metric-detail">
+                      <span className="label">Last Week</span>
+                      <span className="value">{nodesLastWeek}</span>
+                    </div>
+                  </div>
+                  <Sparkline data={nodeTrend} />
+                </>
+              )}
+            />
+            <DashboardTile
+              icon={<span role="img" aria-label="Todos">✅</span>}
+              title="Todos"
+              items={todoItems}
+              moreLink="/todos"
+              metrics={(
+                <>
+                  <div className="metric-value">{todos.length}</div>
+                  <div className="metric-detail-grid">
+                    <div className="metric-detail">
+                      <span className="label">Week Added</span>
+                      <span className="value">{todoAddedWeek}</span>
+                    </div>
+                    <div className="metric-detail">
+                      <span className="label">Week Done</span>
+                      <span className="value">{todoDoneWeek}</span>
+                    </div>
+                  </div>
+                  <Sparkline data={todoTrend} />
+                </>
+              )}
+            />
+            <DashboardTile
+              icon={<span role="img" aria-label="Kanban">📋</span>}
+              title="Kanban Boards"
+              items={boardItems}
+              moreLink="/kanban"
+              metrics={(
+                <>
+                  <div className="metric-value">{boards.length}</div>
+                  <div className="metric-detail-grid">
+                    <div className="metric-detail">
+                      <span className="label">Cards Added</span>
+                      <span className="value">0</span>
+                    </div>
+                    <div className="metric-detail">
+                      <span className="label">Completed</span>
+                      <span className="value">0</span>
+                    </div>
+                  </div>
+                  <Sparkline data={boardTrend} />
+                </>
+              )}
+            />
             <div className="tile create-tile tile-header-center">
               <h2>Create Map</h2>
               <button className="btn-primary btn-wide" onClick={() => { setCreateType('map'); setShowModal(true) }}>Create</button>
@@ -296,73 +362,6 @@ export default function DashboardPage(): JSX.Element {
             <div className="tile create-tile tile-header-center">
               <h2>Create Board</h2>
               <button className="btn-primary btn-wide" onClick={() => { setCreateType('board'); setShowModal(true) }}>Create</button>
-            </div>
-          </div>
-          <div className="dashboard-grid">
-            <DashboardTile
-              icon={<span role="img" aria-label="Mindmap">🧠</span>}
-              title="Mind Maps"
-              items={mapItems}
-              moreLink="/mindmaps"
-            />
-            <DashboardTile
-              icon={<span role="img" aria-label="Todos">✅</span>}
-              title="Todos"
-              items={todoItems}
-              moreLink="/todos"
-            />
-            <DashboardTile
-              icon={<span role="img" aria-label="Kanban">📋</span>}
-              title="Kanban Boards"
-              items={boardItems}
-              moreLink="/kanban"
-            />
-          </div>
-          <div className="metrics-grid">
-            <div className="metric-card">
-              <h3 className="metric-title">Mind Maps</h3>
-              <div className="metric-value">{maps.length}</div>
-              <div className="metric-detail-grid">
-                <div className="metric-detail">
-                  <span className="label">Nodes This Week</span>
-                  <span className="value">{nodesThisWeek}</span>
-                </div>
-                <div className="metric-detail">
-                  <span className="label">Last Week</span>
-                  <span className="value">{nodesLastWeek}</span>
-                </div>
-              </div>
-              <Sparkline data={nodeTrend} />
-            </div>
-            <div className="metric-card">
-              <h3 className="metric-title">Todos</h3>
-              <div className="metric-value">{todos.length}</div>
-              <div className="metric-detail-grid">
-                <div className="metric-detail">
-                  <span className="label">Week Added</span>
-                  <span className="value">{todoAddedWeek}</span>
-                </div>
-                <div className="metric-detail">
-                  <span className="label">Week Done</span>
-                  <span className="value">{todoDoneWeek}</span>
-                </div>
-              </div>
-              <Sparkline data={todoTrend} />
-            </div>
-            <div className="metric-card">
-              <h3 className="metric-title">Kanban Boards</h3>
-              <div className="metric-value">{boards.length}</div>
-              <div className="metric-detail-grid">
-                <div className="metric-detail">
-                  <span className="label">Cards Added</span>
-                  <span className="value">0</span>
-                </div>
-                <div className="metric-detail">
-                  <span className="label">Completed</span>
-                  <span className="value">0</span>
-                </div>
-              </div>
-              <Sparkline data={boardTrend} />
             </div>
           </div>
         </>

--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -11,11 +11,12 @@ interface DashboardTileProps {
   icon?: ReactNode
   title: string
   items?: DashboardItem[]
+  metrics?: ReactNode
   onCreate?: () => void
   moreLink?: string
 }
 
-export default function DashboardTile({ icon, title, items = [], onCreate, moreLink }: DashboardTileProps) {
+export default function DashboardTile({ icon, title, items = [], metrics, onCreate, moreLink }: DashboardTileProps) {
   return (
     <div className="card">
       <header className="card-header">
@@ -31,6 +32,7 @@ export default function DashboardTile({ icon, title, items = [], onCreate, moreL
             </li>
           ))}
         </ul>
+        {metrics && <div className="tile-stats">{metrics}</div>}
       </div>
       <div className="card-footer">
         {onCreate && (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1551,10 +1551,12 @@ hr {
 }
 
 .metric-card {
-  background-color: var(--color-bg-alt);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: var(--spacing-lg);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(8px);
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -1573,6 +1575,17 @@ hr {
   gap: var(--spacing-sm);
   width: 100%;
   margin-top: var(--spacing-sm);
+}
+
+// metrics embedded inside dashboard tiles
+.tile-stats {
+  margin-top: auto;
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 
 .metric-detail {
@@ -2093,11 +2106,12 @@ hr {
 
 // redesigned card styles using brand colors
 .card {
-  background: var(--color-bg-alt);
-  border: 1px solid var(--color-primary);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
+  backdrop-filter: blur(8px);
   transition: transform var(--transition-duration) var(--transition-ease);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- merge metric tiles with the main dashboard grid
- drop the create row for a cleaner layout
- refresh tile styles with a futuristic gradient look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882180ab73083278142858b003fe390