### PR TITLE
Create mindmap root node modal

### DIFF
--- a/migrations/024_add_todo_id_to_nodes.sql
+++ b/migrations/024_add_todo_id_to_nodes.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'nodes' AND column_name = 'todo_id'
+  ) THEN
+    ALTER TABLE nodes ADD COLUMN todo_id UUID REFERENCES todos(id) ON DELETE SET NULL;
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_nodes_todo_id ON nodes(todo_id);

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -1,7 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { useState, useEffect } from 'react'
-import { v4 as uuidv4 } from 'uuid'
-import MindmapCanvas from './MindmapCanvas'
+import MindmapCanvas, { NodeData } from './MindmapCanvas'
 import { authFetch } from '../authFetch'
 
 interface Mindmap {
@@ -56,12 +55,11 @@ export default function MapEditorPage(): JSX.Element {
   const nodes = getSafeArray(mindmap?.nodes ?? mindmap?.data?.nodes)
   const edges = getSafeArray(mindmap?.edges ?? mindmap?.data?.edges)
 
-  const handleAddNode = () => {
+  const handleAddNode = (node: NodeData) => {
     setMindmap(prev => {
       if (!prev) return prev
       const arr = getSafeArray(prev.nodes ?? (prev as any).data?.nodes)
-      const newNode = { id: uuidv4(), x: 0, y: 0, label: 'New Node' }
-      return { ...prev, nodes: [...arr, newNode] }
+      return { ...prev, nodes: [...arr, node] }
     })
     setReloadFlag(f => f + 1)
   }


### PR DESCRIPTION
## Summary
- add migration for `todo_id` on nodes table
- allow `MindmapCanvas` to create a root node from an empty map
- update `MapEditorPage` to store newly created nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68826bd653b083279bb7674e078c9e43