### PR TITLE
Add modal todo creation

### DIFF
--- a/AddTodoButton.tsx
+++ b/AddTodoButton.tsx
@@ -1,14 +1,23 @@
 import { useState } from 'react'
 import Modal from './modal'
 
-export default function AddTodoButton(): JSX.Element {
+export interface AddTodoButtonProps {
+  onCreate: (todo: { title: string; description: string }) => void
+}
+
+export default function AddTodoButton({
+  onCreate,
+}: AddTodoButtonProps): JSX.Element {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    onCreate({ title, description })
     setOpen(false)
     setTitle('')
+    setDescription('')
   }
 
   return (
@@ -24,15 +33,22 @@ export default function AddTodoButton(): JSX.Element {
             className="form-input"
             value={title}
             onChange={e => setTitle(e.target.value)}
-            placeholder="Title"
+            placeholder="Name"
             required
+          />
+          <textarea
+            className="form-input"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Description (optional)"
+            style={{ marginTop: '0.5rem' }}
           />
           <div className="form-actions" style={{ marginTop: '1rem' }}>
             <button type="button" className="btn-cancel" onClick={() => setOpen(false)}>
               Cancel
             </button>
             <button type="submit" className="btn-primary">
-              Add
+              Save
             </button>
           </div>
         </form>

--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -1,8 +1,39 @@
+import { useState } from 'react'
 import TodoPlaceholder from './TodoPlaceholder'
 import AddTodoButton from './AddTodoButton'
 
-export default function TodoCanvas({ todos }: { todos: any[] }): JSX.Element {
-  const isEmpty = !Array.isArray(todos) || todos.length === 0
+export interface TodoItem {
+  id: string
+  title: string
+  description: string
+  nodeId?: string
+  kanbanId?: string
+}
+
+export interface TodoCanvasProps {
+  initialTodos?: TodoItem[]
+  nodeId?: string
+  kanbanId?: string
+}
+
+export default function TodoCanvas({
+  initialTodos = [],
+  nodeId,
+  kanbanId,
+}: TodoCanvasProps): JSX.Element {
+  const [todos, setTodos] = useState<TodoItem[]>(initialTodos)
+  const isEmpty = todos.length === 0
+
+  const handleCreateTodo = (data: { title: string; description: string }) => {
+    const newTodo: TodoItem = {
+      id: Date.now().toString(),
+      title: data.title,
+      description: data.description,
+      nodeId,
+      kanbanId,
+    }
+    setTodos(prev => [newTodo, ...prev])
+  }
 
   return (
     <div className="todo-canvas-wrapper">
@@ -16,7 +47,7 @@ export default function TodoCanvas({ todos }: { todos: any[] }): JSX.Element {
           <div className="modal-overlay empty-canvas-modal">
             <div className="modal">
               <p>No todos yet. Click below to add your first todo!</p>
-              <AddTodoButton />
+              <AddTodoButton onCreate={handleCreateTodo} />
             </div>
           </div>
         </>
@@ -25,11 +56,13 @@ export default function TodoCanvas({ todos }: { todos: any[] }): JSX.Element {
           {todos.map(t => (
             <div key={t.id} className="tile">
               <header className="tile-header">
-                <h2>{t.title || t.content || 'Untitled'}</h2>
+                <h2>{t.title}</h2>
               </header>
-              <section className="tile-body">
-                <p>{t.content || 'Todo details...'}</p>
-              </section>
+              {t.description && (
+                <section className="tile-body">
+                  <p>{t.description}</p>
+                </section>
+              )}
             </div>
           ))}
         </div>

--- a/src/TodoEditorPage.tsx
+++ b/src/TodoEditorPage.tsx
@@ -21,5 +21,5 @@ export default function TodoEditorPage(): JSX.Element {
 
   if (loading) return <p>Loading...</p>
 
-  return <TodoCanvas todos={todos} />
+  return <TodoCanvas initialTodos={todos} />
 }

--- a/src/TodosCanvasPage.tsx
+++ b/src/TodosCanvasPage.tsx
@@ -22,7 +22,7 @@ export default function TodosCanvasPage(): JSX.Element {
   return (
     <div className="dashboard-layout">
       <main className="main-area">
-        <TodoCanvas todos={todo ? [todo] : []} />
+        <TodoCanvas initialTodos={todo ? [todo] : []} />
       </main>
     </div>
   )

--- a/src/global.scss
+++ b/src/global.scss
@@ -2133,6 +2133,9 @@ hr {
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .add-todo-button-wrapper {


### PR DESCRIPTION
## Summary
- allow AddTodoButton to create todos with name and description
- store todos locally in TodoCanvas and map them to node and kanban ids
- center the todo list and update pages for new prop name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68826da626b08327ad3abe1742a4c0d5