### PR TITLE
Fix node drag with toolbox

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -611,11 +611,12 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   transform: `translate(-50%, -100%) scale(${1 / transform.k})`,
                   transformOrigin: 'top left',
                   zIndex: 5,
+                  pointerEvents: 'none',
                 }}
-                onPointerDown={e => e.stopPropagation()}
               >
                 <div
                   className="node-toolbox-button"
+                  style={{ pointerEvents: 'auto' }}
                   onClick={e => {
                     e.stopPropagation()
                     setSelectedId(null)
@@ -628,6 +629,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 </div>
                 <div
                   className="node-toolbox-button"
+                  style={{ pointerEvents: 'auto' }}
                   onClick={e => {
                     e.stopPropagation()
                     setSelectedId(null)
@@ -638,6 +640,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 </div>
                 <div
                   className="node-toolbox-button"
+                  style={{ pointerEvents: 'auto' }}
                   onClick={e => {
                     e.stopPropagation()
                     setSelectedId(null)
@@ -648,6 +651,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 </div>
                 <div
                   className="node-toolbox-button"
+                  style={{ pointerEvents: 'auto' }}
                   onClick={e => {
                     e.stopPropagation()
                     setSelectedId(null)

--- a/src/global.scss
+++ b/src/global.scss
@@ -2432,6 +2432,7 @@ hr {
   background: rgba(20, 20, 20, 0.8);
   backdrop-filter: blur(6px);
   box-shadow: 0 0 10px rgba(255, 165, 0, 0.4);
+  pointer-events: none;
 }
 
 .node-toolbox-button {
@@ -2447,6 +2448,7 @@ hr {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   cursor: pointer;
   transition: transform 0.2s;
+  pointer-events: auto;
 }
 
 .node-toolbox-button:hover {


### PR DESCRIPTION
## Summary
- allow dragging nodes even when toolbox visible
- enable pointer-events on toolbox buttons only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883d5069040832793320f397733bc3e