### PR TITLE
Add cookie module declaration

### DIFF
--- a/cookie.d.ts
+++ b/cookie.d.ts
@@ -1,0 +1,1 @@
+declare module 'cookie';


### PR DESCRIPTION
## Summary
- add `cookie.d.ts` so TypeScript recognizes the `cookie` module when we can't install the `@types` package

## Testing
- `npm install --save-dev @types/cookie` *(fails: Forbidden - registry access blocked)*
- `npm run build` *(fails: `vite` not found since dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_6884357e35f483278902006ae60703c3