### PR TITLE
Add todo title and prompt in canvas

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -20,7 +20,7 @@ export default function TodoCanvas({
   kanbanId,
 }: TodoCanvasProps): JSX.Element {
   const [todos, setTodos] = useState<TodoItem[]>(initialTodos)
-  const [adding, setAdding] = useState(false)
+  const [adding, setAdding] = useState(initialTodos.length === 0)
   const [newTitle, setNewTitle] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -53,9 +53,13 @@ export default function TodoCanvas({
           {todos[0].description && (
             <p className="todo-description">{todos[0].description}</p>
           )}
+          <h2 className="todo-title-below">{todos[0].title}</h2>
         </header>
       )}
       <div className="todo-list">
+        {todos.length === 0 && (
+          <p className="todo-empty-message">Add a new todo to get started.</p>
+        )}
         {todos.map(t => (
           <div key={t.id} className="tile">
             <header className="tile-header">

--- a/src/global.scss
+++ b/src/global.scss
@@ -2246,6 +2246,17 @@ hr {
   flex: 1;
 }
 
+.todo-empty-message {
+  margin-top: 1rem;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.todo-title-below {
+  margin-top: 0.5rem;
+  font-size: 1.25rem;
+}
+
 .done-adding-link {
   margin-top: 0.5rem;
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary
- display the first todo's title at the page top and again beneath its description
- automatically show the add form when there are no todos
- show a helpful message prompting users to add their first todo
- style the new elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e219d5a08327a9c2cadc07c4eff9