### PR TITLE
Implement todo list_id field

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -12,14 +12,14 @@ export interface TodoCanvasProps {
   initialTodos?: TodoItem[]
   nodeId?: string
   kanbanId?: string
-  listId?: string
+  list_id?: string
 }
 
 export default function TodoCanvas({
   initialTodos = [],
   nodeId,
   kanbanId,
-  listId,
+  list_id,
 }: TodoCanvasProps): JSX.Element {
   const [todos, setTodos] = useState<TodoItem[]>(initialTodos)
   const [adding, setAdding] = useState(initialTodos.length === 0)
@@ -36,7 +36,7 @@ export default function TodoCanvas({
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, description: '', listId, nodeId }),
+        body: JSON.stringify({ title, description: '', list_id, nodeId }),
       })
       if (!res.ok) throw new Error('Failed to save todo')
       const created: TodoItem = await res.json()

--- a/netlify/functions/todo-lists.ts
+++ b/netlify/functions/todo-lists.ts
@@ -20,7 +20,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
     if (event.httpMethod === 'GET') {
       const res = await client.query(
         `SELECT l.id, l.title, l.created_at, l.updated_at,
-                COALESCE(jsonb_agg(jsonb_build_object('id', t.id, 'title', t.title, 'completed', t.completed)) FILTER (WHERE t.id IS NOT NULL), '[]') AS todos
+                COALESCE(jsonb_agg(jsonb_build_object('id', t.id, 'title', t.title, 'description', t.description, 'completed', t.completed)) FILTER (WHERE t.id IS NOT NULL), '[]') AS todos
            FROM todo_lists l
            LEFT JOIN todos t ON t.list_id = l.id
           WHERE l.user_id = $1


### PR DESCRIPTION
## Summary
- normalize API to use `list_id` consistently
- return todo descriptions in todo-lists response
- update TodoCanvas to send `list_id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884240a09e083279248e1bff565d30b