### PR TITLE
Improve dashboard tile layout

### DIFF
--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -18,24 +18,18 @@ interface DashboardTileProps {
 
 export default function DashboardTile({ icon, title, items = [], metrics, onCreate, moreLink }: DashboardTileProps) {
   return (
-    <div className={`dashboard-tile${onCreate ? ' highlight-create' : ''}`}>
-      <div className="tile-header">
-        {icon && <span className="dashboard-icon">{icon}</span>}
-        <h2>{title}</h2>
+    <div className={`dashboard-tile${onCreate ? ' can-create' : ''}`}>
+      <header className="tile-header">
+        <div className="tile-title">
+          {icon && <span className="dashboard-icon">{icon}</span>}
+          <h2>{title}</h2>
+        </div>
         {moreLink && (
-          <Link to={moreLink} className="tile-link tile-link-corner">
+          <Link to={moreLink} className="tile-link">
             See All
           </Link>
         )}
-      </div>
-      {onCreate && (
-        <div className="tile-actions">
-          <button className="btn-primary btn-wide" onClick={onCreate}>
-            <span className="btn-plus" aria-hidden="true">+</span>
-            Create
-          </button>
-        </div>
-      )}
+      </header>
       {items.length > 0 && (
         <ul className="recent-list">
           {items.map(item => (
@@ -46,6 +40,14 @@ export default function DashboardTile({ icon, title, items = [], metrics, onCrea
         </ul>
       )}
       {metrics && <div className="tile-stats">{metrics}</div>}
+      {onCreate && (
+        <footer className="tile-footer">
+          <button className="btn-create" onClick={onCreate}>
+            <span className="btn-plus" aria-hidden="true">+</span>
+            Create
+          </button>
+        </footer>
+      )}
     </div>
   )
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -1617,11 +1617,47 @@ hr {
   gap: var(--spacing-sm);
 }
 
-.dashboard-tile.highlight-create {
-  background-color: rgba(255, 248, 236, 0.8);
-  border-color: #fbd8a8;
-  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.4);
-  backdrop-filter: blur(6px);
+.dashboard-tile.can-create {
+  background-color: rgba(255, 248, 236, 0.5);
+  border-color: var(--color-warning);
+  border-style: dashed;
+}
+
+.dashboard-tile .tile-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+}
+.dashboard-tile .tile-title {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+.dashboard-tile .tile-header h2 {
+  font-size: 1.5rem;
+  margin: 0;
+}
+.dashboard-tile .tile-link {
+  font-size: 0.8rem;
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+.dashboard-tile .tile-footer {
+  margin-top: auto;
+  text-align: center;
+}
+.dashboard-tile .btn-create {
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-md);
+  cursor: pointer;
+  transition: background-color var(--transition-duration) var(--transition-ease);
+}
+.dashboard-tile .btn-create:hover {
+  background-color: var(--color-warning);
 }
 
 .metric-tile {
@@ -1651,39 +1687,6 @@ hr {
   color: rgba(255, 255, 255, 0.8);
 }
 
-.dashboard-tile .tile-header {
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: var(--spacing-sm);
-  padding-right: var(--spacing-lg);
-}
-
-.dashboard-tile .tile-header h2 {
-  font-size: 1.75rem;
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-}
-
-.dashboard-tile .tile-header .tile-link-corner {
-  position: absolute;
-  top: 0;
-  right: 0;
-  font-size: 0.8rem;
-  color: var(--color-primary);
-  text-decoration: underline;
-}
-
-.dashboard-tile .tile-actions {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  margin-top: 50px;
-}
 
 .metric-circle {
   width: 2.5rem;


### PR DESCRIPTION
## Summary
- restructure DashboardTile component for better layout
- refine tile styles and remove thick border
- use dashed highlight for create tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882400992608327b8369b4f4a8a0c34