### PR TITLE
Increase dashboard sparkline width

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1675,6 +1675,11 @@ hr {
   backdrop-filter: blur(8px);
 }
 
+// widen sparkline width specifically within dashboard metric tiles
+.metric-tile .sparkline {
+  width: 50%;
+}
+
 .metric-tile h3 {
   margin: 0;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- widen sparkline chart specifically within dashboard metric tiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68829fb5143c8327a34b9c3fef944b0b