### PR TITLE
Improve todo modal

### DIFF
--- a/AddTodoButton.tsx
+++ b/AddTodoButton.tsx
@@ -1,9 +1,42 @@
-import React from 'react'
+import { useState } from 'react'
+import Modal from './modal'
 
 export default function AddTodoButton(): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [title, setTitle] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setOpen(false)
+    setTitle('')
+  }
+
   return (
     <div className="add-todo-button-wrapper">
-      <button className="btn-primary">Add Todo</button>
+      <button className="btn-primary" onClick={() => setOpen(true)}>
+        Create Todo
+      </button>
+      <Modal isOpen={open} onClose={() => setOpen(false)} ariaLabel="Create todo">
+        <form onSubmit={handleSubmit} className="todo-form">
+          <h2>Create Todo</h2>
+          <input
+            type="text"
+            className="form-input"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Title"
+            required
+          />
+          <div className="form-actions" style={{ marginTop: '1rem' }}>
+            <button type="button" className="btn-cancel" onClick={() => setOpen(false)}>
+              Cancel
+            </button>
+            <button type="submit" className="btn-primary">
+              Add
+            </button>
+          </div>
+        </form>
+      </Modal>
     </div>
   )
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -2106,10 +2106,16 @@ hr {
 
 .todo-placeholder-list {
   width: 100%;
-  max-width: 500px;
+  max-width: 600px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
+}
+
+.todo-list {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
 }
 
 .add-todo-button-wrapper {


### PR DESCRIPTION
## Summary
- create modal-enabled AddTodoButton
- adjust placeholder styles and todo list width for centered layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68823460928083278049b90298c690e8