### PR TITLE
Ensure marketing pages scroll to top before navigation

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -49,8 +49,9 @@ const Header = (): JSX.Element => {
   const handleNavSelect = (route: string): void => {
     setProfileMenuOpen(false)
     setMenuOpen(false)
-    navigate(route)
+    // Scroll to the top before navigating so the new page loads from the top
     window.scrollTo({ top: 0, behavior: 'smooth' })
+    navigate(route)
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update marketing header navigation to scroll to the top before route change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688442513c8c8327b3f18356a0ae33d9