### PR TITLE
Improve dashboard metric boxes

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1661,8 +1661,8 @@ hr {
 }
 
 .metric-tile {
-  background: linear-gradient(135deg, #1e3a8a, #4f46e5);
-  border: 1px solid #4f46e5;
+  background: linear-gradient(135deg, rgba(30, 58, 138, 0.8), rgba(79, 70, 229, 0.4));
+  border: 1px solid rgba(79, 70, 229, 0.6);
   border-radius: 12px;
   padding: var(--spacing-md);
   display: flex;
@@ -1671,7 +1671,8 @@ hr {
   gap: var(--spacing-md);
   min-height: 120px;
   color: var(--color-text-inverse);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(8px);
 }
 
 .metric-tile h3 {
@@ -1727,8 +1728,8 @@ hr {
 }
 
 .dashboard-page .metric-right.metric-detail-grid {
-  grid-template-columns: 1fr;
-  justify-items: end;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  justify-items: stretch;
 }
 
 .metric-detail-grid {
@@ -1751,23 +1752,26 @@ hr {
 }
 
 .metric-detail {
-  background: var(--color-surface);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05));
   border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
   padding: var(--spacing-xs) var(--spacing-sm);
   text-align: center;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  backdrop-filter: blur(6px);
+  color: var(--color-text-inverse);
 }
 
 .metric-detail .label {
   display: block;
-  color: var(--color-text-muted);
+  color: rgba(255, 255, 255, 0.7);
   font-size: 0.75rem;
 }
 
 .metric-detail .value {
   font-weight: 600;
   font-size: 0.9rem;
-  color: var(--color-text);
+  color: #ffffff;
 }
 
 


### PR DESCRIPTION
## Summary
- modernize metric tiles with a blurred gradient background
- allow metric detail grids to span two columns
- give metric detail boxes a futuristic glass look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68827d73e0648327990c52709fd0ce33