### PR TITLE
Enable horizontal scroll for Kanban board

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import {
   DragDropContext,
   Droppable,
@@ -33,6 +33,7 @@ export default function InteractiveKanbanBoard({
     description || 'Organize tasks across lanes'
   )
   const [selected, setSelected] = useState<{ laneId: string; card: Card } | null>(null)
+  const autoScrollRightRef = useRef<HTMLDivElement | null>(null)
 
   const addLane = () => {
     const id = `lane-${Date.now()}`
@@ -119,6 +120,12 @@ export default function InteractiveKanbanBoard({
     )
   }
 
+  useEffect(() => {
+    if (autoScrollRightRef.current) {
+      autoScrollRightRef.current.scrollLeft = autoScrollRightRef.current.scrollWidth;
+    }
+  }, [lanes.length]);
+
   const handleDragEnd = (result: DropResult) => {
     const { source, destination, draggableId, type } = result
 
@@ -142,38 +149,40 @@ export default function InteractiveKanbanBoard({
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">
           {provided => (
-            <div
-              className="kanban-board"
-              ref={provided.innerRef}
-              {...provided.droppableProps}
-            >
-              {lanes.map((lane, i) => (
-                <Draggable key={lane.id} draggableId={lane.id} index={i}>
-                  {providedLane => (
-                    <div
-                      ref={providedLane.innerRef}
-                      {...providedLane.draggableProps}
-                      className="lane-wrapper"
-                    >
-                      <div {...providedLane.dragHandleProps} className="lane">
-                        <Lane
-                          lane={lane}
-                          onAddCard={addCard}
-                          onUpdateTitle={updateTitle}
-                          onUpdateCard={updateCard}
-                          onCardClick={(laneId, card) =>
-                            setSelected({ laneId, card })
-                          }
-                          onRemoveLane={removeLane}
-                        />
+            <div className="kanban-scroll-container" ref={autoScrollRightRef}>
+              <div
+                className="kanban-lane-wrapper"
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+              >
+                {lanes.map((lane, i) => (
+                  <Draggable key={lane.id} draggableId={lane.id} index={i}>
+                    {providedLane => (
+                      <div
+                        ref={providedLane.innerRef}
+                        {...providedLane.draggableProps}
+                        className="lane-wrapper"
+                      >
+                        <div {...providedLane.dragHandleProps} className="lane">
+                          <Lane
+                            lane={lane}
+                            onAddCard={addCard}
+                            onUpdateTitle={updateTitle}
+                            onUpdateCard={updateCard}
+                            onCardClick={(laneId, card) =>
+                              setSelected({ laneId, card })
+                            }
+                            onRemoveLane={removeLane}
+                          />
+                        </div>
                       </div>
-                    </div>
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-              <div className="lane add-lane" onClick={addLane}>
-                <button className="add-lane-button">+ Add Lane</button>
+                    )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+                <div className="lane add-lane" onClick={addLane}>
+                  <button className="add-lane-button">+ Add Lane</button>
+                </div>
               </div>
             </div>
           )}

--- a/src/global.scss
+++ b/src/global.scss
@@ -2378,6 +2378,23 @@ hr {
   margin: 0;
 }
 
+.kanban-scroll-container {
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: 100%;
+  height: calc(100vh - 150px);
+  padding: 16px;
+  scroll-behavior: smooth;
+}
+
+.kanban-lane-wrapper {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  min-width: max-content;
+  align-items: flex-start;
+}
+
 /* Kanban board layout */
 .kanban-board {
   display: flex;
@@ -2390,15 +2407,15 @@ hr {
 }
 
 .lane {
-  background: #ffffff;
-  border-radius: 8px;
-  border-top: 6px solid var(--color-primary);
   min-width: 280px;
-  margin-right: 20px;
-  padding: 16px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  max-width: 280px;
+  flex-shrink: 0;
+  background: #ffffff;
+  border-radius: 6px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.06);
   display: flex;
   flex-direction: column;
+  height: 100%;
   position: relative;
 }
 .lane:not(:last-child)::after {


### PR DESCRIPTION
## Summary
- scroll Kanban lanes horizontally
- auto scroll to the newest lane when one is added
- style the lane wrapper and scroll container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884000ae68883279d8addf46a9e6d4d