### PR TITLE
Fix kanban API routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,41 @@
   status = 200
 
 [[redirects]]
+  from = "/api/kanban/boards"
+  to = "/.netlify/functions/kanban-boards"
+  status = 200
+
+[[redirects]]
+  from = "/api/kanban/board-data"
+  to = "/.netlify/functions/kanban-board-data"
+  status = 200
+
+[[redirects]]
+  from = "/api/kanban/columns"
+  to = "/.netlify/functions/kanban-columns"
+  status = 200
+
+[[redirects]]
+  from = "/api/kanban/columns/:id"
+  to = "/.netlify/functions/kanban-columns/:id"
+  status = 200
+
+[[redirects]]
+  from = "/api/kanban/cards"
+  to = "/.netlify/functions/kanban-cards"
+  status = 200
+
+[[redirects]]
+  from = "/api/kanban/cards/:id/move"
+  to = "/.netlify/functions/kanban-cards/:id/move"
+  status = 200
+
+[[redirects]]
+  from = "/api/kanban/cards/:id"
+  to = "/.netlify/functions/kanban-cards/:id"
+  status = 200
+
+[[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,10 @@
 /api/maps/:id /.netlify/functions/mapid 200
+/api/kanban/boards /.netlify/functions/kanban-boards 200
+/api/kanban/board-data /.netlify/functions/kanban-board-data 200
+/api/kanban/columns /.netlify/functions/kanban-columns 200
+/api/kanban/columns/:id /.netlify/functions/kanban-columns/:id 200
+/api/kanban/cards /.netlify/functions/kanban-cards 200
+/api/kanban/cards/:id/move /.netlify/functions/kanban-cards/:id/move 200
+/api/kanban/cards/:id /.netlify/functions/kanban-cards/:id 200
 /api/* /.netlify/functions/:splat 200
 /*  /index.html  200


### PR DESCRIPTION
## Summary
- route `/api/kanban/*` paths to the proper Netlify function names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68851cb76f888327977f74223f88ec65