### PR TITLE
Fix todo canvas list logic

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -30,6 +30,20 @@ export default function TodoCanvas({
     if (adding) inputRef.current?.focus()
   }, [adding])
 
+  useEffect(() => {
+    if (!list_id) return
+    fetch(`/.netlify/functions/todos?list_id=${encodeURIComponent(list_id)}`, {
+      credentials: 'include',
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (Array.isArray(data)) setTodos(data)
+      })
+      .catch(err => {
+        console.error('Failed to load todos', err)
+      })
+  }, [list_id])
+
   const handleCreateTodo = async (title: string) => {
     try {
       const res = await fetch('/.netlify/functions/todos', {

--- a/src/TodosCanvasPage.tsx
+++ b/src/TodosCanvasPage.tsx
@@ -30,7 +30,7 @@ export default function TodosCanvasPage(): JSX.Element {
         {error ? (
           <p className="error">{error}</p>
         ) : (
-          <TodoCanvas initialTodos={todo ? [todo] : []} />
+          <TodoCanvas initialTodos={todo ? [todo] : []} list_id={id} />
         )}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- pass `list_id` from route to `TodoCanvas`
- load todos for a given `list_id` in `TodoCanvas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884609b057083278ed35bc42cc9a9ac