### PR TITLE
Fix MapEditorPage import path

### DIFF
--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { useState, useEffect, useCallback } from 'react'
-import MindmapCanvas, { NodeData, EdgeData } from '../MindmapCanvas'
+import MindmapCanvas, { NodeData, EdgeData } from './MindmapCanvas'
 import { authFetch } from '../authFetch'
 
 function FirstNodeModal({ onCreate }: { onCreate: (label: string) => void }) {


### PR DESCRIPTION
## Summary
- fix import path for `MindmapCanvas` in MapEditorPage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882cdd8f30c8327b6a3189601026eba