### PR TITLE
Fix scroll-to-top when reselecting active nav link

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -3,6 +3,9 @@ import { Link, NavLink, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from './useAuth'
 import { Drawer } from '../drawer'
 
+const normalizePath = (path: string): string =>
+  path.replace(/\/+$/, '') || '/'
+
 export interface NavItem {
   label: string
   route: string
@@ -50,10 +53,13 @@ const Header = (): JSX.Element => {
     setProfileMenuOpen(false)
     setMenuOpen(false)
 
-    if (location.pathname !== route) {
+    const currentPath = normalizePath(location.pathname)
+    const targetPath = normalizePath(route)
+
+    if (currentPath !== targetPath) {
       navigate(route)
     } else {
-      // If already on the target page, manually scroll to top
+      navigate(route, { replace: true })
       window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }


### PR DESCRIPTION
## Summary
- ensure navigation triggers when clicking the current route
- normalize paths and force replace navigation when path matches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688459d3472483279b854e37985b6a06