### PR TITLE
Add DB save for map nodes

### DIFF
--- a/ProjectWorkspace.tsx
+++ b/ProjectWorkspace.tsx
@@ -20,7 +20,13 @@ export default function ProjectWorkspace() {
         <button onClick={() => setTab('kanban')}>Kanban</button>
       </div>
       {tab === 'mindmap' && (
-        <MindmapCanvas nodes={initialNodes} edges={initialEdges} width={600} height={400} />
+        <MindmapCanvas
+          nodes={initialNodes}
+          edges={initialEdges}
+          width={600}
+          height={400}
+          mindmapId="demo"
+        />
       )}
       {tab === 'todo' && <TodoCanvas />}
       {tab === 'kanban' && <KanbanCanvas />}

--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -67,20 +67,24 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       } catch {
         return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid JSON' }) }
       }
-      const id = payload as any && (payload as any).id ? (payload as any).id : crypto.randomUUID()
-      await client.query(
-        `INSERT INTO nodes(id, mindmap_id, parent_id, x, y, label, description) VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+      const result = await client.query(
+        `INSERT INTO nodes (mindmap_id, x, y, label, description, parent_id)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id`,
         [
-          id,
           payload.mindmapId,
-          payload.parentId ?? null,
           payload.x,
           payload.y,
           payload.label ?? null,
           payload.description ?? null,
+          payload.parentId ?? null,
         ]
       )
-      return { statusCode: 201, headers, body: JSON.stringify({ id }) }
+      return {
+        statusCode: 200,
+        headers,
+        body: JSON.stringify({ id: result.rows[0].id })
+      }
     }
 
     if (event.httpMethod === 'PUT' || event.httpMethod === 'PATCH') {

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -241,6 +241,7 @@ export default function MapEditorPage(): JSX.Element {
             initialTransform={transform}
             onTransformChange={handleTransformChange}
             showMiniMap
+            mindmapId={mindmap.id}
           />
           {safeNodes.length === 0 && null}
           {nodesError && (


### PR DESCRIPTION
## Summary
- allow MindmapCanvas to save new nodes through Netlify function
- pass `mindmapId` into MindmapCanvas from MapEditorPage
- update nodes Netlify function to return inserted ID
- adjust demo ProjectWorkspace usage

## Testing
- `npm test`
- `npm run build` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883eeb53a5883278f3d76dc2ff2fe63