### PR TITLE
Improve comment modal UI

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -3038,51 +3038,82 @@ hr {
 
 /* Comment modal styles */
 .comment-modal {
-  background: #fff;
+  position: relative;
   width: 600px;
-  max-width: 90%;
   height: 75vh;
-  border-radius: 12px;
+  background: #fff;
+  border-radius: 16px;
   padding: 1.5rem;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
 }
 
-.comment-list {
-  max-height: 55vh;
+.comment-feed {
+  flex: 1;
   overflow-y: auto;
+  padding-right: 8px;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.comment-bubble {
+  background-color: #f5f5f5;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  max-width: 80%;
+  position: relative;
+  animation: fade-item 0.3s forwards;
+}
+
+.comment-bubble.me {
+  align-self: flex-end;
+  background-color: #e6f7ff;
+}
+
+.comment-meta {
+  font-size: 0.8rem;
+  color: #888;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 4px;
+}
+
+.comment-text {
+  font-size: 0.95rem;
+}
+
+.comment-input-bar {
+  display: flex;
+  gap: 0.5rem;
+  border-top: 1px solid #eee;
+  padding-top: 0.75rem;
+  align-items: center;
+}
+
+.comment-input-bar textarea {
+  flex: 1;
+  resize: none;
+  height: 2.5rem;
+  padding: 0.5rem;
+  font-size: 0.95rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.send-button {
+  background-color: #ff9d33;
+  border: none;
+  color: white;
   padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: bold;
 }
 
-.comment-list .comment:nth-child(even) {
-  background-color: #f8f8f8;
-}
-
-.comment-list .comment:nth-child(odd) {
-  background-color: #ffffff;
-}
-
-.comment {
-  padding: 0.5rem 0.75rem;
-  border-radius: 6px;
-  margin-bottom: 0.5rem;
-  font-size: 14px;
-  line-height: 1.4;
-}
-
-.comment-modal .btn-primary {
-  background: #ff6a00;
-  border: none;
-  padding: 8px 16px;
-  color: #fff;
-  border-radius: 6px;
+.mention {
+  color: var(--color-primary);
   font-weight: 600;
-}
-
-.comment-modal .btn-secondary {
-  background: #e0e0e0;
-  border: none;
-  padding: 8px 16px;
-  margin-right: 8px;
-  border-radius: 6px;
 }


### PR DESCRIPTION
## Summary
- convert comment modal to a chat-like layout
- add mention highlighting and enter-to-send behavior
- style comments as bubbles with fixed input bar

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841560d04483279772894f4efccaba