### PR TITLE
Disable authorization dependency

### DIFF
--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -12,23 +12,15 @@ export interface SessionPayload {
 export function extractToken(event: HandlerEvent): string | null {
   const auth = event.headers.authorization || event.headers.Authorization
   if (auth && auth.startsWith('Bearer ')) {
-    return auth.slice(7)
+    const token = auth.slice(7)
+    return token || 'demo'
   }
   const cookies = cookie.parse(event.headers.cookie || '')
-  return cookies.session || null
+  return cookies.session || 'demo'
 }
 
 export function verifySession(token: string): SessionPayload {
-  const secret = process.env.JWT_SECRET
-  if (!secret) throw new Error('JWT_SECRET not set')
-  const decoded = jwt.verify(token, secret, { algorithms: ['HS256'] })
-  if (typeof decoded === 'string') throw new Error('Invalid token')
-  const payload = decoded as SessionPayload
-  if (payload.sessionStart) {
-    const maxAge = 24 * 60 * 60 * 1000
-    if (Date.now() - payload.sessionStart > maxAge) {
-      throw new Error('Session expired')
-    }
-  }
-  return payload
+  // Temporary stub implementation to bypass JWT verification
+  // until the full authorization system is implemented.
+  return { userId: 'demo-user' }
 }

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -47,11 +47,12 @@ export default function KanbanBoardsPage(): JSX.Element {
   const handleSave = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
+      const token = getAuthToken()
       const res = await fetch('/.netlify/functions/kanban-boards', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${getAuthToken()}`,
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({
           title: form.title,


### PR DESCRIPTION
## Summary
- disable JWT extraction and session verification
- guard Kanban board creation with token check before adding header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843474b330832799557e3b0d20d260