### PR TITLE
Add smooth scroll when clicking About

### DIFF
--- a/src/header.tsx
+++ b/src/header.tsx
@@ -55,11 +55,27 @@ const Header = (): JSX.Element => {
 
     if (location.pathname !== route) {
       navigate(route)
-    } else {
-      // If already on the target page, manually scroll to top
+    }
+
+    // Scroll to the top when the About link (or any active link) is clicked
+    if (route === '/about' || location.pathname === route) {
       window.scrollTo({ top: 0, behavior: 'smooth' })
     }
   }
+
+  useEffect(() => {
+    const selector =
+      'a.header__nav-link.header__nav-link--active[href="/about"]'
+    const aboutLink = document.querySelector<HTMLAnchorElement>(selector)
+    if (!aboutLink) return
+    const handleClick = () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+    aboutLink.addEventListener('click', handleClick)
+    return () => {
+      aboutLink.removeEventListener('click', handleClick)
+    }
+  }, [location.pathname])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary
- scroll to top when About link is selected
- attach listener for active About nav link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884678fa198832788cd2582876b9f8c