### PR TITLE
Implement separate logic for mindmap nodes

### DIFF
--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -4,6 +4,12 @@ import type { PoolClient } from 'pg'
 import { validate as isUuid } from 'uuid'
 import { requireAuth } from './middleware.js'
 
+// Node creation rules:
+// - A mindmap may contain only one root node (parentId null).
+// - The first root node defaults to the canvas center if no coordinates are
+//   provided.
+// - Child nodes require a parentId and coordinates relative to that parent.
+
 interface NodePayload {
   mindmapId: string
   parentId?: string | null


### PR DESCRIPTION
## Summary
- document root vs child node creation rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68852670324c8327a5f6ac1b44703163