### PR TITLE
Fix todo update endpoint

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -75,11 +75,14 @@ export default function TodoCanvas({
   }
 
   const saveTodoUpdate = async (todo: TodoItem) => {
-    await fetch('/.netlify/functions/todos', {
-      method: 'PATCH',
+    await fetch(`/.netlify/functions/todoid/${todo.id}`, {
+      method: 'PUT',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: todo.id, updates: { title: todo.title, completed: (todo as any).completed } }),
+      body: JSON.stringify({
+        title: todo.title,
+        completed: (todo as any).completed,
+      }),
     })
   }
 

--- a/todomanager.tsx
+++ b/todomanager.tsx
@@ -81,7 +81,7 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     abortControllers.current.push(controller)
     if (isMounted.current) { setLoading(true); setError(null) }
     try {
-      const res = await authFetch(`/.netlify/functions/todos/${id}`, {
+      const res = await authFetch(`/.netlify/functions/todoid/${id}`, {
         method: 'DELETE',
         signal: controller.signal
       })
@@ -110,7 +110,7 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     if (isMounted.current) { setLoading(true); setError(null) }
     const updatedCompleted = !todo.completed
     try {
-      const res = await authFetch(`/.netlify/functions/todos/${todo.id}`, {
+      const res = await authFetch(`/.netlify/functions/todoid/${todo.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ completed: updatedCompleted }),
@@ -154,7 +154,7 @@ export default function TodoManager({ todos: initialTodos }: TodoManagerProps) {
     if (editValues.description.trim()) payload.description = editValues.description.trim()
     if (editValues.assigneeId !== undefined) payload.assignee_id = editValues.assigneeId
     try {
-      const res = await authFetch(`/.netlify/functions/todos/${id}`, {
+      const res = await authFetch(`/.netlify/functions/todoid/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- update TodoCanvas to use `todoid` API for updates
- switch todomanager actions to call the `todoid` endpoint for PUT/DELETE

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885313fd1908327b4b673be52cc5ad7