### PR TITLE
Fix homepage responsive layout

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -90,8 +90,18 @@ const Homepage: React.FC = (): JSX.Element => {
 
 
   return (
-    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '114px' }}>
-    <div className="homepage">
+    <div id="top" tabIndex={-1} style={{ scrollMarginTop: '5px' }}>
+      <div
+        className="homepage"
+        style={{
+          width: '100%',
+          maxWidth: '100%',
+          boxSizing: 'border-box',
+          padding: '0 1rem',
+          margin: '0 auto',
+          marginTop: '130px',
+        }}
+      >
         <section className="hero section relative overflow-x-visible">
         <div className="container">
         <div className="shape shape-circle hero-shape1" />


### PR DESCRIPTION
## Summary
- offset homepage content from the fixed header
- set homepage container to full width and add padding

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885291988b48327b16b6b280a786f9c