### PR TITLE
Fix kanban board scrolling

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -188,9 +188,9 @@ export default function InteractiveKanbanBoard({
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">
           {provided => (
-            <div className="kanban-scroll-container" ref={autoScrollRightRef}>
+            <div className="scroll-container" ref={autoScrollRightRef}>
               <div
-                className="kanban-lane-wrapper"
+                className="kanban-board"
                 ref={provided.innerRef}
                 {...provided.droppableProps}
               >
@@ -201,7 +201,6 @@ export default function InteractiveKanbanBoard({
                         ref={providedLane.innerRef}
                         {...providedLane.draggableProps}
                         className="lane-wrapper"
-                        style={{ minWidth: '250px', maxWidth: '250px' }}
                       >
                         <div {...providedLane.dragHandleProps} className="lane">
                           <Lane
@@ -224,7 +223,7 @@ export default function InteractiveKanbanBoard({
                   </Draggable>
                 ))}
                 {provided.placeholder}
-                <div className="lane add-lane" onClick={addLane}>
+                <div className="lane kanban-lane add-lane" onClick={addLane}>
                   <button className="add-lane-button">+ Add Lane</button>
                 </div>
               </div>
@@ -288,7 +287,9 @@ function Lane({
     <Droppable droppableId={lane.id} type="CARD">
       {provided => (
         <div
-          className={`lane ${lane.title.toLowerCase() === 'done' ? 'done' : ''}`}
+          className={`lane kanban-lane ${
+            lane.title.toLowerCase() === 'done' ? 'done' : ''
+          }`}
           ref={provided.innerRef}
           {...provided.droppableProps}
         >

--- a/KanbanLane.tsx
+++ b/KanbanLane.tsx
@@ -6,7 +6,7 @@ export interface Card {
 
 export default function KanbanLane({ title, cards = [] }: { title: string; cards?: Card[] }) {
   return (
-    <div className="lane">
+    <div className="lane kanban-lane">
       <h3 className="lane-title">{title}</h3>
       {cards.map((card, i) => (
         <div className="card" key={i}>

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -86,8 +86,9 @@ export default function Kanban(): JSX.Element {
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
             <p className="section-subtext">Kanban boards are perfect for executing your vision across a team, showing how mind map tasks move from to-do to done.</p>
           </div>
-          <div className="kanban-board">
-            {lanes.map((lane, laneIndex) => {
+          <div className="scroll-container">
+            <div className="kanban-board">
+              {lanes.map((lane, laneIndex) => {
               const laneVisible = step >= laneIndex
               return (
                 <motion.div
@@ -118,6 +119,7 @@ export default function Kanban(): JSX.Element {
                 </motion.div>
               )
             })}
+            </div>
           </div>
           <div className="kanban-upgrade text-center">
             <Link to="/purchase" className="btn">

--- a/src/global.scss
+++ b/src/global.scss
@@ -53,6 +53,12 @@
   box-sizing: border-box;
 }
 
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 html {
   font-family: var(--font-sans);
   font-size: 100%;
@@ -62,7 +68,6 @@ html {
 }
 
 body {
-  min-height: 100vh;
   font-family: 'Inter', sans-serif;
   background-color: var(--color-bg);
   color: var(--color-text);
@@ -70,7 +75,6 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scrollbar-width: thin;
-  overflow-x: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -1022,11 +1026,10 @@ hr {
 .kanban-board {
   display: flex;
   flex-direction: row;
-  gap: 16px;
-  padding: 24px;
-  height: calc(100vh - 80px);
-  overflow-x: auto;
-  background: linear-gradient(180deg, #e6ebf1 0%, #f9fafc 100%);
+  align-items: flex-start;
+  gap: 1rem;
+  min-width: max-content;
+  padding-bottom: 2rem;
 }
 
 .kanban-lane {
@@ -1036,6 +1039,9 @@ hr {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
+  flex-shrink: 0;
+  width: 300px;
+  max-height: 100%;
 }
 
 @media (max-width: 640px) {
@@ -2296,7 +2302,8 @@ hr {
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 1rem;
-  min-width: 250px;
+  width: 300px;
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -2413,49 +2420,37 @@ hr {
 }
 
 
-.kanban-scroll-container {
-  overflow-x: auto;
-  overflow-y: hidden;
+
+.scroll-container {
   width: 100%;
-  height: calc(100vh - 80px);
-  margin-top: 16px;
+  height: calc(100vh - 130px);
+  overflow-x: auto;
+  overflow-y: auto;
   padding: 0 1rem;
-  scroll-behavior: smooth;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}
-.kanban-scroll-container::-webkit-scrollbar {
-  display: none;
 }
 
-.kanban-lane-wrapper {
-  display: flex;
-  flex-direction: row;
-  gap: 16px;
-  min-width: max-content;
-  align-items: flex-start;
-  flex-wrap: nowrap;
-}
-.lane-wrapper {
-  min-width: 250px;
-  max-width: 250px;
-  margin-right: 1rem;
+.scroll-container::-webkit-scrollbar {
+  height: 6px;
 }
 
-/* Kanban board layout */
 .kanban-board {
   display: flex;
-  gap: 20px;
-  padding: 24px;
-  height: calc(100vh - 80px);
-  background: linear-gradient(to bottom, #fff, #fafafa);
-  overflow-x: auto;
+  flex-direction: row;
   align-items: flex-start;
+  gap: 1rem;
+  min-width: max-content;
+  padding-bottom: 2rem;
+}
+
+.kanban-lane {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 300px;
+  max-height: 100%;
 }
 
 .lane {
-  min-width: 250px;
-  max-width: 250px;
   flex-shrink: 0;
   background: #ffffff;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- enable scrolling by wrapping board in `scroll-container`
- style lanes to allow both axis scrolling
- enforce 100% height and hidden overflow on `html`/`body`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688413f35b54832794ada3b37a2118d6