### PR TITLE
Implement Kanban boards API & schema

### DIFF
--- a/getAuthToken.ts
+++ b/getAuthToken.ts
@@ -1,0 +1,3 @@
+export function getAuthToken(): string {
+  return typeof localStorage !== 'undefined' ? localStorage.getItem('authToken') || '' : ''
+}

--- a/migrations/028_create_kanban_columns_tasks.sql
+++ b/migrations/028_create_kanban_columns_tasks.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS kanban_columns (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  board_id UUID NOT NULL REFERENCES kanban_boards(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS kanban_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  column_id UUID NOT NULL REFERENCES kanban_columns(id) ON DELETE CASCADE,
+  board_id UUID NOT NULL REFERENCES kanban_boards(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  position INTEGER NOT NULL DEFAULT 0,
+  assignee_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  due_date TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_columns_board_id ON kanban_columns(board_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_tasks_column_id ON kanban_tasks(column_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_tasks_board_id ON kanban_tasks(board_id);

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   # Install dev dependencies so the vite build tool is available
-  command = "npm install --include=dev && npm run migrate && npm run build"
+  command = "npm install --include=dev && npm run migrate && npm run compile:functions && npm run build"
   publish = "dist"
   functions = "netlify/functions"
 

--- a/netlify/functions/kanban-boards.ts
+++ b/netlify/functions/kanban-boards.ts
@@ -1,0 +1,61 @@
+import { getClient } from './db-client.js'
+import { extractToken, verifySession } from './auth.js'
+
+export const handler = async (event: any) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+  }
+
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers, body: '' }
+
+  const token = extractToken(event)
+  if (!token) return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+
+  const session = verifySession(token)
+  const userId = (session as any)?.userId
+  if (!userId) return { statusCode: 401, headers, body: JSON.stringify({ error: 'Invalid token' }) }
+
+  const client = await getClient()
+
+  try {
+    if (event.httpMethod === 'POST') {
+      const data = JSON.parse(event.body || '{}')
+      const title = data.title?.trim()
+      const description = data.description?.trim() || null
+      if (!title) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Title required' }) }
+
+      const res = await client.query(
+        `
+        INSERT INTO kanban_boards (user_id, title, description)
+        VALUES ($1, $2, $3)
+        RETURNING id, title, description, created_at
+      `,
+        [userId, title, description],
+      )
+
+      const boardId = res.rows[0].id
+      const defaultCols = ['New', 'In-Progress', 'Reviewing', 'Done']
+      for (let i = 0; i < defaultCols.length; i++) {
+        await client.query(
+          `
+          INSERT INTO kanban_columns (board_id, title, position)
+          VALUES ($1, $2, $3)
+        `,
+          [boardId, defaultCols[i], i],
+        )
+      }
+
+      return { statusCode: 201, headers, body: JSON.stringify(res.rows[0]) }
+    }
+
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) }
+  } catch (err) {
+    console.error('[kanban-boards] error', err)
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Server error' }) }
+  } finally {
+    client.release()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "deploy-seed": "curl -s https://mindxdo.netlify.app/api/seed-admin || true",
     "build": "vite build",
+    "compile:functions": "tsc -p tsconfig.json",
     "preview": "vite preview",
     "compile:migrations": "tsc -p tsconfig.migrations.json",
     "migrate": "npm run compile:migrations && node dist/migrationrunner.js",


### PR DESCRIPTION
## Summary
- create migration for kanban columns and tasks
- add serverless function `kanban-boards`
- update board creation logic and modal
- add helper to fetch auth token
- compile functions in Netlify build

## Testing
- `npm test`
- `npm run compile:functions` *(fails: tsc not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688429ed06a483279ace3a254a629977