### PR TITLE
Fix horizontal overflow on mobile

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -56,7 +56,8 @@
 html,
 body {
   height: 100%;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 html {
@@ -1101,7 +1102,7 @@ hr {
 
 .about-section {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: var(--spacing-lg);
   align-items: center;
   justify-items: center;


### PR DESCRIPTION
## Summary
- prevent body from showing horizontal scroll
- shrink about-section grid columns for small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68853362027c8327b2b7c5f7d52d24b7