### PR TITLE
Simplify Kanban header

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -167,18 +167,18 @@ export default function InteractiveKanbanBoard({
 
   return (
     <div className="kanban-canvas">
-      <div className="kanban-header">
+      <header className="kanban-header">
         <div className="kanban-header-info">
-          <div className="kanban-icon" aria-hidden="true">🗂️</div>
+          <div className="kanban-icon" aria-hidden="true">📋</div>
           <div>
             <h1 className="kanban-title">{boardTitle}</h1>
             <p className="kanban-description">{boardDescription}</p>
           </div>
         </div>
         <div className="kanban-header-actions">
-          <button aria-label="Settings">⋯</button>
+          <button aria-label="Settings">⋮</button>
         </div>
-      </div>
+      </header>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">
           {provided => (

--- a/src/KanbanBoardPage.tsx
+++ b/src/KanbanBoardPage.tsx
@@ -28,20 +28,6 @@ export default function KanbanBoardPage(): JSX.Element {
   return (
     <div className="dashboard-layout">
       <main className="main-area">
-        <header className="kanban-header">
-          <div className="kanban-header-info">
-            <div className="kanban-icon" aria-hidden="true">🗂️</div>
-            <div>
-              <h1 className="kanban-title">{boardData?.title || 'Kanban Board'}</h1>
-              {boardData?.description && (
-                <p className="kanban-description">{boardData.description}</p>
-              )}
-            </div>
-          </div>
-          <div className="kanban-header-actions">
-            <button aria-label="Settings">⋯</button>
-          </div>
-        </header>
         <KanbanCanvas boardData={boardData} />
       </main>
     </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2358,11 +2358,11 @@ hr {
   justify-content: space-between;
   gap: 1rem;
   padding: 0 1.5rem;
-  height: 100px;
-  max-height: 100px;
-  background: #fffaf3;
-  border-bottom: 1px solid #e5e7eb;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  height: 80px;
+  max-height: 80px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -2415,7 +2415,7 @@ hr {
   overflow-x: auto;
   overflow-y: hidden;
   width: 100%;
-  height: calc(100vh - 100px);
+  height: calc(100vh - 80px);
   padding: 0 1rem;
   scroll-behavior: smooth;
   -ms-overflow-style: none;
@@ -2444,7 +2444,7 @@ hr {
   display: flex;
   gap: 20px;
   padding: 24px;
-  height: calc(100vh - 100px);
+  height: calc(100vh - 80px);
   background: linear-gradient(to bottom, #fff, #fafafa);
   overflow-x: auto;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- remove duplicate header from `KanbanBoardPage`
- convert Kanban header in `InteractiveKanbanBoard` to a single bar
- shrink header height to 80px and adjust scroll heights

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68840caae62883279c3c177081f303ef