### PR TITLE
Implement kanban card persistence

### DIFF
--- a/CardModal.tsx
+++ b/CardModal.tsx
@@ -20,6 +20,7 @@ export interface Card {
   todoId?: string
   todoListId?: string
   mindmapId?: string
+  position?: number
 }
 
 interface Props {

--- a/netlify/functions/kanban-cards.ts
+++ b/netlify/functions/kanban-cards.ts
@@ -35,21 +35,22 @@ export const handler: Handler = async (event) => {
       const columnId = data.column_id
       const title = (data.title || '').trim()
       if (!columnId || !title) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing column_id or title' }) }
-      const res = await client.query(
-        `INSERT INTO kanban_cards (column_id, title, description, status, priority, due_date, assignee_id, position)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
-         RETURNING id, column_id, title, position`,
-        [
-          columnId,
-          title,
-          data.description ?? null,
-          data.status ?? 'open',
-          data.priority ?? 'low',
-          data.due_date ?? null,
-          data.assignee_id ?? null,
-          Number(data.position) || 0
-        ]
-      )
+    const res = await client.query(
+      `INSERT INTO kanban_cards (column_id, title, description, status, priority, due_date, assignee_id, position)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       RETURNING id, column_id, title, position`,
+      [
+        columnId,
+        title,
+        data.description ?? null,
+        data.status ?? 'open',
+        data.priority ?? 'low',
+        data.due_date ?? null,
+        data.assignee_id ?? null,
+        Number(data.position) || 0
+      ]
+    )
+      await log(client, res.rows[0].id, userId, 'create', 'Card created')
       return { statusCode: 201, headers, body: JSON.stringify(res.rows[0]) }
     }
 


### PR DESCRIPTION
## Summary
- log creation events in `kanban_card_activity_log`
- send API requests via `/api/kanban` routes
- include card position in state and PATCH payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688487f38bb48327a89764647e65e893