### PR TITLE
Update metric tile styling

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -129,22 +129,22 @@ export default function KanbanBoardsPage(): JSX.Element {
                 </button>
               </section>
             </div>
-            <div className="tile">
-              <header className="tile-header"><h2>Metrics</h2></header>
-              <section className="tile-body">
-                <p>Total: {boards.length}</p>
-                <div className="metric-detail-grid">
-                  <div className="metric-detail">
-                    <span className="label">Cards Added</span>
-                    <span className="value">0</span>
+              <div className="tile">
+                <header className="tile-header"><h2>Metrics</h2></header>
+                <section className="tile-body">
+                  <p>Total: {boards.length}</p>
+                  <div className="metric-detail-grid">
+                    <div className="metric-detail">
+                      <span className="label">Today</span>
+                      <span className="value">{boardDay}</span>
+                    </div>
+                    <div className="metric-detail">
+                      <span className="label">Week</span>
+                      <span className="value">{boardWeek}</span>
+                    </div>
                   </div>
-                  <div className="metric-detail">
-                    <span className="label">Completed</span>
-                    <span className="value">0</span>
-                  </div>
-                </div>
-              </section>
-            </div>
+                </section>
+              </div>
             {sorted.map(b => (
               <div className="tile" key={b.id}>
                 <header className="tile-header">

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -139,6 +139,16 @@ export default function MindmapsPage(): JSX.Element {
             <header className="tile-header"><h2>Metrics</h2></header>
             <section className="tile-body">
               <p>Total: {maps.length}</p>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{mapDay}</span>
+                </div>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{mapWeek}</span>
+                </div>
+              </div>
             </section>
           </div>
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -1753,26 +1753,25 @@ hr {
 }
 
 .metric-detail {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05));
+  background: #ffffff;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid #ccc;
   padding: var(--spacing-xs) var(--spacing-sm);
   text-align: center;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-  backdrop-filter: blur(6px);
-  color: var(--color-text-inverse);
+  color: #000;
 }
 
 .metric-detail .label {
   display: block;
-  color: rgba(255, 255, 255, 0.7);
+  color: #555;
   font-size: 0.75rem;
 }
 
 .metric-detail .value {
   font-weight: 600;
   font-size: 0.9rem;
-  color: #ffffff;
+  color: #000;
 }
 
 


### PR DESCRIPTION
## Summary
- adjust metric detail styling for better readability
- display day/week metrics on Mind Maps page
- show day/week metrics on Kanban Boards page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688284baba988327ae76e193d3c7b26b