### PR TITLE
Fix nav scroll check for base paths

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -52,7 +52,9 @@ const Header = (): JSX.Element => {
     // Always scroll to the top when a navigation item is selected
     window.scrollTo({ top: 0, behavior: 'smooth' })
     // Only navigate if the destination route is different from the current one
-    if (location.pathname !== route) {
+    const basePath = import.meta.env.BASE_URL || '/'
+    const currentRoute = location.pathname.replace(basePath, '/')
+    if (currentRoute !== route) {
       navigate(route)
     }
   }


### PR DESCRIPTION
## Summary
- account for router `basename` when comparing current path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68844d3bc31c8327aa7771ec75aba0cb