### PR TITLE
Improve Kanban card persistence

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -127,7 +127,14 @@ export default function InteractiveKanbanBoard({
           const done = prev.find(l => l.title === 'Done')
           const others = prev.filter(l => l.title !== 'Done')
           const lane = { id, title: data.title, cards: [] }
-          return done ? [...others, lane, done] : [...prev, lane]
+          const updated = done ? [...others, lane, done] : [...prev, lane]
+          const payload = updated.map((ln, idx) => ({ id: ln.id, position: idx }))
+          authFetch(`${API_BASE}/columns`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ columns: payload })
+          }).catch(() => {})
+          return updated
         })
       })
       .catch(err => console.error('addLane', err))
@@ -213,13 +220,12 @@ export default function InteractiveKanbanBoard({
       const withoutDone = copy.filter(l => l.title !== 'Done')
       const done = copy.find(l => l.title === 'Done')
       const result = done ? [...withoutDone, done] : withoutDone
-      result.forEach((ln, idx) => {
-        authFetch(`${API_BASE}/columns/${ln.id}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ position: idx })
-        }).catch(() => {})
-      })
+      const payload = result.map((ln, idx) => ({ id: ln.id, position: idx }))
+      authFetch(`${API_BASE}/columns`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ columns: payload })
+      }).catch(() => {})
       return result
     })
   }

--- a/netlify/functions/kanban-cards.ts
+++ b/netlify/functions/kanban-cards.ts
@@ -92,7 +92,8 @@ export const handler: Handler = async (event) => {
         [...values, cardId]
       )
       if (res.rowCount === 0) return { statusCode: 404, headers, body: JSON.stringify({ error: 'Not found' }) }
-      await log(client, cardId, userId, 'update', 'Card updated')
+      const changed = keys.filter(k => data[k] !== undefined).join(',')
+      await log(client, cardId, userId, 'update', `Updated: ${changed}`)
       return { statusCode: 200, headers, body: JSON.stringify({ id: cardId }) }
     }
 


### PR DESCRIPTION
## Summary
- support bulk column position updates via `/api/kanban/columns`
- log which fields changed when updating a card
- update frontend board to keep column order in sync

## Testing
- `npm test`
- `npm run compile:functions` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68851534d4b48327b3ab7da8ca0bd6b4