### PR TITLE
Fix node state sync with map editor

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -70,6 +70,14 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const [showCreate, setShowCreate] = useState(false)
 
     useEffect(() => {
+      setNodes(safePropNodes)
+    }, [propNodes])
+
+    useEffect(() => {
+      setEdges(safePropEdges)
+    }, [propEdges])
+
+    useEffect(() => {
       if (Array.isArray(nodes) && nodes.length === 0) {
         setShowCreate(true)
       }


### PR DESCRIPTION
## Summary
- keep MindmapCanvas nodes and edges in sync with props

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883ebb990f0832788ef4caa86d1a477