### PR TITLE
Fix first-node logic using existing canvas modal

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -65,6 +65,12 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const svgRef = useRef<SVGSVGElement | null>(null)
     const containerRef = useRef<HTMLDivElement | null>(null)
     const [showCreate, setShowCreate] = useState(false)
+
+    useEffect(() => {
+      if (Array.isArray(nodes) && nodes.length === 0) {
+        setShowCreate(true)
+      }
+    }, [nodes])
     const [newName, setNewName] = useState('')
   const [newDesc, setNewDesc] = useState('')
   const [hoveredId, setHoveredId] = useState<string | null>(null)
@@ -597,7 +603,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           <button type="button" onClick={() => zoom(1.1)}>+</button>
           <button type="button" onClick={() => zoom(0.9)}>-</button>
         </div>
-        {safeNodes.length === 0 && safeEdges.length === 0 && (
+        {safeNodes.length === 0 && safeEdges.length === 0 && !showCreate && (
           <div className="modal-overlay empty-canvas-modal">
             <div className="modal">
               <p>No nodes yet. Click below to start building your map!</p>

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -58,18 +58,12 @@ export default function MapEditorPage(): JSX.Element {
     return () => controller.abort()
   }, [id, reloadFlag])
 
+
   if (error) return <div>Error loading map. Failed to load map: 404</div>
   if (!mindmap) return <div>Loading mind map...</div>
 
   const safeNodes = Array.isArray(nodes) ? nodes : []
 
-  if (safeNodes.length === 0) {
-    return (
-      <div className="empty-message">
-        This map is empty. Add your first node to begin.
-      </div>
-    )
-  }
 
   const edges: EdgeData[] = safeNodes
     .filter(n => n.parentId)
@@ -89,6 +83,7 @@ export default function MapEditorPage(): JSX.Element {
       })
       .catch(() => {})
   }
+
 
   if (safeNodes.length === 0 && edges.length === 0) {
     console.log('[mindmap] No nodes or edges found, rendering empty canvas')


### PR DESCRIPTION
## Summary
- remove unused `EmptyMapStartupModal`
- rely on built-in canvas modal for first node creation
- automatically open create node modal when the map is empty
- keep canvas rendering even when there are no nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882b4d73d948327a936b7efee3eef77