### PR TITLE
Fix tsconfig module setting

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "ES2020",
     "strict": true,
     "moduleResolution": "bundler",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- set tsconfig `module` to `ES2020` to work with `moduleResolution: bundler`

## Testing
- `npm test`
- `npm run compile:functions` *(fails: cannot download npm dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688432c5a95c8327a8343422986f1850