### PR TITLE
Enable hover and click tools in mind map

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -73,6 +73,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
   const [todoNodeId, setTodoNodeId] = useState<string | null>(null)
   const [newTask, setNewTask] = useState('')
   const [todoLists, setTodoLists] = useState<Record<string, { id: string; text: string; done: boolean }[]>>({})
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
   const modeRef = useRef<'canvas' | 'node' | null>(null)
     const dragStartRef = useRef({ x: 0, y: 0 })
     const originRef = useRef({ x: 0, y: 0 })
@@ -520,6 +521,9 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   e.stopPropagation()
                   setSelectedId(node.id)
                 }}
+                onMouseEnter={() => setHoveredId(node.id)}
+                onMouseLeave={() => setHoveredId(null)}
+                onTouchStart={() => setSelectedId(node.id)}
               >
                 <circle
                   r={20 / transform.k}
@@ -546,7 +550,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   ✓
                 </text>
               ) : null}
-              {selectedId === node.id && (
+              {(selectedId === node.id || hoveredId === node.id) && (
                 <g
                   className="hover-panel"
                   transform={`translate(${20 / transform.k},${-20 / transform.k})`}


### PR DESCRIPTION
## Summary
- show the node tools panel when a node is hovered or clicked
- add `hoveredId` state to track which node is hovered

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68831056ffe08327baa9852b2ff38e23