### PR TITLE
Add node creation persistence and drag save

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -437,7 +437,13 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       if (e.touches.length < 2) {
         pinchRef.current = null
       }
-    }, [])
+      if (dragNodeIdRef.current && modeRef.current === 'node') {
+        const node = safeNodes.find(n => n.id === dragNodeIdRef.current)
+        if (node && onMoveNode) onMoveNode(node)
+      }
+      dragNodeIdRef.current = null
+      nodeOriginRef.current = null
+    }, [Array.isArray(nodes) ? nodes : [], onMoveNode])
 
 
     const containerWidth =

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -155,11 +155,16 @@ export default function MapEditorPage(): JSX.Element {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...node, mindmapId: id })
     })
-      .then(res => res.json())
-      .then(data => {
+      .then(async res => {
+        if (!res.ok) {
+          throw new Error(`Failed to create node: ${res.status}`)
+        }
+        const data = await res.json()
         setNodes(prev => [...prev, { ...node, id: data.id || node.id }])
       })
-      .catch(() => {})
+      .catch(err => {
+        console.error('[handleAddNode] error', err)
+      })
   }
 
   const handleCreateFirstNode = (label: string) => {
@@ -176,8 +181,11 @@ export default function MapEditorPage(): JSX.Element {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ ...newNode, mindmapId: id })
     })
-      .then(res => res.json())
-      .then(data => {
+      .then(async res => {
+        if (!res.ok) {
+          throw new Error(`Failed to create node: ${res.status}`)
+        }
+        const data = await res.json()
         setNodes(prev => [...prev, { ...newNode, id: data.id } as NodeData])
         setShowFirstNodeModal(false)
       })


### PR DESCRIPTION
## Summary
- ensure node creation requests fail loudly in MapEditorPage
- store first node with error handling
- trigger `onMoveNode` on touch end so mobile drags save positions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68830b718c208327ac131317aaa045c1