### PR TITLE
Improve Kanban board UI

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -11,15 +11,25 @@ interface Lane {
   cards: Card[]
 }
 
-export default function InteractiveKanbanBoard() {
+interface Props {
+  title?: string
+  description?: string
+}
+
+export default function InteractiveKanbanBoard({
+  title,
+  description,
+}: Props) {
   const [lanes, setLanes] = useState<Lane[]>([
     { id: 'lane-1', title: 'New', cards: [] },
     { id: 'lane-2', title: 'In-Progress', cards: [] },
     { id: 'lane-3', title: 'Reviewing', cards: [] },
-    { id: 'lane-4', title: 'Done', cards: [] }
+    { id: 'lane-4', title: 'Done', cards: [] },
   ])
-  const [boardTitle] = useState('Kanban Board')
-  const [boardDescription] = useState('Organize tasks across lanes')
+  const [boardTitle] = useState(title || 'Kanban Board')
+  const [boardDescription] = useState(
+    description || 'Organize tasks across lanes'
+  )
 
   const addLane = () => {
     const id = `lane-${Date.now()}`

--- a/KanbanCanvas.tsx
+++ b/KanbanCanvas.tsx
@@ -1,104 +1,11 @@
-import { useState } from 'react'
-import KanbanLane from './KanbanLane'
-import EmptyKanbanBoard from './EmptyKanbanBoard'
-import Modal from './modal'
+import InteractiveKanbanBoard from './InteractiveKanbanBoard'
 
 interface Props {
-  boardData?: any
-  nodeId?: string
-  todoId?: string
+  boardData?: { title?: string; description?: string }
 }
 
-export default function KanbanCanvas({ boardData, nodeId, todoId }: Props) {
-  const [board, setBoard] = useState(boardData)
-  const [showModal, setShowModal] = useState(!boardData)
-  const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('')
-
-  const createBoard = async () => {
-    try {
-      const res = await fetch('/.netlify/functions/boards', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, description, nodeId, todoId }),
-      })
-      const json = await res.json()
-      if (json?.boardId || json?.id) {
-        setBoard({
-          id: json.boardId || json.id,
-          lanes: [
-            { id: 'lane-new', title: 'New', cards: [] },
-            { id: 'lane-progress', title: 'In Progress', cards: [] },
-            { id: 'lane-review', title: 'Review', cards: [] },
-            { id: 'lane-complete', title: 'Complete', cards: [] },
-          ],
-        })
-      }
-      setShowModal(false)
-      setTitle('')
-      setDescription('')
-    } catch (err) {
-      console.error(err)
-    }
-  }
-
-  const activeBoard = board
-  const hasCards = activeBoard?.lanes?.some((lane: any) => lane.cards?.length > 0)
-
-  if (!activeBoard) {
-    return (
-      <>
-        <div className="kanban-board">
-          {['New', 'In Progress', 'Review', 'Complete'].map(l => (
-            <KanbanLane key={l} title={l} cards={[]} />
-          ))}
-        </div>
-        <Modal isOpen={showModal} onClose={() => setShowModal(false)} ariaLabel="Create board">
-          <form
-            onSubmit={e => {
-              e.preventDefault()
-              createBoard()
-            }}
-          >
-            <h2>Create Board</h2>
-            <input
-              className="form-input"
-              value={title}
-              onChange={e => setTitle(e.target.value)}
-              placeholder="Name"
-              required
-            />
-            <textarea
-              className="form-input"
-              value={description}
-              onChange={e => setDescription(e.target.value)}
-              placeholder="Description (optional)"
-              style={{ marginTop: '0.5rem' }}
-            />
-            <div className="form-actions" style={{ marginTop: '1rem' }}>
-              <button type="button" className="btn-cancel" onClick={() => setShowModal(false)}>
-                Cancel
-              </button>
-              <button type="submit" className="btn-primary">
-                Save
-              </button>
-            </div>
-          </form>
-        </Modal>
-      </>
-    )
-  }
-
-  if (!hasCards) {
-    return <EmptyKanbanBoard lanes={activeBoard.lanes.map((l: any) => l.title)} />
-  }
-
-  return (
-    <div className="kanban-board">
-      {activeBoard.lanes.map((lane: any) => (
-        <KanbanLane key={lane.id} title={lane.title} cards={lane.cards} />
-      ))}
-    </div>
-  )
+export default function KanbanCanvas({ boardData }: Props) {
+  const title = boardData?.title
+  const description = boardData?.description
+  return <InteractiveKanbanBoard title={title} description={description} />
 }

--- a/src/KanbanBoardPage.tsx
+++ b/src/KanbanBoardPage.tsx
@@ -3,21 +3,22 @@ import { useParams } from 'react-router-dom'
 import KanbanCanvas from '../KanbanCanvas'
 import { authFetch } from '../authFetch'
 
-interface BoardItem {
+interface Board {
   id: string
   title?: string
+  description?: string
   created_at?: string
 }
 
 export default function KanbanBoardPage(): JSX.Element {
   const { id } = useParams<{ id: string }>()
-  const [boardData, setBoardData] = useState<any>(null)
+  const [boardData, setBoardData] = useState<Board | null>(null)
 
   useEffect(() => {
     if (!id) return
     authFetch(`/.netlify/functions/boards?id=${id}`)
       .then(res => res.json())
-      .then(data => setBoardData(data))
+      .then(data => setBoardData(data.board))
       .catch(err => {
         console.error('Error loading kanban board', err)
         setBoardData(null)


### PR DESCRIPTION
## Summary
- refactor `InteractiveKanbanBoard` to accept title and description props
- simplify `KanbanCanvas` to render the interactive board
- load board details in `KanbanBoardPage` and pass to the canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883ea65f6508327ba78ba00216a08e6