### PR TITLE
Fix todo delete endpoint and list removal

### DIFF
--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -116,7 +116,7 @@ export default function TodosPage(): JSX.Element {
   const handleDelete = async (id: string): Promise<void> => {
     if (!confirm('Delete this todo?')) return
     try {
-      const res = await fetch(`/.netlify/functions/todos/${id}`, {
+      const res = await fetch(`/.netlify/functions/todoid/${id}`, {
         method: 'DELETE',
         credentials: 'include',
       })

--- a/tododashboard.tsx
+++ b/tododashboard.tsx
@@ -46,6 +46,17 @@ export default function TodoDashboard(): JSX.Element {
     setNewTitle('')
   }
 
+  const handleDeleteList = async (id: string) => {
+    if (!confirm('Delete this list and all todos?')) return
+    const res = await fetch(`/.netlify/functions/todo-lists?id=${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    })
+    if (res.ok) {
+      setLists(prev => prev.filter(l => l.id !== id))
+    }
+  }
+
   return (
     <div className="todo-dashboard relative overflow-hidden">
       <MindmapArm side="left" />
@@ -61,7 +72,14 @@ export default function TodoDashboard(): JSX.Element {
         <div className="todo-lists-grid">
           {lists.map(list => (
             <div key={list.id || 'unassigned'} className="todo-card">
-              <h3>{list.title}</h3>
+              <div className="card-header">
+                <h3>{list.title}</h3>
+                {list.id && (
+                  <button className="delete-btn" onClick={() => handleDeleteList(list.id!)}>
+                    Delete
+                  </button>
+                )}
+              </div>
               <ul className="todo-list">
                 {list.todos.map(t => (
                   <li key={t.id}>{t.title}</li>


### PR DESCRIPTION
## Summary
- point `/todos` delete button at correct `todoid` function
- allow deleting entire todo lists via `todo-lists` function
- add delete button to todo list dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688450fec7a88327b3dcd5919d1208b2