### PR TITLE
Improve kanban comments modal

### DIFF
--- a/CardModal.tsx
+++ b/CardModal.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
 import Modal from './modal'
-import { v4 as uuid } from 'uuid'
 
 export interface Comment {
   id: string
@@ -34,7 +33,6 @@ export default function CardModal({ card, onClose, onSave, currentUser }: Props)
   const [title, setTitle] = useState(card?.title || '')
   const [description, setDescription] = useState(card?.description || '')
   const [comments, setComments] = useState<Comment[]>(card?.comments || [])
-  const [newComment, setNewComment] = useState('')
   const [dueDate, setDueDate] = useState(card?.dueDate || '')
   const [priority, setPriority] = useState<Card['priority']>(card?.priority || 'low')
   const [status, setStatus] = useState<Card['status']>(card?.status || 'open')
@@ -76,17 +74,6 @@ export default function CardModal({ card, onClose, onSave, currentUser }: Props)
       .catch(() => {})
   }, [])
 
-  const handleAddComment = () => {
-    if (!newComment.trim()) return
-    const comment: Comment = {
-      id: uuid(),
-      text: newComment,
-      createdAt: new Date().toISOString(),
-      author: currentUser?.name || 'Anon'
-    }
-    setComments(prev => [...prev, comment])
-    setNewComment('')
-  }
 
   const sortedComments = useMemo(
     () => [...comments].sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
@@ -223,24 +210,12 @@ export default function CardModal({ card, onClose, onSave, currentUser }: Props)
               ))}
             </div>
 
-            <label>
-              Comment
-              <textarea
-                value={newComment}
-                onChange={e => setNewComment(e.target.value)}
-                className="textarea-styled"
-              />
-            </label>
-
-              <div className="card-actions">
-                <button onClick={handleAddComment} className="btn-post">
-                  Post
-                </button>
-                <button onClick={onClose} className="btn-cancel">Cancel</button>
-                <button onClick={save} className="btn-save" disabled={!isDirty}>
-                  Save
-                </button>
-              </div>
+            <div className="card-actions">
+              <button onClick={onClose} className="btn-cancel">Cancel</button>
+              <button onClick={save} className="btn-save" disabled={!isDirty}>
+                Save
+              </button>
+            </div>
           </section>
         </div>
       )}

--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -29,29 +29,35 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
 
   return (
     <Modal isOpen={!!card} onClose={onClose} ariaLabel={`Comments for ${card.title}`}>
-      <div className="modal-container max-w-xl p-6 mx-auto bg-white shadow-lg rounded">
-        <h2 className="mb-4 text-lg font-semibold">Comments for "{card.title}"</h2>
-        <div className="space-y-4 max-h-60 overflow-y-auto mb-4">
-          {(card.comments || []).map(c => (
-            <div key={c.id} className="p-2 border rounded">
-              <div className="text-sm font-semibold">{c.author}</div>
-              <div className="text-sm">{c.text}</div>
-              <div className="text-xs text-gray-500">
-                {new Date(c.createdAt).toLocaleString()}
+      <div className="comment-modal">
+        <h2 className="mb-2 text-lg font-semibold">Comments for "{card.title}"</h2>
+        <div className="comment-list">
+          {(card.comments || []).map((c, idx) => {
+            const isMine = c.author === currentUser?.name
+            const name = isMine ? 'Me' : c.author || 'Anon'
+            return (
+              <div key={c.id} className="comment">
+                <div className="text-sm font-semibold">{name}</div>
+                <div className="text-sm">{c.text}</div>
+                <div className="text-xs text-gray-500">
+                  {new Date(c.createdAt).toLocaleString()}
+                </div>
               </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
-        <textarea
-          value={text}
-          onChange={e => setText(e.target.value)}
-          className="textarea-styled w-full mb-4"
-        />
-        <div className="flex justify-end space-x-2">
-          <button onClick={onClose} className="btn-cancel">Cancel</button>
-          <button onClick={add} className="btn-post" disabled={!text.trim()}>
-            Post Comment
-          </button>
+        <div style={{ marginTop: '1rem' }}>
+          <textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            className="textarea-styled w-full"
+          />
+          <div style={{ textAlign: 'right', marginTop: '0.5rem' }}>
+            <button onClick={onClose} className="btn-secondary">Cancel</button>
+            <button onClick={add} className="btn-primary" disabled={!text.trim()}>
+              Post Comment
+            </button>
+          </div>
         </div>
       </div>
     </Modal>

--- a/src/global.scss
+++ b/src/global.scss
@@ -3035,3 +3035,54 @@ hr {
   color: var(--color-text-muted);
   margin-bottom: 0.25rem;
 }
+
+/* Comment modal styles */
+.comment-modal {
+  background: #fff;
+  width: 600px;
+  max-width: 90%;
+  height: 75vh;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+}
+
+.comment-list {
+  max-height: 55vh;
+  overflow-y: auto;
+  padding: 0.5rem 1rem;
+}
+
+.comment-list .comment:nth-child(even) {
+  background-color: #f8f8f8;
+}
+
+.comment-list .comment:nth-child(odd) {
+  background-color: #ffffff;
+}
+
+.comment {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.comment-modal .btn-primary {
+  background: #ff6a00;
+  border: none;
+  padding: 8px 16px;
+  color: #fff;
+  border-radius: 6px;
+  font-weight: 600;
+}
+
+.comment-modal .btn-secondary {
+  background: #e0e0e0;
+  border: none;
+  padding: 8px 16px;
+  margin-right: 8px;
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Summary
- polish the kanban comments modal
- style comment modal with scrollable list and modern buttons
- show `Me` label for your own comments
- remove the comment post field from Card edit modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688411908b48832793da6c4c1fe5df39