### PR TITLE
Improve dashboard tile styling

### DIFF
--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -40,6 +40,7 @@ export default function DashboardTile({ icon, title, items = [], metrics, onCrea
       {onCreate && (
         <div className="tile-actions">
           <button className="btn-primary btn-wide" onClick={onCreate}>
+            <span className="btn-plus" aria-hidden="true">+</span>
             Create
           </button>
         </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1656,11 +1656,11 @@ hr {
 }
 
 .dashboard-tile .tile-header h2 {
-  font-size: 1.25rem;
+  font-size: 1.4rem;
   margin: 0;
   display: flex;
   align-items: center;
-  gap: var(--spacing-xs);
+  gap: var(--spacing-sm);
 }
 
 .dashboard-tile .tile-header .tile-link-corner {
@@ -1675,6 +1675,7 @@ hr {
 .dashboard-tile .tile-actions {
   display: flex;
   justify-content: center;
+  text-align: center;
   margin-top: var(--spacing-sm);
 }
 
@@ -1952,6 +1953,11 @@ hr {
 .btn-wide {
   padding: var(--spacing-sm) var(--spacing-lg);
   font-size: 1rem;
+}
+
+.btn-plus {
+  margin-right: var(--spacing-xs);
+  font-weight: 600;
 }
 
 .btn-primary:hover {
@@ -2269,6 +2275,7 @@ hr {
 .dashboard-icon {
   font-size: 2rem;
   filter: grayscale(100%);
+  margin-right: var(--spacing-xs);
 }
 
 .card-body {


### PR DESCRIPTION
## Summary
- enlarge dashboard tile headers and space icons
- center create buttons and add plus sign

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68823a2a9b548327b612051f66577cc3