### PR TITLE
Guard mindmap canvas props

### DIFF
--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -176,8 +176,8 @@ export default function MapEditorPage(): JSX.Element {
           Save Layout
         </button>
         <MindmapCanvas
-          nodes={safeNodes}
-          edges={edges}
+          nodes={Array.isArray(nodes) ? nodes : []}
+          edges={Array.isArray(edges) ? edges : []}
           onAddNode={handleAddNode}
           onMoveNode={handleMoveNode}
           showMiniMap


### PR DESCRIPTION
## Summary
- guard `nodes` and `edges` props when rendering `MindmapCanvas`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882c1e9d17c832780811b8e4c9d8b3e