### PR TITLE
Improve card edit modal styling

### DIFF
--- a/CardModal.tsx
+++ b/CardModal.tsx
@@ -12,6 +12,7 @@ export interface Comment {
 export interface Card {
   id: string
   title: string
+  description?: string
   comments?: Comment[]
   dueDate?: string
   priority?: 'low' | 'medium' | 'high'
@@ -31,6 +32,7 @@ interface Props {
 
 export default function CardModal({ card, onClose, onSave, currentUser }: Props) {
   const [title, setTitle] = useState(card?.title || '')
+  const [description, setDescription] = useState(card?.description || '')
   const [comments, setComments] = useState<Comment[]>(card?.comments || [])
   const [newComment, setNewComment] = useState('')
   const [dueDate, setDueDate] = useState(card?.dueDate || '')
@@ -42,6 +44,7 @@ export default function CardModal({ card, onClose, onSave, currentUser }: Props)
   useEffect(() => {
     if (card) {
       setTitle(card.title)
+      setDescription(card.description || '')
       setComments(card.comments || [])
       setDueDate(card.dueDate || '')
       setPriority(card.priority || 'low')
@@ -76,6 +79,7 @@ export default function CardModal({ card, onClose, onSave, currentUser }: Props)
     onSave({
       ...card,
       title,
+      description,
       comments,
       dueDate,
       priority,
@@ -87,72 +91,126 @@ export default function CardModal({ card, onClose, onSave, currentUser }: Props)
 
   return (
     <Modal isOpen={!!card} onClose={onClose} ariaLabel="Edit card">
-      <div className="card-modal">
-        <h2>Edit Card</h2>
-        <input
-          value={title}
-          onChange={e => setTitle(e.target.value)}
-          className="w-full border p-2 mb-4"
-        />
-        <label className="block mb-1">Due Date</label>
-        <input
-          type="date"
-          value={dueDate}
-          onChange={e => setDueDate(e.target.value)}
-          className="w-full border p-2 mb-4"
-        />
-        <label className="block mb-1">Priority</label>
-        <select
-          value={priority}
-          onChange={e => setPriority(e.target.value as Card['priority'])}
-          className="w-full border p-2 mb-4"
-        >
-          <option value="low">Low</option>
-          <option value="medium">Medium</option>
-          <option value="high">High</option>
-        </select>
-        <label className="block mb-1">Status</label>
-        <select
-          value={status}
-          onChange={e => setStatus(e.target.value as Card['status'])}
-          className="w-full border p-2 mb-4"
-        >
-          <option value="open">Open</option>
-          <option value="done">Done</option>
-        </select>
-        <label className="block mb-1">Assignee</label>
-        <select
-          value={assignee}
-          onChange={e => setAssignee(e.target.value)}
-          className="w-full border p-2 mb-4"
-        >
-          <option value="">Unassigned</option>
-          {teamMembers.map(m => (
-            <option key={m.id} value={m.id}>
-              {m.name}
-            </option>
-          ))}
-        </select>
-        <div className="mb-4">
-          {comments.map(c => (
-            <div key={c.id} className="comment">
-              <strong>{c.author}</strong>
-              <p>{c.text}</p>
-              <span>{new Date(c.createdAt).toLocaleString()}</span>
+      {card && (
+        <div className="card-modal">
+          <h2>Edit Card</h2>
+
+          {card.todoId && (
+            <div className="card-links">
+              <span>
+                🔗 Linked to <a href={`/todo/${card.todoListId}`}>Todo List</a>
+              </span>
+              {card.mindmapId && (
+                <span>
+                  {' '} & <a href={`/maps/${card.mindmapId}`}>Mindmap</a>
+                </span>
+              )}
             </div>
-          ))}
+          )}
+
+          <label>
+            Title
+            <input
+              type="text"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              className="input"
+            />
+          </label>
+
+          <label>
+            Description
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              className="textarea"
+            />
+          </label>
+
+          <div className="card-meta-grid">
+            <div>
+              <label>Status</label>
+              <select
+                value={status}
+                onChange={e => setStatus(e.target.value as Card['status'])}
+                className="select"
+              >
+                <option value="open">Open</option>
+                <option value="done">Done</option>
+              </select>
+            </div>
+
+            <div>
+              <label>Due Date</label>
+              <input
+                type="date"
+                value={dueDate}
+                onChange={e => setDueDate(e.target.value)}
+                className="input"
+              />
+            </div>
+
+            <div>
+              <label>Priority</label>
+              <select
+                value={priority}
+                onChange={e =>
+                  setPriority(e.target.value as Card['priority'])
+                }
+                className="select"
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+            </div>
+
+            <div>
+              <label>Assignee</label>
+              <select
+                value={assignee}
+                onChange={e => setAssignee(e.target.value)}
+                className="select"
+              >
+                <option value="">Unassigned</option>
+                {teamMembers.map(m => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            {comments.map(c => (
+              <div key={c.id} className="comment">
+                <strong>{c.author}</strong>
+                <p>{c.text}</p>
+                <span>{new Date(c.createdAt).toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+
+          <label>
+            Comment
+            <textarea
+              value={newComment}
+              onChange={e => setNewComment(e.target.value)}
+              className="textarea"
+            />
+          </label>
+
+          <div className="card-actions">
+            <button onClick={handleAddComment} className="button orange">
+              Post
+            </button>
+            <button onClick={save} className="button blue">
+              Save
+            </button>
+          </div>
         </div>
-        <textarea
-          className="w-full border p-2 mb-2"
-          placeholder="Add a comment..."
-          value={newComment}
-          onChange={e => setNewComment(e.target.value)}
-        />
-        <div className="flex justify-end gap-2">
-          <button onClick={handleAddComment} className="btn-secondary">Post</button>
-          <button onClick={save} className="btn-primary">Save</button>
-        </div>
-      </div>
+      )}
     </Modal>
   )
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -2500,16 +2500,60 @@ hr {
 }
 
 .card-modal {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  width: 600px;
-  transform: translate(-50%, -50%);
   background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 10px 50px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
   padding: 24px;
-  z-index: 1000;
+  width: 480px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.2);
+  font-family: 'Inter', sans-serif;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  font-size: 14px;
+}
+
+.card-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.button {
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.button.orange {
+  background: #FFA726;
+  color: #fff;
+}
+
+.button.blue {
+  background: #1D72F3;
+  color: #fff;
+}
+
+.card-links {
+  font-size: 0.875rem;
 }
 
 .comment {


### PR DESCRIPTION
## Summary
- restyle the Card edit modal container and add new UI classes
- restructure card modal fields with labels and metadata grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883fd83a72c8327a912b2f38683ff2c