### PR TITLE
Update Kanban header style

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -166,8 +166,16 @@ export default function InteractiveKanbanBoard({
   return (
     <div className="kanban-canvas">
       <div className="kanban-header">
-        <h1 className="kanban-title">{boardTitle}</h1>
-        <p className="kanban-description">{boardDescription}</p>
+        <div className="kanban-header-info">
+          <div className="kanban-icon" aria-hidden="true">🗂️</div>
+          <div>
+            <h1 className="kanban-title">{boardTitle}</h1>
+            <p className="kanban-description">{boardDescription}</p>
+          </div>
+        </div>
+        <div className="kanban-header-actions">
+          <button aria-label="Settings">⋯</button>
+        </div>
       </div>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">

--- a/src/KanbanBoardPage.tsx
+++ b/src/KanbanBoardPage.tsx
@@ -29,10 +29,18 @@ export default function KanbanBoardPage(): JSX.Element {
     <div className="dashboard-layout">
       <main className="main-area">
         <header className="kanban-header">
-          <h1>{boardData?.title || 'Kanban Board'}</h1>
-          {boardData?.description && (
-            <p className="description">{boardData.description}</p>
-          )}
+          <div className="kanban-header-info">
+            <div className="kanban-icon" aria-hidden="true">🗂️</div>
+            <div>
+              <h1 className="kanban-title">{boardData?.title || 'Kanban Board'}</h1>
+              {boardData?.description && (
+                <p className="kanban-description">{boardData.description}</p>
+              )}
+            </div>
+          </div>
+          <div className="kanban-header-actions">
+            <button aria-label="Settings">⋯</button>
+          </div>
         </header>
         <KanbanCanvas boardData={boardData} />
       </main>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2352,24 +2352,44 @@ hr {
 }
 
 /* New Kanban board styles */
-
 .kanban-header {
-  padding: 12px 24px;
-  background: #f9f9f9;
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  border-bottom: 1px solid #ddd;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 1.5rem;
+  height: 100px;
+  max-height: 100px;
+  background: #fffaf3;
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   position: sticky;
   top: 0;
   z-index: 10;
-  backdrop-filter: blur(6px);
+}
+
+.kanban-header-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.kanban-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 9999px;
+  background: #fff4e5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  color: #fb923c;
 }
 
 .kanban-title {
-  font-size: 1.4rem;
+  font-size: 1.25rem;
   font-weight: 600;
-  margin-bottom: 4px;
+  margin: 0;
 }
 
 .kanban-description {
@@ -2378,11 +2398,24 @@ hr {
   margin: 0;
 }
 
+.kanban-header-actions button {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  color: #6b7280;
+  cursor: pointer;
+}
+
+.kanban-header-actions button:hover {
+  color: #374151;
+}
+
+
 .kanban-scroll-container {
   overflow-x: auto;
   overflow-y: hidden;
   width: 100%;
-  height: calc(100vh - 150px);
+  height: calc(100vh - 100px);
   padding: 0;
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- slim down kanban header
- add icon/action areas and brand colors
- adjust kanban board layout sizing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68840899c4f88327bd83e2630c8d1e55