### PR TITLE
Improve dashboard tiles layout

### DIFF
--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -18,14 +18,15 @@ interface DashboardTileProps {
 
 export default function DashboardTile({ icon, title, items = [], metrics, onCreate, moreLink }: DashboardTileProps) {
   return (
-    <div className="dashboard-tile">
+    <div className={`dashboard-tile${onCreate ? ' highlight-create' : ''}`}>
       <div className="tile-header">
         {icon && <span className="dashboard-icon">{icon}</span>}
         <h2>{title}</h2>
-        {onCreate && (
-          <button className="btn-primary btn-wide" onClick={onCreate}>Create</button>
+        {moreLink && (
+          <Link to={moreLink} className="tile-link tile-link-corner">
+            See All
+          </Link>
         )}
-        {moreLink && <Link to={moreLink} className="tile-link">See All</Link>}
       </div>
       {items.length > 0 && (
         <ul className="recent-list">
@@ -35,6 +36,13 @@ export default function DashboardTile({ icon, title, items = [], metrics, onCrea
             </li>
           ))}
         </ul>
+      )}
+      {onCreate && (
+        <div className="tile-actions">
+          <button className="btn-primary btn-wide" onClick={onCreate}>
+            Create
+          </button>
+        </div>
       )}
       {metrics && <div className="tile-stats">{metrics}</div>}
     </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1615,6 +1615,11 @@ hr {
   gap: var(--spacing-sm);
 }
 
+.dashboard-tile.highlight-create {
+  border-color: var(--color-warning);
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.4);
+}
+
 .metric-tile {
   background: linear-gradient(135deg, #e0e7ff, #f8fafc);
   border: 1px solid #cbd5e1;
@@ -1640,10 +1645,12 @@ hr {
 }
 
 .dashboard-tile .tile-header {
+  position: relative;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   margin-bottom: var(--spacing-sm);
+  padding-right: var(--spacing-lg);
 }
 
 .dashboard-tile .tile-header h2 {
@@ -1654,14 +1661,19 @@ hr {
   gap: var(--spacing-xs);
 }
 
-.dashboard-tile .tile-header .btn-primary {
-  margin-left: auto;
-}
-
-.dashboard-tile .tile-header .tile-link {
+.dashboard-tile .tile-header .tile-link-corner {
+  position: absolute;
+  top: 0;
+  right: 0;
   font-size: 0.8rem;
   color: var(--color-primary);
   text-decoration: underline;
+}
+
+.dashboard-tile .tile-actions {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-sm);
 }
 
 .metric-circle {


### PR DESCRIPTION
## Summary
- highlight dashboard tiles that provide creation actions
- move create buttons to the center
- place "See All" links in the tile corner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688232b4479c8327a1e94a00c5eaf79b