### PR TITLE
Improve metrics tiles layout

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -143,21 +143,21 @@ export default function KanbanBoardsPage(): JSX.Element {
                 </button>
               </section>
             </div>
-              <div className="metric-tile">
-                <header className="tile-header"><h2>Metrics</h2></header>
-                <section className="tile-body">
-                  <p>Total: {boards.length}</p>
-                  <div className="metric-detail-grid">
-                    <div className="metric-detail">
-                      <span className="label">Today</span>
-                      <span className="value">{boardDay}</span>
-                    </div>
-                    <div className="metric-detail">
-                      <span className="label">Week</span>
-                      <span className="value">{boardWeek}</span>
-                    </div>
+              <div className="metric-tile simple">
+                <div className="metric-header stacked">
+                  <h3>Metrics</h3>
+                  <div className="metric-circle">{boards.length}</div>
+                </div>
+                <div className="metric-detail-grid">
+                  <div className="metric-detail">
+                    <span className="label">Today</span>
+                    <span className="value">{boardDay}</span>
                   </div>
-                </section>
+                  <div className="metric-detail">
+                    <span className="label">Week</span>
+                    <span className="value">{boardWeek}</span>
+                  </div>
+                </div>
               </div>
             {sorted.map(b => (
               <div className="dashboard-tile open-tile" key={b.id}>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -149,21 +149,21 @@ export default function MindmapsPage(): JSX.Element {
               </button>
             </section>
           </div>
-          <div className="metric-tile">
-            <header className="tile-header"><h2>Metrics</h2></header>
-            <section className="tile-body">
-              <p>Total: {maps.length}</p>
-              <div className="metric-detail-grid">
-                <div className="metric-detail">
-                  <span className="label">Today</span>
-                  <span className="value">{mapDay}</span>
-                </div>
-                <div className="metric-detail">
-                  <span className="label">Week</span>
-                  <span className="value">{mapWeek}</span>
-                </div>
+          <div className="metric-tile simple">
+            <div className="metric-header stacked">
+              <h3>Metrics</h3>
+              <div className="metric-circle">{maps.length}</div>
+            </div>
+            <div className="metric-detail-grid">
+              <div className="metric-detail">
+                <span className="label">Today</span>
+                <span className="value">{mapDay}</span>
               </div>
-            </section>
+              <div className="metric-detail">
+                <span className="label">Week</span>
+                <span className="value">{mapWeek}</span>
+              </div>
+            </div>
           </div>
 
           {sorted.length === 0 ? (

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -143,21 +143,21 @@ export default function TodosPage(): JSX.Element {
                 </button>
               </section>
             </div>
-            <div className="metric-tile">
-              <header className="tile-header"><h2>Metrics</h2></header>
-              <section className="tile-body">
-                <p>Total: {todos.length}</p>
-                <div className="metric-detail-grid">
-                  <div className="metric-detail">
-                    <span className="label">Today</span>
-                    <span className="value">{addedDay}</span>
-                  </div>
-                  <div className="metric-detail">
-                    <span className="label">Week</span>
-                    <span className="value">{addedWeek}</span>
-                  </div>
+            <div className="metric-tile simple">
+              <div className="metric-header stacked">
+                <h3>Metrics</h3>
+                <div className="metric-circle">{todos.length}</div>
+              </div>
+              <div className="metric-detail-grid">
+                <div className="metric-detail">
+                  <span className="label">Today</span>
+                  <span className="value">{addedDay}</span>
                 </div>
-              </section>
+                <div className="metric-detail">
+                  <span className="label">Week</span>
+                  <span className="value">{addedWeek}</span>
+                </div>
+              </div>
             </div>
             {sorted.map(t => (
               <div className="dashboard-tile open-tile" key={t.id}>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1675,6 +1675,14 @@ hr {
   backdrop-filter: blur(8px);
 }
 
+/* compact variant used on list pages */
+.metric-tile.simple {
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  min-height: auto;
+}
+
 // widen sparkline width specifically within dashboard metric tiles
 .metric-tile .sparkline {
   width: 100%;
@@ -1723,6 +1731,11 @@ hr {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
+}
+
+.metric-header.stacked {
+  flex-direction: column;
+  align-items: center;
 }
 
 .metric-right {


### PR DESCRIPTION
## Summary
- update Mindmaps, Todos, and Kanban dashboard metric tiles
- add compact metric tile styles for list pages

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883c828fa1883278cefd61bcd63568b