### PR TITLE
Fix scroll anchors for marketing pages

### DIFF
--- a/about.tsx
+++ b/about.tsx
@@ -57,7 +57,7 @@ const sections: AboutSection[] = [
 export default function AboutPage(): JSX.Element {
   useScrollReveal()
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
       <div className="about-page">
       <section className="section section--one-col reveal relative overflow-x-visible">
         <MindmapArm side="left" />

--- a/homepage.tsx
+++ b/homepage.tsx
@@ -90,7 +90,7 @@ const Homepage: React.FC = (): JSX.Element => {
 
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
     <div className="homepage">
         <section className="hero section relative overflow-x-visible">
         <div className="container">

--- a/kanban.tsx
+++ b/kanban.tsx
@@ -78,7 +78,7 @@ export default function Kanban(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
     <div className="kanban-demo-page">
       <section className="kanban-demo section reveal relative overflow-x-visible">
         <FaintMindmapBackground className="mindmap-bg-small" />

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -84,7 +84,7 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
   }, [inView, step, totalSteps])
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
     <div className="mindmap-demo-page">
       <section ref={sectionRef} className="mindmap-demo section reveal relative overflow-x-visible">
         <FaintMindmapBackground />

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -34,7 +34,7 @@ const LoginPage = () => {
   }
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
     <section className="section relative overflow-hidden login-page">
       <FaintMindmapBackground />
       <div className="form-card">

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -35,7 +35,7 @@ const PurchasePage = () => {
   }
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
     <section className="section relative overflow-x-visible">
       <div className="container">
         <h1 className="text-center mb-md">Purchase MindXdo</h1>

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -88,7 +88,7 @@ export default function TodoDemo(): JSX.Element {
   }, [step, totalSteps])
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
       <div className="todo-demo-page">
       <section className="todo-demo section reveal relative overflow-x-visible">
         <FaintMindmapBackground />


### PR DESCRIPTION
## Summary
- adjust `scrollMarginTop` on marketing pages to keep headers from hiding content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68852383192c83279605dc97635f53c9