### PR TITLE
Add board creation workflow

### DIFF
--- a/EmptyKanbanBoard.tsx
+++ b/EmptyKanbanBoard.tsx
@@ -1,7 +1,11 @@
 import KanbanLane from './KanbanLane'
 
-export default function EmptyKanbanBoard() {
-  const lanes = ['To Do', 'In Progress', 'Done']
+interface Props {
+  lanes?: string[]
+  onCreateBoard?: () => void
+}
+
+export default function EmptyKanbanBoard({ lanes = ['To Do', 'In Progress', 'Done'], onCreateBoard }: Props) {
 
   return (
     <>
@@ -12,8 +16,19 @@ export default function EmptyKanbanBoard() {
       </div>
       <div className="modal-overlay empty-canvas-modal">
         <div className="modal">
-          <p>No cards yet. Click below to add your first card!</p>
-          <button className="btn-primary">Add Card</button>
+          {onCreateBoard ? (
+            <>
+              <p>No board found. Click below to create one.</p>
+              <button className="btn-primary" onClick={onCreateBoard}>
+                Create Board
+              </button>
+            </>
+          ) : (
+            <>
+              <p>No cards yet. Click below to add your first card!</p>
+              <button className="btn-primary">Add Card</button>
+            </>
+          )}
         </div>
       </div>
     </>

--- a/KanbanCanvas.tsx
+++ b/KanbanCanvas.tsx
@@ -1,16 +1,98 @@
+import { useState } from 'react'
 import KanbanLane from './KanbanLane'
 import EmptyKanbanBoard from './EmptyKanbanBoard'
+import Modal from './modal'
 
-export default function KanbanCanvas({ boardData }: { boardData?: any }) {
-  const hasCards = boardData?.lanes?.some((lane: any) => lane.cards?.length > 0)
+interface Props {
+  boardData?: any
+  nodeId?: string
+  todoId?: string
+}
+
+export default function KanbanCanvas({ boardData, nodeId, todoId }: Props) {
+  const [board, setBoard] = useState(boardData)
+  const [showModal, setShowModal] = useState(false)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+
+  const createBoard = async () => {
+    try {
+      const res = await fetch('/.netlify/functions/boards', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, description, nodeId, todoId }),
+      })
+      const json = await res.json()
+      if (json?.boardId || json?.id) {
+        setBoard({
+          id: json.boardId || json.id,
+          lanes: [
+            { id: 'lane-new', title: 'New', cards: [] },
+            { id: 'lane-progress', title: 'In Progress', cards: [] },
+            { id: 'lane-review', title: 'Review', cards: [] },
+            { id: 'lane-complete', title: 'Complete', cards: [] },
+          ],
+        })
+      }
+      setShowModal(false)
+      setTitle('')
+      setDescription('')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const activeBoard = board
+  const hasCards = activeBoard?.lanes?.some((lane: any) => lane.cards?.length > 0)
+
+  if (!activeBoard) {
+    return (
+      <>
+        <EmptyKanbanBoard onCreateBoard={() => setShowModal(true)} />
+        <Modal isOpen={showModal} onClose={() => setShowModal(false)} ariaLabel="Create board">
+          <form
+            onSubmit={e => {
+              e.preventDefault()
+              createBoard()
+            }}
+          >
+            <h2>Create Board</h2>
+            <input
+              className="form-input"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="Name"
+              required
+            />
+            <textarea
+              className="form-input"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder="Description (optional)"
+              style={{ marginTop: '0.5rem' }}
+            />
+            <div className="form-actions" style={{ marginTop: '1rem' }}>
+              <button type="button" className="btn-cancel" onClick={() => setShowModal(false)}>
+                Cancel
+              </button>
+              <button type="submit" className="btn-primary">
+                Save
+              </button>
+            </div>
+          </form>
+        </Modal>
+      </>
+    )
+  }
 
   if (!hasCards) {
-    return <EmptyKanbanBoard />
+    return <EmptyKanbanBoard lanes={activeBoard.lanes.map((l: any) => l.title)} />
   }
 
   return (
     <div className="kanban-board">
-      {boardData.lanes.map((lane: any) => (
+      {activeBoard.lanes.map((lane: any) => (
         <KanbanLane key={lane.id} title={lane.title} cards={lane.cards} />
       ))}
     </div>

--- a/migrations/025_create_canvas_links.sql
+++ b/migrations/025_create_canvas_links.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS canvas_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  node_id UUID REFERENCES nodes(id) ON DELETE SET NULL,
+  todo_id UUID REFERENCES todos(id) ON DELETE SET NULL,
+  board_id UUID REFERENCES kanban_boards(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_canvas_links_node_id ON canvas_links(node_id);
+CREATE INDEX IF NOT EXISTS idx_canvas_links_todo_id ON canvas_links(todo_id);
+CREATE INDEX IF NOT EXISTS idx_canvas_links_board_id ON canvas_links(board_id);

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -123,7 +123,7 @@ export default function KanbanBoardsPage(): JSX.Element {
             <div className="tile create-tile">
               <header className="tile-header"><h2>Create Board</h2></header>
               <section className="tile-body">
-                <p className="create-help">Click Create to manually add or use AI to get started.</p>
+                <p className="create-help">Click Create to Start</p>
                 <button className="btn-primary" onClick={() => setShowModal(true)}>
                   Create
                 </button>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -129,7 +129,7 @@ export default function MindmapsPage(): JSX.Element {
               <h2>Create Mind Map</h2>
             </header>
             <section className="tile-body">
-              <p className="create-help">Click Create to manually add or use AI to get started.</p>
+              <p className="create-help">Click Create to Start</p>
               <button className="btn-primary" onClick={() => setShowModal(true)}>
                 Create
               </button>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -123,7 +123,7 @@ export default function TodosPage(): JSX.Element {
             <div className="tile create-tile">
               <header className="tile-header"><h2>Create Todo</h2></header>
               <section className="tile-body">
-                <p className="create-help">Click Create to manually add or use AI to get started.</p>
+                <p className="create-help">Click Create to Start</p>
                 <button className="btn-primary" onClick={() => setShowModal(true)}>
                   Create
                 </button>


### PR DESCRIPTION
## Summary
- allow new Kanban boards to be created from an empty canvas
- store board links in new `canvas_links` table
- adjust board creation API to accept linking info
- tweak create-help text on Mindmaps, Todos and Kanban dashboards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68826ecedc48832784fc6e4774484474