### PR TITLE
Improve mindmap logging

### DIFF
--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -169,7 +169,9 @@ export default function MapEditorPage(): JSX.Element {
     console.log('[mindmap] No nodes or edges found, rendering empty canvas')
   }
 
-  console.log('mapData:', mindmap)
+  if (typeof mindmap === 'object' && mindmap !== null) {
+    console.log('mapData:', { id: mindmap.id, title: mindmap.title })
+  }
 
   const handleMoveNode = (node: NodeData) => {
     fetch(`/.netlify/functions/nodes/${node.id}`, {


### PR DESCRIPTION
## Summary
- log only mindmap id and title in MapEditorPage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882df2aff5c8327a0950572edd8d675