### PR TITLE
Improve node toolbox behavior

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -342,6 +342,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const handlePointerDown = useCallback(
       (e: React.PointerEvent<SVGSVGElement>) => {
         console.log('[MindmapCanvas] handlePointerDown')
+        e.stopPropagation()
         if ((e.target as HTMLElement).closest('.add-child-button')) return
         const target = (e.target as HTMLElement).closest('.mindmap-node') as HTMLElement | null
         dragStartRef.current = { x: e.clientX, y: e.clientY }
@@ -488,6 +489,10 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     return (
       <div
         ref={containerRef}
+        onPointerDown={() => {
+          setSelectedId(null)
+          modeRef.current = null
+        }}
         style={{
           width: containerWidth,
           height: containerHeight,


### PR DESCRIPTION
## Summary
- close toolbox when clicking canvas
- stop pointer event bubbling so canvas click handler doesn't fire

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d1ee67d083278bb342d03528a381