### PR TITLE
Fix sparkline width

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -177,6 +177,7 @@ export default function DashboardPage(): JSX.Element {
                     <h3>Mind Maps</h3>
                   </div>
                   <Sparkline data={mapTrend} />
+                  <span className="trend-label">Week Trend</span>
                 </div>
                 <div className="metric-right metric-detail-grid">
                   <div className="metric-detail">
@@ -196,6 +197,7 @@ export default function DashboardPage(): JSX.Element {
                     <h3>Todos</h3>
                   </div>
                   <Sparkline data={todoTrend} />
+                  <span className="trend-label">Week Trend</span>
                 </div>
                 <div className="metric-right metric-detail-grid">
                   <div className="metric-detail">
@@ -215,6 +217,7 @@ export default function DashboardPage(): JSX.Element {
                     <h3>Kanban Boards</h3>
                   </div>
                   <Sparkline data={boardTrend} />
+                  <span className="trend-label">Week Trend</span>
                 </div>
                 <div className="metric-right metric-detail-grid">
                   <div className="metric-detail">

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -303,6 +303,7 @@ export default function DashboardPage(): JSX.Element {
                     <h3>Mind Maps</h3>
                   </div>
                   <Sparkline data={mapTrend} />
+                  <span className="trend-label">Week Trend</span>
                 </div>
                 <div className="metric-right metric-detail-grid">
                   <div className="metric-detail">
@@ -322,6 +323,7 @@ export default function DashboardPage(): JSX.Element {
                     <h3>Todos</h3>
                   </div>
                   <Sparkline data={todoTrend} />
+                  <span className="trend-label">Week Trend</span>
                 </div>
                 <div className="metric-right metric-detail-grid">
                   <div className="metric-detail">
@@ -341,6 +343,7 @@ export default function DashboardPage(): JSX.Element {
                     <h3>Kanban Boards</h3>
                   </div>
                   <Sparkline data={boardTrend} />
+                  <span className="trend-label">Week Trend</span>
                 </div>
                 <div className="metric-right metric-detail-grid">
                   <div className="metric-detail">

--- a/src/Sparkline.tsx
+++ b/src/Sparkline.tsx
@@ -25,7 +25,7 @@ export default function Sparkline({
   return (
     <svg
       className="sparkline"
-      width={width}
+      width="100%"
       height={height}
       viewBox={`0 0 ${width} ${height}`}
     >

--- a/src/global.scss
+++ b/src/global.scss
@@ -1677,7 +1677,13 @@ hr {
 
 // widen sparkline width specifically within dashboard metric tiles
 .metric-tile .sparkline {
-  width: 50%;
+  width: 100%;
+}
+
+.trend-label {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .metric-tile h3 {


### PR DESCRIPTION
## Summary
- make sparklines span the full metric tile width
- show a new `Week Trend` label under sparklines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a359272083279b782ac7e4c45b80