### PR TITLE
Fix auth implementation

### DIFF
--- a/authHeaders.ts
+++ b/authHeaders.ts
@@ -1,7 +1,5 @@
 export function authHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
   return {
     'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
   };
 }

--- a/getAuthToken.ts
+++ b/getAuthToken.ts
@@ -1,3 +1,0 @@
-export function getAuthToken(): string {
-  return typeof localStorage !== 'undefined' ? localStorage.getItem('authToken') || '' : ''
-}

--- a/login.tsx
+++ b/login.tsx
@@ -98,11 +98,7 @@ const LoginPage = (): JSX.Element => {
           throw new Error('Failed to parse server response')
         }
       })
-      .then(data => {
-        const { token } = data as { token?: string }
-        if (token) {
-          localStorage.setItem('token', token)
-        }
+      .then(() => {
         navigate('/dashboard')
       })
       .catch(err => {

--- a/migrations/029_create_sessions_table.sql
+++ b/migrations/029_create_sessions_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import MiniMap from './MiniMap'
 import type { NodeData, EdgeData } from './mindmapTypes'
-import { getAuthToken } from './getAuthToken'
+import { authFetch } from './authFetch'
 
 const DOT_SPACING = 50
 const GRID_SIZE = 500
@@ -143,15 +143,11 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         mindmapId,
       }
 
-      const token = getAuthToken()
-
-      fetch('/.netlify/functions/nodes', {
+      authFetch('/.netlify/functions/nodes', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
-        credentials: 'include',
         body: JSON.stringify(newNode),
       })
         .then(async res => {

--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -13,14 +13,12 @@ export function extractToken(event: HandlerEvent): string | null {
   const auth = event.headers.authorization || event.headers.Authorization
   if (auth && auth.startsWith('Bearer ')) {
     const token = auth.slice(7)
-    return token || 'demo'
+    return token || null
   }
   const cookies = cookie.parse(event.headers.cookie || '')
-  return cookies.session || 'demo'
+  return cookies.token || null
 }
 
 export function verifySession(token: string): SessionPayload {
-  // Temporary stub implementation to bypass JWT verification
-  // until the full authorization system is implemented.
-  return { userId: '11111111-1111-1111-1111-111111111111' }
+  return jwt.verify(token, process.env.JWT_SECRET!) as SessionPayload
 }

--- a/netlify/functions/login.ts
+++ b/netlify/functions/login.ts
@@ -156,19 +156,16 @@ export const handler = async (
     const token = jwt.sign(
       { userId: user.id, sessionStart: Date.now() },
       JWT_SECRET,
-      { expiresIn: '1h' }
+      { expiresIn: '7d' }
     )
 
     const cookieParts = [
-      `session=${token}`,
+      `token=${token}`,
       'HttpOnly',
       'Path=/',
-      'SameSite=Lax'
+      'Secure',
+      'Max-Age=604800'
     ]
-
-    if (process.env.NODE_ENV === 'production') {
-      cookieParts.push('Secure')
-    }
 
     console.info(`Login successful for ${email} from ${ip}`)
     return {

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -99,11 +99,18 @@ export const handler = async (
     const token = jwt.sign(
       { userId: user.id },
       JWT_SECRET!,
-      { expiresIn: '1h' }
+      { expiresIn: '7d' }
     )
+    const cookieParts = [
+      `token=${token}`,
+      'HttpOnly',
+      'Path=/',
+      'Secure',
+      'Max-Age=604800'
+    ]
     return {
       statusCode: 201,
-      headers: corsHeaders,
+      headers: { ...corsHeaders, 'Set-Cookie': cookieParts.join('; ') },
       body: JSON.stringify({ success: true, user, token }),
     }
   } catch (error) {

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, FormEvent } from 'react'
 import { authFetch } from '../authFetch'
 import { authHeaders } from '../authHeaders'
-import { getAuthToken } from '../getAuthToken'
 import { useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
@@ -47,13 +46,9 @@ export default function KanbanBoardsPage(): JSX.Element {
   const handleSave = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
     try {
-      const token = getAuthToken()
-      const res = await fetch('/.netlify/functions/kanban-boards', {
+      const res = await authFetch('/.netlify/functions/kanban-boards', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           title: form.title,
           description: form.description,

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -24,11 +24,7 @@ const LoginPage = () => {
         const data = await res.json().catch(() => ({}))
         throw new Error(data.error || 'Login failed')
       }
-      const data = await res.json().catch(() => ({}))
-      const token = (data as { token?: string }).token
-      if (token) {
-        localStorage.setItem('token', token)
-      }
+      await res.json().catch(() => ({}))
       navigate('/dashboard')
     } catch (err: any) {
       setError(err?.message || 'An unexpected error occurred')


### PR DESCRIPTION
## Summary
- implement actual JWT session verification
- generate tokens for a week and set secure cookie
- update registration to send cookie
- drop local storage token handling
- add sessions table migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843cb042cc8327b5715739a81f50c8