### PR TITLE
Add layout autosave and minimap

### DIFF
--- a/MiniMap.tsx
+++ b/MiniMap.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import type { NodeData, EdgeData } from './mindmapcanvas'
+
+const CANVAS_SIZE = 50 * 500
+const MINIMAP_SIZE = 150
+
+interface MiniMapProps {
+  nodes: NodeData[]
+  edges: EdgeData[]
+  transform: { x: number; y: number; k: number }
+  onNavigate: (x: number, y: number) => void
+}
+
+const MiniMap: React.FC<MiniMapProps> = ({ nodes, edges, transform, onNavigate }) => {
+  const scale = MINIMAP_SIZE / CANVAS_SIZE
+
+  const handlePointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect()
+    const x = (e.clientX - rect.left) / scale
+    const y = (e.clientY - rect.top) / scale
+    onNavigate(x, y)
+  }
+
+  const viewX = -transform.x / transform.k
+  const viewY = -transform.y / transform.k
+  const viewW = MINIMAP_SIZE / transform.k
+  const viewH = MINIMAP_SIZE / transform.k
+
+  return (
+    <svg
+      width={MINIMAP_SIZE}
+      height={MINIMAP_SIZE}
+      style={{ position: 'absolute', right: 10, bottom: 10, background: '#fff', border: '1px solid #ccc' }}
+      onPointerDown={handlePointerDown}
+    >
+      <g transform={`scale(${scale})`}>
+        {edges.map(edge => {
+          const from = nodes.find(n => n.id === edge.from)
+          const to = nodes.find(n => n.id === edge.to)
+          if (!from || !to) return null
+          return (
+            <path
+              key={edge.id}
+              d={`M${from.x},${from.y} Q${(from.x + to.x) / 2},${(from.y + to.y) / 2 - 40} ${to.x},${to.y}`}
+              fill="none"
+              stroke="#ccc"
+              strokeWidth={1}
+            />
+          )
+        })}
+        {nodes.map(node => (
+          <circle key={node.id} cx={node.x} cy={node.y} r={5} fill="orange" />
+        ))}
+      </g>
+      <rect
+        x={viewX * scale}
+        y={viewY * scale}
+        width={viewW}
+        height={viewH}
+        fill="none"
+        stroke="red"
+        strokeWidth={1}
+      />
+    </svg>
+  )
+}
+
+export default MiniMap

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useEffect
 } from 'react'
+import MiniMap from './MiniMap'
 
 interface NodeData {
   id: string
@@ -31,6 +32,7 @@ interface MindmapCanvasProps {
   height?: number | string
   onAddNode?: (node: NodeData) => void
   onMoveNode?: (node: NodeData) => void
+  showMiniMap?: boolean
 }
 
 interface MindmapCanvasHandle {
@@ -50,6 +52,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       height,
       onAddNode,
       onMoveNode,
+      showMiniMap = false,
     },
     ref
   ) => {
@@ -544,6 +547,23 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
               </div>
             </div>
           </div>
+        )}
+        {showMiniMap && (
+          <MiniMap
+            nodes={safeNodes}
+            edges={safeEdges}
+            transform={transform}
+            onNavigate={(x, y) => {
+              if (!containerRef.current) return
+              const cw = containerRef.current.clientWidth
+              const ch = containerRef.current.clientHeight
+              setTransform(prev => ({
+                x: cw / 2 - x * prev.k,
+                y: ch / 2 - y * prev.k,
+                k: prev.k,
+              }))
+            }}
+          />
         )}
       </div>
     )

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import MindmapCanvas, { NodeData, EdgeData } from './MindmapCanvas'
 import { authFetch } from '../authFetch'
 
@@ -96,14 +96,32 @@ export default function MapEditorPage(): JSX.Element {
     }).catch(() => {})
   }
 
+  const handleSaveLayout = useCallback(() => {
+    nodes.forEach(n => {
+      fetch(`/.netlify/functions/nodes/${n.id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x: n.x, y: n.y })
+      }).catch(() => {})
+    })
+  }, [nodes])
+
   return (
     <div className="dashboard-layout">
       <main className="main-area">
+        <button
+          onClick={handleSaveLayout}
+          style={{ position: 'absolute', top: 10, right: 10, zIndex: 10 }}
+        >
+          Save Layout
+        </button>
         <MindmapCanvas
           nodes={nodes}
           edges={edges}
           onAddNode={handleAddNode}
           onMoveNode={handleMoveNode}
+          showMiniMap
         />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- add a small minimap overlay
- allow `MindmapCanvas` to optionally render the minimap
- add "Save Layout" button that persists all node positions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828e51535c8327830699bdd80459d5