### PR TITLE
Fix node drag performance issues

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -325,9 +325,18 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const handlePointerUp = useCallback(
       (e: PointerEvent) => {
         console.log('[MindmapCanvas] handlePointerUp')
-        if (modeRef.current === 'node' && dragNodeIdRef.current) {
+        if (
+          modeRef.current === 'node' &&
+          dragNodeIdRef.current &&
+          nodeOriginRef.current
+        ) {
           const node = safeNodes.find(n => n.id === dragNodeIdRef.current)
-          if (node && onMoveNode) onMoveNode(node)
+          if (
+            node &&
+            (node.x !== nodeOriginRef.current.x || node.y !== nodeOriginRef.current.y)
+          ) {
+            onMoveNode && onMoveNode(node)
+          }
         }
         modeRef.current = null
         dragNodeIdRef.current = null
@@ -515,17 +524,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
         >
-          <defs>
-            <pattern
-              id="dot-grid"
-              width="50"
-              height="50"
-              patternUnits="userSpaceOnUse"
-            >
-              <circle cx="1" cy="1" r="1" fill="#FF6A00" />
-            </pattern>
-          </defs>
-          <rect width={CANVAS_SIZE} height={CANVAS_SIZE} fill="url(#dot-grid)" />
+          <rect width={CANVAS_SIZE} height={CANVAS_SIZE} fill="#fff" />
           <g
             transform={`translate(${transform.x},${transform.y}) scale(${transform.k})`}
           >

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -144,7 +144,7 @@ export default function MapEditorPage(): JSX.Element {
   const safeNodes = Array.isArray(nodes) ? nodes : []
 
   const handleSaveLayout = useCallback(() => {
-    if (!Array.isArray(safeNodes)) return
+    if (!Array.isArray(safeNodes) || !mindmap?.id) return
     safeNodes.forEach(n => {
       fetch(`/.netlify/functions/nodes/${n.id}`, {
         method: 'PATCH',
@@ -153,7 +153,13 @@ export default function MapEditorPage(): JSX.Element {
         body: JSON.stringify({ x: n.x, y: n.y })
       }).catch(() => {})
     })
-  }, [safeNodes])
+    fetch(`/.netlify/functions/update/mindmap/${mindmap.id}`, {
+      method: 'PATCH',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ config: { ...(mindmap.config || {}), transform } })
+    }).catch(() => {})
+  }, [safeNodes, mindmap, transform])
 
   const edges: EdgeData[] = Array.isArray(safeNodes)
     ? safeNodes
@@ -209,16 +215,8 @@ export default function MapEditorPage(): JSX.Element {
       setMindmap(prev =>
         prev ? { ...prev, config: { ...(prev.config || {}), transform: t } } : prev
       )
-      if (mindmap?.id) {
-        fetch(`/.netlify/functions/update/mindmap/${mindmap.id}`, {
-          method: 'PATCH',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ config: { ...(mindmap.config || {}), transform: t } })
-        }).catch(() => {})
-      }
     },
-    [mindmap]
+    []
   )
 
   if (error) return <div>Error loading map.</div>


### PR DESCRIPTION
## Summary
- update mindmap canvas to stop calling `onMoveNode` unless the node position actually changes
- remove dotted background grid to prevent snap behaviour
- avoid updating map transform on every pointer move
- persist transform only when saving layout

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883da0a82a08327a2205bc09e159a21