### PR TITLE
Improve dashboard metrics layout

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom'
 import LoadingSkeleton from './loadingskeleton'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
+import Sparkline from './src/Sparkline'
 
 interface MapItem {
   id: string
@@ -170,25 +171,61 @@ export default function DashboardPage(): JSX.Element {
           <div className="dashboard-grid">
             <div className="dashboard-row">
               <div className="metric-tile">
-                <h3>Mind Maps</h3>
-                <div className="metric-circle">{maps.length}</div>
-                <p>Created Today: {mapDay}</p>
-                <p>Created This Week: {mapWeek}</p>
-                <Sparkline data={mapTrend} />
+                <div className="metric-left">
+                  <div className="metric-header">
+                    <div className="metric-circle">{maps.length}</div>
+                    <h3>Mind Maps</h3>
+                  </div>
+                  <Sparkline data={mapTrend} />
+                </div>
+                <div className="metric-right metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{mapDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{mapWeek}</span>
+                  </div>
+                </div>
               </div>
               <div className="metric-tile">
-                <h3>Todos</h3>
-                <div className="metric-circle">{todos.length}</div>
-                <p>Completed Today: {todoDoneDay}</p>
-                <p>Completed This Week: {todoDoneWeek}</p>
-                <Sparkline data={todoTrend} />
+                <div className="metric-left">
+                  <div className="metric-header">
+                    <div className="metric-circle">{todos.length}</div>
+                    <h3>Todos</h3>
+                  </div>
+                  <Sparkline data={todoTrend} />
+                </div>
+                <div className="metric-right metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Done Today</span>
+                    <span className="value">{todoDoneDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Done Week</span>
+                    <span className="value">{todoDoneWeek}</span>
+                  </div>
+                </div>
               </div>
               <div className="metric-tile">
-                <h3>Kanban Boards</h3>
-                <div className="metric-circle">{boards.length}</div>
-                <p>Created Today: {boardDay}</p>
-                <p>Created This Week: {boardWeek}</p>
-                <Sparkline data={boardTrend} />
+                <div className="metric-left">
+                  <div className="metric-header">
+                    <div className="metric-circle">{boards.length}</div>
+                    <h3>Kanban Boards</h3>
+                  </div>
+                  <Sparkline data={boardTrend} />
+                </div>
+                <div className="metric-right metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{boardDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{boardWeek}</span>
+                  </div>
+                </div>
               </div>
             </div>
             <div className="dashboard-row">

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -287,25 +287,61 @@ export default function DashboardPage(): JSX.Element {
           <div className="dashboard-grid">
             <div className="dashboard-row">
               <div className="metric-tile">
-                <h3>Mind Maps</h3>
-                <div className="metric-circle">{maps.length}</div>
-                <p>Created Today: {mapDay}</p>
-                <p>Created This Week: {mapWeek}</p>
-                <Sparkline data={mapTrend} />
+                <div className="metric-left">
+                  <div className="metric-header">
+                    <div className="metric-circle">{maps.length}</div>
+                    <h3>Mind Maps</h3>
+                  </div>
+                  <Sparkline data={mapTrend} />
+                </div>
+                <div className="metric-right metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{mapDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{mapWeek}</span>
+                  </div>
+                </div>
               </div>
               <div className="metric-tile">
-                <h3>Todos</h3>
-                <div className="metric-circle">{todos.length}</div>
-                <p>Completed Today: {todoDoneDay}</p>
-                <p>Completed This Week: {todoDoneWeek}</p>
-                <Sparkline data={todoTrend} />
+                <div className="metric-left">
+                  <div className="metric-header">
+                    <div className="metric-circle">{todos.length}</div>
+                    <h3>Todos</h3>
+                  </div>
+                  <Sparkline data={todoTrend} />
+                </div>
+                <div className="metric-right metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Done Today</span>
+                    <span className="value">{todoDoneDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Done Week</span>
+                    <span className="value">{todoDoneWeek}</span>
+                  </div>
+                </div>
               </div>
               <div className="metric-tile">
-                <h3>Kanban Boards</h3>
-                <div className="metric-circle">{boards.length}</div>
-                <p>Created Today: {boardDay}</p>
-                <p>Created This Week: {boardWeek}</p>
-                <Sparkline data={boardTrend} />
+                <div className="metric-left">
+                  <div className="metric-header">
+                    <div className="metric-circle">{boards.length}</div>
+                    <h3>Kanban Boards</h3>
+                  </div>
+                  <Sparkline data={boardTrend} />
+                </div>
+                <div className="metric-right metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{boardDay}</span>
+                  </div>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{boardWeek}</span>
+                  </div>
+                </div>
               </div>
             </div>
             <div className="dashboard-row">

--- a/src/Sparkline.tsx
+++ b/src/Sparkline.tsx
@@ -11,7 +11,7 @@ export default function Sparkline({
   data,
   width = 100,
   height = 40,
-  color = '#0a84ff',
+  color = '#38bdf8',
 }: SparklineProps) {
   const max = Math.max(...data, 1)
   const points = data
@@ -32,7 +32,8 @@ export default function Sparkline({
       <polyline
         fill="none"
         stroke={color}
-        strokeWidth="2"
+        strokeWidth="3"
+        strokeLinecap="round"
         points={points}
       />
     </svg>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1666,10 +1666,9 @@ hr {
   border-radius: 12px;
   padding: var(--spacing-md);
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  gap: var(--spacing-sm);
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-md);
   min-height: 120px;
   color: var(--color-text-inverse);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
@@ -1689,9 +1688,9 @@ hr {
 
 
 .metric-circle {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 6px;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
   background: linear-gradient(135deg, #0ea5e9, #6366f1);
   color: var(--color-text-inverse);
   font-size: 1.25rem;
@@ -1699,6 +1698,26 @@ hr {
   align-items: center;
   justify-content: center;
   font-weight: 600;
+}
+
+.metric-left {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+}
+
+.metric-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.metric-right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--spacing-xs);
 }
 
 .metric-detail-grid {
@@ -1742,8 +1761,8 @@ hr {
 
 .sparkline {
   width: 100%;
-  height: 24px;
-  margin-left: auto;
+  height: 32px;
+  margin-left: 0;
 }
 
 .tiles-grid {


### PR DESCRIPTION
## Summary
- redesign metric tiles with left/right layout
- show counts inside circular badges and bold sparkline
- tweak CSS for new metric layout and bigger sparkline
- make sparkline stroke bolder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688270f7ed90832786ef14dd09cd0127