### PR TITLE
Improve node toolbox design

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -13,6 +13,8 @@ import type { NodeData, EdgeData } from './mindmapTypes'
 const DOT_SPACING = 50
 const GRID_SIZE = 500
 const CANVAS_SIZE = DOT_SPACING * GRID_SIZE
+const TOOL_OFFSET_X = 0
+const TOOL_OFFSET_Y = -60
 
 interface MindmapCanvasProps {
   nodes?: NodeData[]
@@ -564,74 +566,72 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   ✓
                 </text>
               ) : null}
-              {(selectedId === node.id || hoveredId === node.id) && (
-                <g
-                  className="hover-panel"
-                  transform={`translate(${20 / transform.k},${-20 / transform.k})`}
-                  onPointerDown={e => e.stopPropagation()}
-                >
-                  <rect
-                    x={-4 / transform.k}
-                    y={-4 / transform.k}
-                    width={88 / transform.k}
-                    height={88 / transform.k}
-                    fill="#fff"
-                    stroke="#000"
-                    strokeWidth={1 / transform.k}
-                    rx={4 / transform.k}
-                  />
-                  <g
-                    transform="translate(0,0)"
-                    onClick={e => {
-                      e.stopPropagation()
-                      setSelectedId(null)
-                      setAddParentId(node.id)
-                      setNewName('')
-                      setNewDesc('')
-                    }}
-                  >
-                    <circle r={20 / transform.k} fill="orange" stroke="#000" strokeWidth={1 / transform.k} />
-                    <text textAnchor="middle" dy=".35em" fontSize={20 / transform.k} pointerEvents="none">+</text>
-                  </g>
-                  <g
-                    transform={`translate(${40 / transform.k},0)`}
-                    onClick={e => {
-                      e.stopPropagation()
-                      setSelectedId(null)
-                      openEditModal(node.id)
-                    }}
-                  >
-                    <circle r={20 / transform.k} fill="orange" stroke="#000" strokeWidth={1 / transform.k} />
-                    <text textAnchor="middle" dy=".35em" fontSize={20 / transform.k} pointerEvents="none">✏️</text>
-                  </g>
-                  <g
-                    transform={`translate(0,${40 / transform.k})`}
-                    onClick={e => {
-                      e.stopPropagation()
-                      setSelectedId(null)
-                      handleDeleteNode(node.id)
-                    }}
-                  >
-                    <circle r={20 / transform.k} fill="orange" stroke="#000" strokeWidth={1 / transform.k} />
-                    <text textAnchor="middle" dy=".35em" fontSize={20 / transform.k} pointerEvents="none">🗑️</text>
-                  </g>
-                  <g
-                    transform={`translate(${40 / transform.k},${40 / transform.k})`}
-                    onClick={e => {
-                      e.stopPropagation()
-                      setSelectedId(null)
-                      setTodoNodeId(node.id)
-                    }}
-                  >
-                    <circle r={20 / transform.k} fill="orange" stroke="#000" strokeWidth={1 / transform.k} />
-                    <text textAnchor="middle" dy=".35em" fontSize={20 / transform.k} pointerEvents="none">✓</text>
-                  </g>
-                </g>
-              )}
+              {(selectedId === node.id || hoveredId === node.id) && null}
               </g>
             ))}
           </g>
         </svg>
+        {Array.isArray(safeNodes) &&
+          safeNodes.map(node =>
+            selectedId === node.id || hoveredId === node.id ? (
+              <div
+                key={`toolbox-${node.id}`}
+                className="node-toolbox"
+                style={{
+                  position: 'absolute',
+                  left: node.x * transform.k + transform.x + TOOL_OFFSET_X,
+                  top: node.y * transform.k + transform.y + TOOL_OFFSET_Y,
+                  transform: `translate(-50%, -100%) scale(${1 / transform.k})`,
+                  transformOrigin: 'top left',
+                  zIndex: 5,
+                }}
+                onPointerDown={e => e.stopPropagation()}
+              >
+                <div
+                  className="node-toolbox-button"
+                  onClick={e => {
+                    e.stopPropagation()
+                    setSelectedId(null)
+                    setAddParentId(node.id)
+                    setNewName('')
+                    setNewDesc('')
+                  }}
+                >
+                  +
+                </div>
+                <div
+                  className="node-toolbox-button"
+                  onClick={e => {
+                    e.stopPropagation()
+                    setSelectedId(null)
+                    openEditModal(node.id)
+                  }}
+                >
+                  🖉
+                </div>
+                <div
+                  className="node-toolbox-button"
+                  onClick={e => {
+                    e.stopPropagation()
+                    setSelectedId(null)
+                    handleDeleteNode(node.id)
+                  }}
+                >
+                  🗑
+                </div>
+                <div
+                  className="node-toolbox-button"
+                  onClick={e => {
+                    e.stopPropagation()
+                    setSelectedId(null)
+                    setTodoNodeId(node.id)
+                  }}
+                >
+                  ✅
+                </div>
+              </div>
+            ) : null
+          )}
         <div
           className="zoom-controls"
           style={{

--- a/src/global.scss
+++ b/src/global.scss
@@ -2393,3 +2393,33 @@ hr {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+
+.node-toolbox {
+  display: grid;
+  grid-template-columns: repeat(2, 48px);
+  grid-gap: 10px;
+  padding: 8px;
+  border-radius: 12px;
+  background: rgba(20, 20, 20, 0.8);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 0 10px rgba(255, 165, 0, 0.4);
+}
+
+.node-toolbox-button {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #ffa500, #ffb733);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  color: #000;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.node-toolbox-button:hover {
+  transform: scale(1.1);
+}


### PR DESCRIPTION
## Summary
- modernize mindmap node toolbox styling
- draw floating node toolbox using HTML overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688312e5201c8327a515684e09b5914a