### PR TITLE
Add scroll anchors to marketing pages

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -57,7 +57,8 @@ const sections: AboutSection[] = [
 export default function AboutPage(): JSX.Element {
   useScrollReveal()
   return (
-    <div className="about-page">
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
+      <div className="about-page">
       <section className="section section--one-col reveal relative overflow-x-visible">
         <MindmapArm side="left" />
         <FaintMindmapBackground />
@@ -98,6 +99,7 @@ export default function AboutPage(): JSX.Element {
           )}
         </section>
       ))}
+      </div>
     </div>
   )
 }

--- a/src/ScrollToTop.tsx
+++ b/src/ScrollToTop.tsx
@@ -4,7 +4,24 @@ import { useLocation } from 'react-router-dom'
 export default function ScrollToTop(): JSX.Element {
   const { pathname } = useLocation()
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    const dashboardPaths = [
+      '/dashboard',
+      '/mindmaps',
+      '/todos',
+      '/kanban',
+      '/team-members',
+      '/profile',
+      '/billing',
+      '/account',
+      '/maps',
+      '/todo-canvas'
+    ]
+    const isDashboard = dashboardPaths.some(
+      p => pathname === p || pathname.startsWith(p + '/')
+    )
+    if (isDashboard) {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
   }, [pathname])
   return null
 }

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -57,25 +57,18 @@ const Header = (): JSX.Element => {
       navigate(route)
     }
 
-    // Scroll to the top when the About link (or any active link) is clicked
-    if (route === '/about' || location.pathname === route) {
-      window.scrollTo({ top: 0, behavior: 'smooth' })
+    const marketingPaths = ['/about', '/todo-demo', '/contact', '/pricing']
+    if (marketingPaths.includes(route)) {
+      setTimeout(() => {
+        const topAnchor = document.getElementById('top')
+        if (topAnchor) {
+          topAnchor.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        } else {
+          window.scrollTo({ top: 0, behavior: 'smooth' })
+        }
+      }, 50)
     }
   }
-
-  useEffect(() => {
-    const selector =
-      'a.header__nav-link.header__nav-link--active[href="/about"]'
-    const aboutLink = document.querySelector<HTMLAnchorElement>(selector)
-    if (!aboutLink) return
-    const handleClick = () => {
-      window.scrollTo({ top: 0, behavior: 'smooth' })
-    }
-    aboutLink.addEventListener('click', handleClick)
-    return () => {
-      aboutLink.removeEventListener('click', handleClick)
-    }
-  }, [location.pathname])
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -88,7 +88,8 @@ export default function TodoDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div className="todo-demo-page">
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
+      <div className="todo-demo-page">
       <section className="todo-demo section reveal relative overflow-x-visible">
         <FaintMindmapBackground />
         <div className="container">
@@ -188,6 +189,7 @@ export default function TodoDemo(): JSX.Element {
           </p>
         </div>
       </section>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- wrap marketing pages with a container that can be anchored by id `top`
- update navigation helper to scroll to the anchor when visiting marketing routes
- relax global `ScrollToTop` so it only triggers on dashboard routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848310a2b88327b78b32c473b298eb