### PR TITLE
Fix node creation errors

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -161,15 +161,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         })
         .catch(err => {
           console.error('[CreateNode] Failed to save node:', err)
-          // Fallback: create a client-side id so the user can continue editing
-          const fallbackId =
-            typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-              ? crypto.randomUUID()
-              : Math.random().toString(36).slice(2)
-          setNodes(prev => [...prev, { ...newNode, id: fallbackId }])
-          setShowCreate(false)
-          setNewName('')
-          setNewDesc('')
         })
     }
 

--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -86,8 +86,8 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
 
       try {
         const result = await client.query(
-          `INSERT INTO nodes (mindmap_id, x, y, label, description, parent_id)
-           VALUES ($1, $2, $3, $4, $5, $6)
+          `INSERT INTO nodes (mindmap_id, x, y, label, description, parent_id, content)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)
            RETURNING id`,
           [
             payload.mindmapId,
@@ -95,7 +95,8 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
             payload.y,
             payload.label ?? null,
             payload.description ?? null,
-            payload.parentId ?? null
+            payload.parentId ?? null,
+            payload.label ?? ''
           ]
         )
 


### PR DESCRIPTION
## Summary
- add missing `content` column to node insertion query
- remove client-side fallback when creating the first node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68846da1fc688327ac50afe759361e64