### PR TITLE
Add top anchors & scroll logic for marketing pages

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -90,6 +90,7 @@ const Homepage: React.FC = (): JSX.Element => {
 
 
   return (
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
     <div className="homepage">
         <section className="hero section relative overflow-x-visible">
         <div className="container">
@@ -323,6 +324,7 @@ const Homepage: React.FC = (): JSX.Element => {
         </div>
       </section>
 
+    </div>
     </div>
   )
 }

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -78,6 +78,7 @@ export default function Kanban(): JSX.Element {
   }, [step, totalSteps])
 
   return (
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
     <div className="kanban-demo-page">
       <section className="kanban-demo section reveal relative overflow-x-visible">
         <FaintMindmapBackground className="mindmap-bg-small" />
@@ -188,6 +189,7 @@ export default function Kanban(): JSX.Element {
           </p>
         </div>
       </section>
+      </div>
     </div>
   )
 }

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -84,6 +84,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
   }, [inView, step, totalSteps])
 
   return (
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
     <div className="mindmap-demo-page">
       <section ref={sectionRef} className="mindmap-demo section reveal relative overflow-x-visible">
         <FaintMindmapBackground />
@@ -232,6 +233,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
           </section>
         </>
       )}
+    </div>
     </div>
   )
 }

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -34,6 +34,7 @@ const LoginPage = () => {
   }
 
   return (
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
     <section className="section relative overflow-hidden login-page">
       <FaintMindmapBackground />
       <div className="form-card">
@@ -80,6 +81,7 @@ const LoginPage = () => {
         </form>
       </div>
     </section>
+    </div>
   )
 }
 

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -35,6 +35,7 @@ const PurchasePage = () => {
   }
 
   return (
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '64px' }}>
     <section className="section relative overflow-x-visible">
       <div className="container">
         <h1 className="text-center mb-md">Purchase MindXdo</h1>
@@ -140,6 +141,7 @@ const PurchasePage = () => {
         </div>
       </div>
     </section>
+    </div>
   )
 }
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -57,7 +57,15 @@ const Header = (): JSX.Element => {
       navigate(route)
     }
 
-    const marketingPaths = ['/about', '/todo-demo', '/contact', '/pricing']
+    const marketingPaths = [
+      '/',
+      '/about',
+      '/mindmap-demo',
+      '/todo-demo',
+      '/kanban-demo',
+      '/purchase',
+      '/login'
+    ]
     if (marketingPaths.includes(route)) {
       setTimeout(() => {
         const topAnchor = document.getElementById('top')


### PR DESCRIPTION
## Summary
- add `#top` anchor wrappers to homepage, demos, purchase, and login pages
- update header navigation to scroll to `#top` on marketing routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884858403ec8327a0578017e6afb7e9