### PR TITLE
Add delete links for dashboard items

### DIFF
--- a/netlify/functions/boards.ts
+++ b/netlify/functions/boards.ts
@@ -97,6 +97,21 @@ export const handler = async (
       return { statusCode: 200, headers, body: JSON.stringify({ boards: rows }) }
     }
 
+    if (event.httpMethod === 'DELETE') {
+      const id = event.queryStringParameters?.id
+      if (!id) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing id' }) }
+      }
+      const result = await client.query(
+        'DELETE FROM kanban_boards WHERE id = $1 AND user_id = $2',
+        [id, userId]
+      )
+      if (result.rowCount === 0) {
+        return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found' }) }
+      }
+      return { statusCode: 204, headers, body: '' }
+    }
+
     return { statusCode: 405, headers: { ...headers, Allow: 'GET,POST,OPTIONS' }, body: JSON.stringify({ error: 'Method Not Allowed' }) }
   } catch (err: any) {
     console.error('Board error:', err)

--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -94,6 +94,21 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       return { statusCode: 200, headers, body: JSON.stringify(maps) }
     }
 
+    if (event.httpMethod === 'DELETE') {
+      const id = event.queryStringParameters?.id
+      if (!id) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing id' }) }
+      }
+      const result = await client.query(
+        'DELETE FROM mindmaps WHERE id = $1 AND user_id = $2',
+        [id, userId]
+      )
+      if (result.rowCount === 0) {
+        return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found' }) }
+      }
+      return { statusCode: 204, headers, body: '' }
+    }
+
     // ❌ No other method allowed
     return {
       statusCode: 405,

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -90,6 +90,20 @@ export default function KanbanBoardsPage(): JSX.Element {
     }
   }
 
+  const handleDelete = async (id: string): Promise<void> => {
+    if (!confirm('Delete this board?')) return
+    try {
+      const res = await fetch(`/.netlify/functions/boards?id=${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Failed to delete')
+      setBoards(prev => prev.filter(b => b.id !== id))
+    } catch (err: any) {
+      alert(err.message || 'Delete failed')
+    }
+  }
+
   const now = Date.now()
   const oneDay = 24 * 60 * 60 * 1000
   const oneWeek = 7 * oneDay
@@ -149,17 +163,26 @@ export default function KanbanBoardsPage(): JSX.Element {
               <div className="tile" key={b.id}>
                 <header className="tile-header">
                   <h2>{b.title || 'Board'}</h2>
-                  <Link
-                    to={`/kanban/${b.id}`}
-                    onClick={() =>
-                      localStorage.setItem(
-                        `board_last_viewed_${b.id}`,
-                        Date.now().toString()
-                      )
-                    }
-                  >
-                    Open
-                  </Link>
+                  <div className="tile-actions">
+                    <Link
+                      to={`/kanban/${b.id}`}
+                      onClick={() =>
+                        localStorage.setItem(
+                          `board_last_viewed_${b.id}`,
+                          Date.now().toString()
+                        )
+                      }
+                      className="tile-link"
+                    >
+                      Open
+                    </Link>
+                    <button
+                      className="tile-link delete-link"
+                      onClick={() => handleDelete(b.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </header>
                 <section className="tile-body">
                   <p>Board details coming soon...</p>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -89,6 +89,20 @@ export default function MindmapsPage(): JSX.Element {
     }
   }
 
+  const handleDelete = async (id: string): Promise<void> => {
+    if (!confirm('Delete this mind map?')) return
+    try {
+      const res = await fetch(`/.netlify/functions/mindmaps?id=${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Failed to delete')
+      setMaps(prev => prev.filter(m => m.id !== id))
+    } catch (err: any) {
+      alert(err.message || 'Delete failed')
+    }
+  }
+
   const getLastViewed = (id: string): number => {
     const v = localStorage.getItem(`mindmap_last_viewed_${id}`)
     return v ? parseInt(v, 10) : 0
@@ -161,17 +175,26 @@ export default function MindmapsPage(): JSX.Element {
               <div className="tile" key={m.id}>
                 <header className="tile-header">
                   <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
-                  <Link
-                    to={`/maps/${m.id}`}
-                    onClick={() =>
-                      localStorage.setItem(
-                        `mindmap_last_viewed_${m.id}`,
-                        Date.now().toString()
-                      )
-                    }
-                  >
-                    Open
-                  </Link>
+                  <div className="tile-actions">
+                    <Link
+                      to={`/maps/${m.id}`}
+                      onClick={() =>
+                        localStorage.setItem(
+                          `mindmap_last_viewed_${m.id}`,
+                          Date.now().toString()
+                        )
+                      }
+                      className="tile-link"
+                    >
+                      Open
+                    </Link>
+                    <button
+                      className="tile-link delete-link"
+                      onClick={() => handleDelete(m.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </header>
                 <section className="tile-body">
                   <p>{m.data?.description || 'Map details coming soon...'}</p>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -90,6 +90,20 @@ export default function TodosPage(): JSX.Element {
     }
   }
 
+  const handleDelete = async (id: string): Promise<void> => {
+    if (!confirm('Delete this todo?')) return
+    try {
+      const res = await fetch(`/.netlify/functions/todos/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) throw new Error('Failed to delete')
+      setTodos(prev => prev.filter(t => t.id !== id))
+    } catch (err: any) {
+      alert(err.message || 'Delete failed')
+    }
+  }
+
   const now = Date.now()
   const oneDay = 24 * 60 * 60 * 1000
   const oneWeek = 7 * oneDay
@@ -149,17 +163,26 @@ export default function TodosPage(): JSX.Element {
               <div className="tile" key={t.id}>
                 <header className="tile-header">
                   <h2>{t.title || t.content}</h2>
-                  <Link
-                    to={`/todos/${t.id}`}
-                    onClick={() =>
-                      localStorage.setItem(
-                        `todo_last_viewed_${t.id}`,
-                        Date.now().toString()
-                      )
-                    }
-                  >
-                    Open
-                  </Link>
+                  <div className="tile-actions">
+                    <Link
+                      to={`/todos/${t.id}`}
+                      onClick={() =>
+                        localStorage.setItem(
+                          `todo_last_viewed_${t.id}`,
+                          Date.now().toString()
+                        )
+                      }
+                      className="tile-link"
+                    >
+                      Open
+                    </Link>
+                    <button
+                      className="tile-link delete-link"
+                      onClick={() => handleDelete(t.id)}
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </header>
                 <section className="tile-body">
                   <p>{t.content || 'Todo details coming soon...'}</p>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1863,6 +1863,10 @@ hr {
   text-decoration: underline;
 }
 
+.delete-link {
+  color: var(--color-error);
+}
+
 .recent-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- support DELETE in mindmap and board APIs
- show delete link on Mindmaps, Todos and Kanban boards pages
- style delete link in red

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688305fedfd0832796b42f20519efe58