### PR TITLE
Fix hook order in MapEditorPage

### DIFF
--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -103,15 +103,22 @@ export default function MapEditorPage(): JSX.Element {
     if (nodes.length === 0) setShowFirstNodeModal(true)
   }, [nodes])
 
-
-  if (error) return <div>Error loading map. Failed to load map: 404</div>
-  if (!mindmap) return <div>Loading mind map...</div>
-  // Validate shape of loaded mindmap
-  if (!mindmap?.id) {
-    return <div>Error: This map is missing or invalid.</div>
-  }
-
   const safeNodes = Array.isArray(nodes) ? nodes : []
+
+  const handleSaveLayout = useCallback(() => {
+    safeNodes.forEach(n => {
+      fetch(`/.netlify/functions/nodes/${n.id}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x: n.x, y: n.y })
+      }).catch(() => {})
+    })
+  }, [safeNodes])
+
+  if (error) return <div>Error loading map.</div>
+  if (!mindmap) return <div>Loading...</div>
+  if (!mindmap?.id) return <div>Invalid map.</div>
 
 
   const edges: EdgeData[] = safeNodes
@@ -172,17 +179,6 @@ export default function MapEditorPage(): JSX.Element {
       body: JSON.stringify({ x: node.x, y: node.y })
     }).catch(() => {})
   }
-
-  const handleSaveLayout = useCallback(() => {
-    safeNodes.forEach(n => {
-      fetch(`/.netlify/functions/nodes/${n.id}`, {
-        method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ x: n.x, y: n.y })
-      }).catch(() => {})
-    })
-  }, [safeNodes])
 
   return (
     <div className="dashboard-layout">


### PR DESCRIPTION
## Summary
- ensure all hooks run before conditional returns in `MapEditorPage`
- display cleaner loading/error messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ddd95fa0832796690fe28b2f6dcf