### PR TITLE
Fix compile error for cookie module

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,8 @@
     "esModuleInterop": true,
     "outDir": "dist"
   },
-  "include": ["netlify/functions"]
+  "include": [
+    "netlify/functions",
+    "cookie.d.ts"
+  ]
 }

--- a/tsconfig.migrations.json
+++ b/tsconfig.migrations.json
@@ -9,5 +9,9 @@
     "rootDir": ".",
     "types": ["node", "@netlify/functions"]
   },
-  "include": ["migrationrunner.ts", "netlify/functions/**/*.ts"]
+  "include": [
+    "migrationrunner.ts",
+    "netlify/functions/**/*.ts",
+    "cookie.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- include `cookie.d.ts` in TypeScript configuration

## Testing
- `npm run compile:functions` *(fails: Cannot find module '@netlify/functions' due to missing packages)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884367cc79c8327b8e1c3a830d11e8a