### PR TITLE
Fix tile action styling

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -165,7 +165,7 @@ export default function KanbanBoardsPage(): JSX.Element {
                   <h2>{b.title || 'Board'}</h2>
                   <div className="tile-actions">
                     <button
-                      className="btn btn-primary btn-wide"
+                      className="btn btn-primary"
                       onClick={() => {
                         localStorage.setItem(
                           `board_last_viewed_${b.id}`,

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -177,7 +177,7 @@ export default function MindmapsPage(): JSX.Element {
                   <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
                   <div className="tile-actions">
                     <button
-                      className="btn btn-primary btn-wide"
+                      className="btn btn-primary"
                       onClick={() => {
                         localStorage.setItem(
                           `mindmap_last_viewed_${m.id}`,

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -165,7 +165,7 @@ export default function TodosPage(): JSX.Element {
                   <h2>{t.title || t.content}</h2>
                   <div className="tile-actions">
                     <button
-                      className="btn btn-primary btn-wide"
+                      className="btn btn-primary"
                       onClick={() => {
                         localStorage.setItem(
                           `todo_last_viewed_${t.id}`,

--- a/src/global.scss
+++ b/src/global.scss
@@ -1867,7 +1867,7 @@ hr {
   margin-top: var(--spacing-xs);
 }
 
-.delete-link {
+.tile-actions .delete-link {
   color: var(--color-error);
 }
 


### PR DESCRIPTION
## Summary
- keep tile `Open` buttons the same size as the `Create` buttons
- ensure delete links are red by overriding the tile link style

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68830f2a3f10832791e1382240cede20