### PR TITLE
Apply unified tile style across pages

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -134,7 +134,7 @@ export default function KanbanBoardsPage(): JSX.Element {
       ) : (
         <> 
           <div className="four-col-grid">
-            <div className="tile create-tile">
+            <div className="dashboard-tile create-tile">
               <header className="tile-header"><h2>Create Board</h2></header>
               <section className="tile-body">
                 <p className="create-help">Click Create to Start</p>
@@ -143,7 +143,7 @@ export default function KanbanBoardsPage(): JSX.Element {
                 </button>
               </section>
             </div>
-              <div className="tile">
+              <div className="metric-tile">
                 <header className="tile-header"><h2>Metrics</h2></header>
                 <section className="tile-body">
                   <p>Total: {boards.length}</p>
@@ -160,7 +160,7 @@ export default function KanbanBoardsPage(): JSX.Element {
                 </section>
               </div>
             {sorted.map(b => (
-              <div className="tile" key={b.id}>
+              <div className="dashboard-tile open-tile" key={b.id}>
                 <header className="tile-header">
                   <h2>{b.title || 'Board'}</h2>
                   <div className="tile-actions">
@@ -194,7 +194,7 @@ export default function KanbanBoardsPage(): JSX.Element {
               </div>
             ))}
             {Array.from({ length: 10 }).map((_v, i) => (
-              <div className="tile ghost-tile" key={`ghost-${i}`}></div>
+              <div className="dashboard-tile ghost-tile" key={`ghost-${i}`}></div>
             ))}
           </div>
         </>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -138,7 +138,7 @@ export default function MindmapsPage(): JSX.Element {
         <p className="error">{error}</p>
       ) : (
         <div className="four-col-grid">
-          <div className="tile create-tile">
+          <div className="dashboard-tile create-tile">
             <header className="tile-header">
               <h2>Create Mind Map</h2>
             </header>
@@ -149,7 +149,7 @@ export default function MindmapsPage(): JSX.Element {
               </button>
             </section>
           </div>
-          <div className="tile">
+          <div className="metric-tile">
             <header className="tile-header"><h2>Metrics</h2></header>
             <section className="tile-body">
               <p>Total: {maps.length}</p>
@@ -167,12 +167,12 @@ export default function MindmapsPage(): JSX.Element {
           </div>
 
           {sorted.length === 0 ? (
-            <div className="tile empty">
+            <div className="dashboard-tile empty">
               <p>No mind maps found.</p>
             </div>
           ) : (
             sorted.map(m => (
-              <div className="tile" key={m.id}>
+              <div className="dashboard-tile open-tile" key={m.id}>
                 <header className="tile-header">
                   <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
                   <div className="tile-actions">
@@ -207,7 +207,7 @@ export default function MindmapsPage(): JSX.Element {
             ))
           )}
           {Array.from({ length: 10 }).map((_v, i) => (
-            <div className="tile ghost-tile" key={`ghost-${i}`}></div>
+            <div className="dashboard-tile ghost-tile" key={`ghost-${i}`}></div>
           ))}
         </div>
       )}

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -134,7 +134,7 @@ export default function TodosPage(): JSX.Element {
       ) : (
         <> 
           <div className="four-col-grid">
-            <div className="tile create-tile">
+            <div className="dashboard-tile create-tile">
               <header className="tile-header"><h2>Create Todo</h2></header>
               <section className="tile-body">
                 <p className="create-help">Click Create to Start</p>
@@ -143,7 +143,7 @@ export default function TodosPage(): JSX.Element {
                 </button>
               </section>
             </div>
-            <div className="tile">
+            <div className="metric-tile">
               <header className="tile-header"><h2>Metrics</h2></header>
               <section className="tile-body">
                 <p>Total: {todos.length}</p>
@@ -160,7 +160,7 @@ export default function TodosPage(): JSX.Element {
               </section>
             </div>
             {sorted.map(t => (
-              <div className="tile" key={t.id}>
+              <div className="dashboard-tile open-tile" key={t.id}>
                 <header className="tile-header">
                   <h2>{t.title || t.content}</h2>
                   <div className="tile-actions">
@@ -194,7 +194,7 @@ export default function TodosPage(): JSX.Element {
               </div>
             ))}
             {Array.from({ length: 10 }).map((_v, i) => (
-              <div className="tile ghost-tile" key={`ghost-${i}`}></div>
+              <div className="dashboard-tile ghost-tile" key={`ghost-${i}`}></div>
             ))}
           </div>
         </>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1927,6 +1927,12 @@ hr {
   opacity: 0.5;
 }
 
+/* tiles that contain an open button */
+.open-tile {
+  border: 1px dashed #fbd8a8;
+  background: linear-gradient(135deg, #f8f8f8, #fff8ec);
+}
+
 .tile-header-center {
   text-align: center;
   margin-bottom: 1rem;


### PR DESCRIPTION
## Summary
- use dashboard tile styles on list pages
- add `open-tile` style for items with open buttons
- update mindmaps, todos and kanban pages to use new styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883c2d06c688327b3f4ef8a3637be91