### PR TITLE
Fix sparkline scaling

### DIFF
--- a/src/Sparkline.tsx
+++ b/src/Sparkline.tsx
@@ -28,6 +28,7 @@ export default function Sparkline({
       width="100%"
       height={height}
       viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
     >
       <polyline
         fill="none"


### PR DESCRIPTION
## Summary
- ensure sparkline uses all available width by disabling SVG aspect ratio

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a6737d6483279112313f5e9be081