### PR TITLE
Enhance kanban header UI

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -174,15 +174,15 @@ export default function InteractiveKanbanBoard({
   return (
     <div className="kanban-canvas">
       <header className="kanban-header">
-        <div className="kanban-header-info">
-          <div className="kanban-icon" aria-hidden="true">📋</div>
+        <div className="header-left">
+          <div className="kanban-icon" />
           <div>
             <h1 className="kanban-title">{boardTitle}</h1>
             <p className="kanban-description">{boardDescription}</p>
           </div>
         </div>
-        <div className="kanban-header-actions">
-          <button aria-label="Settings">⋮</button>
+        <div className="header-right">
+          <button className="settings-button" aria-label="Settings">⋯</button>
         </div>
       </header>
       <DragDropContext onDragEnd={handleDragEnd}>

--- a/KanbanCanvas.tsx
+++ b/KanbanCanvas.tsx
@@ -5,7 +5,7 @@ interface Props {
 }
 
 export default function KanbanCanvas({ boardData }: Props) {
-  const title = boardData?.title
-  const description = boardData?.description
+  const { title, description } =
+    boardData || { title: 'Kanban Board', description: '' }
   return <InteractiveKanbanBoard title={title} description={description} />
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -2354,51 +2354,48 @@ hr {
 /* New Kanban board styles */
 .kanban-header {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 0 1.5rem;
-  height: 80px;
-  max-height: 80px;
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  align-items: center;
+  height: 100px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 16px 24px;
+  border-bottom: 1px solid #eee;
+  margin-bottom: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+  backdrop-filter: blur(6px);
+  border-radius: 8px;
   position: sticky;
   top: 0;
   z-index: 10;
 }
 
-.kanban-header-info {
+.header-left {
   display: flex;
+  gap: 16px;
   align-items: center;
-  gap: 1rem;
 }
 
 .kanban-icon {
-  width: 40px;
-  height: 40px;
-  border-radius: 9999px;
-  background: #fff4e5;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.25rem;
-  color: #fb923c;
+  width: 48px;
+  height: 48px;
+  background: linear-gradient(to bottom right, #ffba08, #faa307);
+  border-radius: 12px;
+  box-shadow: 0 0 8px rgba(255, 186, 8, 0.4);
 }
 
 .kanban-title {
-  font-size: 1.25rem;
-  font-weight: 600;
   margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
 }
 
 .kanban-description {
-  font-size: 0.9rem;
-  color: #666;
   margin: 0;
+  font-size: 0.9rem;
+  color: #888;
 }
 
-.kanban-header-actions button {
+.header-right .settings-button {
   background: none;
   border: none;
   font-size: 1.25rem;
@@ -2406,7 +2403,7 @@ hr {
   cursor: pointer;
 }
 
-.kanban-header-actions button:hover {
+.header-right .settings-button:hover {
   color: #374151;
 }
 
@@ -2415,7 +2412,8 @@ hr {
   overflow-x: auto;
   overflow-y: hidden;
   width: 100%;
-  height: calc(100vh - 80px);
+  height: calc(100vh - 100px);
+  margin-top: 8px;
   padding: 0 1rem;
   scroll-behavior: smooth;
   -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- pull board info with sensible defaults
- modernize header markup with minimal height and new classes
- apply futuristic CSS styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68840fe67bf083279a2b298f3d836f0f