### PR TITLE
Display todo lists on dashboard

### DIFF
--- a/src/DashboardTile.tsx
+++ b/src/DashboardTile.tsx
@@ -3,8 +3,9 @@ import { Link } from 'react-router-dom'
 
 export interface DashboardItem {
   id: string
-  label: string
+  label: ReactNode | string
   link: string
+  subText?: string
 }
 
 interface DashboardTileProps {
@@ -14,9 +15,10 @@ interface DashboardTileProps {
   metrics?: ReactNode
   onCreate?: () => void
   moreLink?: string
+  listClassName?: string
 }
 
-export default function DashboardTile({ icon, title, items = [], metrics, onCreate, moreLink }: DashboardTileProps) {
+export default function DashboardTile({ icon, title, items = [], metrics, onCreate, moreLink, listClassName = 'recent-list' }: DashboardTileProps) {
   return (
     <div className={`dashboard-tile${onCreate ? ' can-create' : ''}`}>
       <header className="tile-header">
@@ -31,10 +33,15 @@ export default function DashboardTile({ icon, title, items = [], metrics, onCrea
         )}
       </header>
       {items.length > 0 && (
-        <ul className="recent-list">
+        <ul className={listClassName}>
           {items.map(item => (
             <li key={item.id}>
-              <Link to={item.link}>{item.label}</Link>
+              <Link to={item.link} className="dashboard-link">
+                {item.label}
+              </Link>
+              {item.subText && (
+                <span className="dashboard-subtext">{item.subText}</span>
+              )}
             </li>
           ))}
         </ul>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1944,6 +1944,37 @@ hr {
   color: var(--color-secondary);
 }
 
+.dashboard-list-preview {
+  list-style: none;
+  padding: 0;
+}
+
+.dashboard-list-preview li {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-xs);
+  font-size: 0.85rem;
+}
+
+.dashboard-link {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.dashboard-link:hover {
+  color: var(--color-secondary);
+}
+
+.dashboard-subtext {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.dashboard-empty {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
 /* style for create tiles */
 .create-tile {
   display: flex;


### PR DESCRIPTION
## Summary
- fetch todo list data in dashboard
- compute todo metrics from lists
- preview todo lists in dashboard tiles
- support subtext items in `DashboardTile`
- style todo list preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68847286f5f48327a1ffc29bc0e11e86