### PR TITLE
UI polish for Kanban board

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2383,7 +2383,7 @@ hr {
   overflow-y: hidden;
   width: 100%;
   height: calc(100vh - 150px);
-  padding: 16px;
+  padding: 0;
   scroll-behavior: smooth;
 }
 
@@ -2417,6 +2417,12 @@ hr {
   flex-direction: column;
   height: 100%;
   position: relative;
+}
+.lane-header-bar {
+  height: 5px;
+  width: 100%;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
 }
 .lane:not(:last-child)::after {
   content: '';


### PR DESCRIPTION
## Summary
- remove padding on kanban scroll container
- freeze Done column position and disable dragging
- add colorful header bars for each lane

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884017b43c483278d3dd9e9fbd0ab6a