### PR TITLE
Add Todo modals and kanban actions

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -1,4 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
+import CommentsModal from './CommentsModal'
+import TodoModal from './TodoModal'
+import Modal from './modal'
+import type { Comment } from './CardModal'
 
 export interface TodoItem {
   id: string
@@ -6,6 +10,8 @@ export interface TodoItem {
   description: string
   nodeId?: string
   kanbanId?: string
+  assignee?: string
+  comments?: Comment[]
 }
 
 export interface TodoCanvasProps {
@@ -28,6 +34,11 @@ export default function TodoCanvas({
   const [newTitle, setNewTitle] = useState('')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editTitle, setEditTitle] = useState('')
+  const [editingTodo, setEditingTodo] = useState<TodoItem | null>(null)
+  const [commentingTodo, setCommentingTodo] = useState<TodoItem | null>(null)
+  const [sendingTodo, setSendingTodo] = useState<TodoItem | null>(null)
+  const [boards, setBoards] = useState<{ id: string; title: string }[]>([])
+  const [selectedBoard, setSelectedBoard] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -84,9 +95,38 @@ export default function TodoCanvas({
     }
   }
 
+  const handleModalSave = async (updated: TodoItem) => {
+    setTodos(prev => prev.map(t => (t.id === updated.id ? updated : t)))
+    setEditingTodo(null)
+    try {
+      await saveTodoUpdate(updated)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
   const startEditing = (todo: TodoItem) => {
     setEditingId(todo.id)
     setEditTitle(todo.title)
+  }
+
+  const openEditModal = (todo: TodoItem) => {
+    setEditingTodo(todo)
+  }
+
+  const openCommentPanel = (todo: TodoItem) => {
+    setCommentingTodo(todo)
+  }
+
+  const openKanbanSendDialog = async (todo: TodoItem) => {
+    setSendingTodo(todo)
+    try {
+      const res = await fetch('/.netlify/functions/boards', { credentials: 'include' })
+      const data = await res.json()
+      if (Array.isArray(data.boards)) setBoards(data.boards)
+    } catch {
+      setBoards([])
+    }
   }
 
   const saveEdit = async (todo: TodoItem) => {
@@ -138,6 +178,20 @@ export default function TodoCanvas({
                   {t.title}
                 </span>
               )}
+              <div className="tile-actions">
+                <button className="btn-icon" onClick={() => openEditModal(t)}>
+                  ✏️
+                </button>
+                <button className="btn-icon" onClick={() => openCommentPanel(t)}>
+                  💬
+                </button>
+                <button
+                  className="btn-secondary"
+                  onClick={() => openKanbanSendDialog(t)}
+                >
+                  ➡ Send to Kanban
+                </button>
+              </div>
             </div>
           </div>
         ))}
@@ -207,6 +261,62 @@ export default function TodoCanvas({
           </>
         )}
       </div>
+      <TodoModal
+        todo={editingTodo}
+        onClose={() => setEditingTodo(null)}
+        onSave={handleModalSave}
+      />
+      <CommentsModal
+        card={commentingTodo ? { ...commentingTodo, comments: commentingTodo.comments || [], id: commentingTodo.id, title: commentingTodo.title } : null}
+        onClose={() => setCommentingTodo(null)}
+        onAdd={c => {
+          if (commentingTodo) {
+            const updated = {
+              ...commentingTodo,
+              comments: [...(commentingTodo.comments || []), c],
+            }
+            setTodos(prev => prev.map(t => (t.id === updated.id ? updated : t)))
+            setCommentingTodo(updated)
+          }
+        }}
+      />
+      {sendingTodo && (
+        <Modal isOpen={true} onClose={() => setSendingTodo(null)} ariaLabel="Send to kanban">
+          <div className="modal-container card-modal">
+            <h2 className="mb-2 text-lg font-semibold">Send to Kanban</h2>
+            <select value={selectedBoard} onChange={e => setSelectedBoard(e.target.value)} className="input-styled">
+              <option value="">Select board</option>
+              {boards.map(b => (
+                <option key={b.id} value={b.id}>{b.title}</option>
+              ))}
+            </select>
+            <div className="card-actions" style={{ marginTop: '1rem' }}>
+              <button className="btn-cancel" onClick={() => setSendingTodo(null)}>Cancel</button>
+              <button
+                className="btn-save"
+                disabled={!selectedBoard}
+                onClick={async () => {
+                  if (!sendingTodo) return
+                  await fetch('/.netlify/functions/kanban-items', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({
+                      title: sendingTodo.title,
+                      description: sendingTodo.description,
+                      list_id: selectedBoard,
+                      metadata: { from: 'todo', todo_id: sendingTodo.id },
+                    }),
+                  })
+                  setSendingTodo(null)
+                }}
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   )
 }

--- a/TodoModal.tsx
+++ b/TodoModal.tsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react'
+import Modal from './modal'
+import type { TodoItem } from './TodoCanvas'
+
+interface Props {
+  todo: TodoItem | null
+  onClose: () => void
+  onSave: (todo: TodoItem) => void
+}
+
+export default function TodoModal({ todo, onClose, onSave }: Props) {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+
+  useEffect(() => {
+    if (todo) {
+      setTitle(todo.title)
+      setDescription(todo.description || '')
+    }
+  }, [todo])
+
+  if (!todo) return null
+
+  const save = () => {
+    onSave({ ...todo, title, description })
+    onClose()
+  }
+
+  return (
+    <Modal isOpen={!!todo} onClose={onClose} ariaLabel="Edit todo">
+      <div className="modal-container card-modal">
+        <h2 className="mb-2 text-lg font-semibold">Edit Todo</h2>
+        <div className="modal-section">
+          <label>
+            Title
+            <input
+              type="text"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              className="input-styled"
+            />
+          </label>
+          <label>
+            Description
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              className="textarea-styled"
+            />
+          </label>
+        </div>
+        <div className="card-actions">
+          <button onClick={onClose} className="btn-cancel">Cancel</button>
+          <button onClick={save} className="btn-save">Save</button>
+        </div>
+      </div>
+    </Modal>
+  )
+}


### PR DESCRIPTION
## Summary
- allow editing todos in a modal
- add comment button on todo items
- add dialog to send todos to a kanban board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688470068f008327b98d5dd7cdb7f1be