### PR TITLE
Add list_id to TodoInput

### DIFF
--- a/netlify/functions/todoid.ts
+++ b/netlify/functions/todoid.ts
@@ -9,6 +9,7 @@ type TodoInput = {
   description?: string | null
   completed?: boolean
   assignee_id?: string | null
+  list_id?: string | null
 }
 
 const updateTodoSchema = z


### PR DESCRIPTION
## Summary
- include optional `list_id` in `TodoInput` type for Netlify function `todoid`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68842093f5408327954d6ded512dc920