### PR TITLE
Add smooth scroll and white background for marketing pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { useEffect } from 'react'
 import Homepage from '../homepage'
 import AboutPage from '../about'
 import MindmapDemo from '../mindmapdemo'
@@ -81,6 +82,14 @@ function AppLayout() {
   const isDashboard = dashboardPaths.some(path =>
     location.pathname === path || location.pathname.startsWith(path + '/')
   )
+
+  useEffect(() => {
+    if (isDashboard) {
+      document.body.classList.remove('marketing')
+    } else {
+      document.body.classList.add('marketing')
+    }
+  }, [isDashboard])
 
   return isDashboard ? (
     <div className="app-layout">

--- a/src/ScrollToTop.tsx
+++ b/src/ScrollToTop.tsx
@@ -4,7 +4,7 @@ import { useLocation } from 'react-router-dom'
 export default function ScrollToTop(): JSX.Element {
   const { pathname } = useLocation()
   useEffect(() => {
-    window.scrollTo(0, 0)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [pathname])
   return null
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -78,6 +78,10 @@ body {
   scrollbar-width: thin;
 }
 
+body.marketing {
+  --color-bg: #ffffff;
+}
+
 h1, h2, h3, h4, h5, h6 {
   color: var(--color-text);
   line-height: 1.25;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -50,6 +50,7 @@ const Header = (): JSX.Element => {
     setProfileMenuOpen(false)
     setMenuOpen(false)
     navigate(route)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- animate scrolling back to the top on navigation
- change marketing menu selection to trigger smooth scroll
- set white background for marketing pages
- toggle marketing styles based on route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843a53b1f48327a9c66f15c137bb61