### PR TITLE
Persist mindmap layout

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -21,6 +21,8 @@ interface MindmapCanvasProps {
   height?: number | string
   onAddNode?: (node: NodeData) => void
   onMoveNode?: (node: NodeData) => void
+  initialTransform?: { x: number; y: number; k: number }
+  onTransformChange?: (t: { x: number; y: number; k: number }) => void
   showMiniMap?: boolean
 }
 
@@ -41,6 +43,8 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       height,
       onAddNode,
       onMoveNode,
+      initialTransform = { x: 0, y: 0, k: 1 },
+      onTransformChange,
       showMiniMap = false,
     },
     ref
@@ -53,7 +57,13 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
 
     const safeNodes = Array.isArray(nodes) ? nodes : []
     const safeEdges = Array.isArray(edges) ? edges : []
-    const [transform, setTransform] = useState({ x: 0, y: 0, k: 1 })
+    const [transform, setTransform] = useState<{ x: number; y: number; k: number }>(
+      () => initialTransform
+    )
+
+    useEffect(() => {
+      setTransform(initialTransform)
+    }, [initialTransform])
     const svgRef = useRef<SVGSVGElement | null>(null)
     const containerRef = useRef<HTMLDivElement | null>(null)
     const [showCreate, setShowCreate] = useState(false)
@@ -63,6 +73,10 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         setShowCreate(true)
       }
     }, [nodes])
+
+    useEffect(() => {
+      onTransformChange?.(transform)
+    }, [transform, onTransformChange])
     const [newName, setNewName] = useState('')
   const [newDesc, setNewDesc] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)

--- a/netlify/functions/update.ts
+++ b/netlify/functions/update.ts
@@ -17,7 +17,8 @@ const resourceConfigs: Record<string, { table: string; schema: z.ZodTypeAny }> =
     schema: z
       .object({
         title: z.string().min(1).optional(),
-        description: z.string().optional()
+        description: z.string().optional(),
+        config: z.any().optional()
       })
       .refine(data => Object.keys(data).length > 0, {
         message: 'At least one field must be provided'


### PR DESCRIPTION
## Summary
- expose `initialTransform` and `onTransformChange` props for `MindmapCanvas`
- record canvas transform in `MapEditorPage` and save to DB
- allow updating mindmap config via `update` function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688311545128832794bd3031ad67e7e4