### PR TITLE
Improve Kanban header look

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -175,7 +175,7 @@ export default function InteractiveKanbanBoard({
     <div className="kanban-canvas">
       <header className="kanban-header">
         <div className="header-left">
-          <div className="kanban-icon" />
+          <div className="kanban-icon" aria-hidden="true">🗂️</div>
           <div>
             <h1 className="kanban-title">{boardTitle}</h1>
             <p className="kanban-description">{boardDescription}</p>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2356,14 +2356,14 @@ hr {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 100px;
-  background: rgba(255, 255, 255, 0.9);
-  padding: 16px 24px;
-  border-bottom: 1px solid #eee;
-  margin-bottom: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
-  backdrop-filter: blur(6px);
-  border-radius: 8px;
+  height: 80px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.2));
+  padding: 12px 24px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  margin-bottom: 16px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
+  backdrop-filter: blur(8px);
+  border-radius: 12px;
   position: sticky;
   top: 0;
   z-index: 10;
@@ -2378,9 +2378,14 @@ hr {
 .kanban-icon {
   width: 48px;
   height: 48px;
-  background: linear-gradient(to bottom right, #ffba08, #faa307);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  background: linear-gradient(135deg, #4facfe, #00f2fe);
   border-radius: 12px;
-  box-shadow: 0 0 8px rgba(255, 186, 8, 0.4);
+  box-shadow: 0 0 10px rgba(79, 172, 254, 0.5);
+  color: #fff;
 }
 
 .kanban-title {
@@ -2412,8 +2417,8 @@ hr {
   overflow-x: auto;
   overflow-y: hidden;
   width: 100%;
-  height: calc(100vh - 100px);
-  margin-top: 8px;
+  height: calc(100vh - 80px);
+  margin-top: 16px;
   padding: 0 1rem;
   scroll-behavior: smooth;
   -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- add icon to Kanban header and style it
- adjust Kanban header gradient, spacing and shadow for a glassy look
- tweak scroll container height to match shorter header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884128f1e848327a447d5de1e9be28e