### PR TITLE
Change tile actions to buttons and links

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
 import { authHeaders } from '../authHeaders'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
@@ -164,24 +164,28 @@ export default function KanbanBoardsPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{b.title || 'Board'}</h2>
                   <div className="tile-actions">
-                    <Link
-                      to={`/kanban/${b.id}`}
-                      onClick={() =>
+                    <button
+                      className="btn btn-primary btn-wide"
+                      onClick={() => {
                         localStorage.setItem(
                           `board_last_viewed_${b.id}`,
                           Date.now().toString()
                         )
-                      }
-                      className="tile-link"
+                        navigate(`/kanban/${b.id}`)
+                      }}
                     >
                       Open
-                    </Link>
-                    <button
+                    </button>
+                    <a
+                      href="#"
                       className="tile-link delete-link"
-                      onClick={() => handleDelete(b.id)}
+                      onClick={e => {
+                        e.preventDefault()
+                        handleDelete(b.id)
+                      }}
                     >
                       Delete
-                    </button>
+                    </a>
                   </div>
                 </header>
                 <section className="tile-body">

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
 import { authHeaders } from '../authHeaders'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
@@ -176,24 +176,28 @@ export default function MindmapsPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
                   <div className="tile-actions">
-                    <Link
-                      to={`/maps/${m.id}`}
-                      onClick={() =>
+                    <button
+                      className="btn btn-primary btn-wide"
+                      onClick={() => {
                         localStorage.setItem(
                           `mindmap_last_viewed_${m.id}`,
                           Date.now().toString()
                         )
-                      }
-                      className="tile-link"
+                        navigate(`/maps/${m.id}`)
+                      }}
                     >
                       Open
-                    </Link>
-                    <button
+                    </button>
+                    <a
+                      href="#"
                       className="tile-link delete-link"
-                      onClick={() => handleDelete(m.id)}
+                      onClick={e => {
+                        e.preventDefault()
+                        handleDelete(m.id)
+                      }}
                     >
                       Delete
-                    </button>
+                    </a>
                   </div>
                 </header>
                 <section className="tile-body">

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
 import { authHeaders } from '../authHeaders'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
@@ -164,24 +164,28 @@ export default function TodosPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{t.title || t.content}</h2>
                   <div className="tile-actions">
-                    <Link
-                      to={`/todos/${t.id}`}
-                      onClick={() =>
+                    <button
+                      className="btn btn-primary btn-wide"
+                      onClick={() => {
                         localStorage.setItem(
                           `todo_last_viewed_${t.id}`,
                           Date.now().toString()
                         )
-                      }
-                      className="tile-link"
+                        navigate(`/todos/${t.id}`)
+                      }}
                     >
                       Open
-                    </Link>
-                    <button
+                    </button>
+                    <a
+                      href="#"
                       className="tile-link delete-link"
-                      onClick={() => handleDelete(t.id)}
+                      onClick={e => {
+                        e.preventDefault()
+                        handleDelete(t.id)
+                      }}
                     >
                       Delete
-                    </button>
+                    </a>
                   </div>
                 </header>
                 <section className="tile-body">

--- a/src/global.scss
+++ b/src/global.scss
@@ -1863,6 +1863,10 @@ hr {
   text-decoration: underline;
 }
 
+.tile-actions .btn {
+  margin-top: var(--spacing-xs);
+}
+
 .delete-link {
   color: var(--color-error);
 }


### PR DESCRIPTION
## Summary
- swap open links for buttons on todos, mindmaps and kanban boards
- style delete as a red text link
- ensure consistent spacing for buttons in tile actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68830c72294c8327b2d8a50c50dad95b