### PR TITLE
Refine dashboard metric tile styles

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1600,56 +1600,81 @@ hr {
 
 .dashboard-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--spacing-lg);
 }
 
-.dashboard-tile,
-.metric-tile {
-  background: #fffdf8;
-  border: 1px solid #ffa500;
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+.dashboard-tile {
+  background: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: var(--spacing-lg);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.metric-tile {
+  background: linear-gradient(135deg, #e0e7ff, #f8fafc);
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  min-height: 80px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.metric-tile h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.metric-tile p {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
 }
 
 .dashboard-tile .tile-header {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-sm);
 }
 
 .dashboard-tile .tile-header h2 {
-  font-size: 1.25rem;
-  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
 }
 
 .dashboard-tile .tile-header .btn-primary {
-  margin: 0.5rem 0;
+  margin-left: auto;
 }
 
 .dashboard-tile .tile-header .tile-link {
-  font-size: 0.9rem;
-  color: #007aff;
+  font-size: 0.8rem;
+  color: var(--color-primary);
   text-decoration: underline;
 }
 
 .metric-circle {
-  margin: 0.75rem 0;
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  background: #ffa500;
-  color: #fff;
-  font-size: 1.75rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 6px;
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  font-size: 1.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .metric-detail-grid {
@@ -1693,8 +1718,8 @@ hr {
 
 .sparkline {
   width: 100%;
-  height: 40px;
-  margin-top: var(--spacing-sm);
+  height: 24px;
+  margin-left: auto;
 }
 
 .tiles-grid {
@@ -1775,6 +1800,17 @@ hr {
 
 .recent-list li {
   margin-bottom: var(--spacing-xs);
+  font-size: 0.85rem;
+}
+
+.recent-list li a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color var(--transition-duration) var(--transition-ease);
+}
+
+.recent-list li a:hover {
+  color: var(--color-secondary);
 }
 
 /* style for create tiles */
@@ -1786,14 +1822,14 @@ hr {
   text-align: center;
   min-height: 150px;
   aspect-ratio: 16 / 10;
-  background-color: #fff7ed;
-  border: 1px solid var(--color-warning);
-  box-shadow: 0 2px 6px rgba(245, 158, 11, 0.2);
+  background-color: var(--color-bg-alt);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
 }
 
 .create-tile button {
   margin-top: var(--spacing-md);
-  background-color: var(--color-warning);
+  background-color: var(--color-primary);
   color: var(--color-text-inverse);
   border: none;
   border-radius: 4px;
@@ -1802,7 +1838,7 @@ hr {
 }
 
 .create-tile button:hover {
-  background-color: #f97316;
+  background-color: #2563eb;
 }
 
 .ghost-tile {


### PR DESCRIPTION
## Summary
- restyle metric tiles with blue gradients and compact layout
- lighten create tiles and dashboard tile headers
- adjust dashboard row spacing
- trim sparkline height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68822f397c108327884a6256af0593d3