### PR TITLE
Improve Kanban board UX

### DIFF
--- a/CardModal.tsx
+++ b/CardModal.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react'
+import Modal from './modal'
+import { v4 as uuid } from 'uuid'
+
+export interface Comment {
+  id: string
+  text: string
+  createdAt: string
+  author: string
+}
+
+export interface Card {
+  id: string
+  title: string
+  comments?: Comment[]
+}
+
+interface Props {
+  card: Card | null
+  onClose: () => void
+  onSave: (card: Card) => void
+  currentUser?: { name: string }
+}
+
+export default function CardModal({ card, onClose, onSave, currentUser }: Props) {
+  const [title, setTitle] = useState(card?.title || '')
+  const [comments, setComments] = useState<Comment[]>(card?.comments || [])
+  const [newComment, setNewComment] = useState('')
+
+  useEffect(() => {
+    if (card) {
+      setTitle(card.title)
+      setComments(card.comments || [])
+    }
+  }, [card])
+
+  const handleAddComment = () => {
+    if (!newComment.trim()) return
+    const comment: Comment = {
+      id: uuid(),
+      text: newComment,
+      createdAt: new Date().toISOString(),
+      author: currentUser?.name || 'Anon'
+    }
+    setComments([...comments, comment])
+    setNewComment('')
+  }
+
+  const save = () => {
+    if (!card) return
+    onSave({ ...card, title, comments })
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={!!card} onClose={onClose} ariaLabel="Edit card">
+      <div className="card-modal">
+        <h2>Edit Card</h2>
+        <input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="w-full border p-2 mb-4"
+        />
+        <div className="mb-4">
+          {comments.map(c => (
+            <div key={c.id} className="comment">
+              <strong>{c.author}</strong>
+              <p>{c.text}</p>
+              <span>{new Date(c.createdAt).toLocaleString()}</span>
+            </div>
+          ))}
+        </div>
+        <textarea
+          className="w-full border p-2 mb-2"
+          placeholder="Add a comment..."
+          value={newComment}
+          onChange={e => setNewComment(e.target.value)}
+        />
+        <div className="flex justify-end gap-2">
+          <button onClick={handleAddComment} className="btn-secondary">Post</button>
+          <button onClick={save} className="btn-primary">Save</button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -2354,29 +2354,38 @@ hr {
   color: #666;
 }
 
-.kanban-lanes {
+/* Kanban board layout */
+.kanban-board {
   display: flex;
-  height: calc(100vh - 100px);
+  height: calc(100vh - 60px);
   overflow-x: auto;
+  background: #f4f5f7;
+  padding: 16px;
 }
 
 .lane {
-  flex: 1;
-  min-width: 250px;
-  background: #f7f8fa;
-  border-right: 1px solid #ddd;
+  background: white;
+  border-radius: 6px;
+  min-width: 280px;
+  margin-right: 16px;
   display: flex;
   flex-direction: column;
-  padding: 12px;
+  max-height: 100%;
 }
 
 .card {
-  background: white;
+  background: #fff;
+  border: 1px solid #dfe1e6;
+  border-radius: 6px;
   padding: 12px;
-  margin-bottom: 12px;
-  border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
-  position: relative;
+  margin-bottom: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
 
 .card-header {
@@ -2395,6 +2404,28 @@ hr {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.card-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 600px;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 10px 50px rgba(0, 0, 0, 0.2);
+  padding: 24px;
+  z-index: 1000;
+}
+
+.comment {
+  margin-bottom: 0.5rem;
+}
+
+.comment span {
+  font-size: 0.75rem;
+  color: #666;
 }
 
 /* Empty canvas modal */


### PR DESCRIPTION
## Summary
- add `CardModal` component for editing Kanban cards and posting comments
- refactor `InteractiveKanbanBoard` to use modal editing and save card details
- restyle Kanban lanes and cards for Jira-like feel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883f3eabbe083279955e37ad07eae8e