### PR TITLE
Modernize dashboard layout

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -252,9 +252,9 @@ export default function DashboardPage(): JSX.Element {
     return bTime - aTime
   }
 
-  const recentMaps = [...maps].sort(dateSort).slice(0, 6)
-  const recentTodos = [...todos].sort(dateSort).slice(0, 6)
-  const recentBoards = [...boards].sort(dateSort).slice(0, 6)
+  const recentMaps = [...maps].sort(dateSort).slice(0, 10)
+  const recentTodos = [...todos].sort(dateSort).slice(0, 10)
+  const recentBoards = [...boards].sort(dateSort).slice(0, 10)
 
   const mapItems: DashboardItem[] = recentMaps.map(m => ({
     id: m.id,
@@ -284,7 +284,30 @@ export default function DashboardPage(): JSX.Element {
         <p className="error">{error}</p>
       ) : (
         <>
-          <div className="dashboard-grid">
+          <div className="dashboard-metrics-row">
+            <div className="metric-card">
+              <h3 className="metric-title">Maps</h3>
+              <div className="metric-value">{maps.length}</div>
+              <p>Today {mapDay}</p>
+              <p>Week {mapWeek}</p>
+              <Sparkline data={mapTrend} />
+            </div>
+            <div className="metric-card">
+              <h3 className="metric-title">Todos</h3>
+              <div className="metric-value">{todos.length}</div>
+              <p>Today {todoDoneDay}</p>
+              <p>Week {todoDoneWeek}</p>
+              <Sparkline data={todoTrend} />
+            </div>
+            <div className="metric-card">
+              <h3 className="metric-title">Boards</h3>
+              <div className="metric-value">{boards.length}</div>
+              <p>Today {boardDay}</p>
+              <p>Week {boardWeek}</p>
+              <Sparkline data={boardTrend} />
+            </div>
+          </div>
+          <div className="dashboard-tile-grid">
             <DashboardTile
               icon={<span role="img" aria-label="Mindmap">🧠</span>}
               title="Mind Maps"
@@ -305,66 +328,6 @@ export default function DashboardPage(): JSX.Element {
               items={boardItems}
               moreLink="/kanban"
               onCreate={() => { setCreateType('board'); setShowModal(true) }}
-            />
-            <DashboardTile
-              icon={<span role="img" aria-label="Mindmap">🧠</span>}
-              title="Mind Map Metrics"
-              metrics={(
-                <>
-                  <div className="metric-value">{maps.length}</div>
-                  <div className="metric-detail-grid">
-                    <div className="metric-detail">
-                      <span className="label">Nodes This Week</span>
-                      <span className="value">{nodesThisWeek}</span>
-                    </div>
-                    <div className="metric-detail">
-                      <span className="label">Last Week</span>
-                      <span className="value">{nodesLastWeek}</span>
-                    </div>
-                  </div>
-                  <Sparkline data={nodeTrend} />
-                </>
-              )}
-            />
-            <DashboardTile
-              icon={<span role="img" aria-label="Todos">✅</span>}
-              title="Todo Metrics"
-              metrics={(
-                <>
-                  <div className="metric-value">{todos.length}</div>
-                  <div className="metric-detail-grid">
-                    <div className="metric-detail">
-                      <span className="label">Week Added</span>
-                      <span className="value">{todoAddedWeek}</span>
-                    </div>
-                    <div className="metric-detail">
-                      <span className="label">Week Done</span>
-                      <span className="value">{todoDoneWeek}</span>
-                    </div>
-                  </div>
-                  <Sparkline data={todoTrend} />
-                </>
-              )}
-            />
-            <DashboardTile
-              icon={<span role="img" aria-label="Kanban">📋</span>}
-              title="Board Metrics"
-              metrics={(
-                <>
-                  <div className="metric-value">{boards.length}</div>
-                  <div className="metric-detail-grid">
-                    <div className="metric-detail">
-                      <span className="label">Cards Added</span>
-                      <span className="value">0</span>
-                    </div>
-                    <div className="metric-detail">
-                      <span className="label">Completed</span>
-                      <span className="value">0</span>
-                    </div>
-                  </div>
-                  <Sparkline data={boardTrend} />
-                </>
-              )}
             />
           </div>
         </>

--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -18,30 +18,25 @@ interface DashboardTileProps {
 
 export default function DashboardTile({ icon, title, items = [], metrics, onCreate, moreLink }: DashboardTileProps) {
   return (
-    <div className="card">
-      <header className="card-header">
+    <div className="tile">
+      <div className="tile-header-center">
         {icon && <span className="dashboard-icon">{icon}</span>}
-        {title}
-      </header>
-      <div className="card-body">
-        {items.length > 0 && <div className="card-subtitle">Recent</div>}
-        <ul className="recent-links">
+        <h2>{title}</h2>
+        {onCreate && (
+          <button className="btn-primary btn-wide" onClick={onCreate}>Create</button>
+        )}
+        {moreLink && <Link to={moreLink} className="tile-link">See All</Link>}
+      </div>
+      {items.length > 0 && (
+        <ul className="recent-list">
           {items.map(item => (
             <li key={item.id}>
               <Link to={item.link}>{item.label}</Link>
             </li>
           ))}
         </ul>
-        {metrics && <div className="tile-stats">{metrics}</div>}
-      </div>
-      <div className="card-footer">
-        {onCreate && (
-          <button className="btn-create" onClick={onCreate}>Create</button>
-        )}
-        {moreLink && (
-          <Link to={moreLink} className="card-more">See All</Link>
-        )}
-      </div>
+      )}
+      {metrics && <div className="tile-stats">{metrics}</div>}
     </div>
   )
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -1550,23 +1550,39 @@ hr {
   }
 }
 
-.metric-card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
-  padding: var(--spacing-lg);
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.08);
-  backdrop-filter: blur(8px);
-  text-align: center;
+.dashboard-metrics-row {
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  gap: 2rem;
+  padding: 2rem 1rem;
   justify-content: space-between;
-  min-height: 200px;
+  flex-wrap: wrap;
+}
+
+.metric-card {
+  background: #fffdf9;
+  border: 1px solid #ffa500;
+  border-radius: 12px;
+  flex: 1 1 28%;
+  padding: 1.5rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+  text-align: left;
+}
+
+.metric-card .metric-title {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.metric-card .metric-value {
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #ff8400;
 }
 
 .metric-card p {
-  margin: 0 0 var(--spacing-xs);
+  margin: 0.25rem 0;
+  font-size: 0.9rem;
 }
 
 .metric-detail-grid {
@@ -1607,25 +1623,6 @@ hr {
   font-size: 0.9rem;
 }
 
-.metric-title {
-  margin-bottom: var(--spacing-md);
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.metric-value {
-  width: 70px;
-  height: 70px;
-  background: var(--color-primary);
-  color: var(--color-text-inverse);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.75rem;
-  font-weight: 700;
-  margin-bottom: var(--spacing-md);
-}
 
 .sparkline {
   width: 100%;
@@ -1749,20 +1746,24 @@ hr {
 }
 
 .tile-header-center {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   text-align: center;
+  margin-bottom: 1rem;
 }
 
-.tile-header-center button {
-  margin-top: var(--spacing-sm);
+.tile-header-center h2 {
+  margin-bottom: 0.5rem;
+}
+
+.tile-header-center .btn-primary {
+  display: block;
+  margin: 0.5rem auto;
 }
 
 .tile-header-center .tile-link {
-  margin-top: 50px;
-  font-size: 0.85rem;
-  color: var(--color-primary);
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #007aff;
   text-decoration: underline;
 }
 
@@ -2092,23 +2093,23 @@ hr {
   opacity: 0.4;
 }
 \n// Dashboard tile redesign
-.dashboard-grid {
+.dashboard-tile-grid {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
-  grid-template-columns: 1fr;
+  margin: 2rem 0;
+  padding: 1rem;
 }
 
-@media (min-width: 768px) {
-  .dashboard-grid {
+@media (max-width: 900px) {
+  .dashboard-tile-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
-@media (min-width: 1024px) {
-  .dashboard-grid {
-    grid-template-columns: repeat(3, 1fr);
-    grid-template-rows: repeat(2, 1fr);
-    grid-auto-rows: 1fr;
+@media (max-width: 600px) {
+  .dashboard-tile-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign dashboard tiles with central headers and consistent buttons
- add metrics row with new metric card styles
- adjust slices for recent items and update responsive grid classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882264494e483278dacd46e28abeb38