### PR TITLE
Fix modal imports

### DIFF
--- a/modal.tsx
+++ b/modal.tsx
@@ -1,3 +1,7 @@
+import React, { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import FocusTrap from 'focus-trap-react'
+
 let openModalCount = 0
 let originalOverflow = ''
 


### PR DESCRIPTION
## Summary
- fix error "useRef is not defined" on Todo canvas
- add missing React hooks imports in `modal.tsx`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688238ff34c483278b611ef7b228e0a2