### PR TITLE
Final visual polish for todo builder

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -199,7 +199,7 @@ export default function TodoCanvas({
       {listDescription && (
         <p className="todo-description">{listDescription}</p>
       )}
-      <h3 className="todo-progress">
+      <h3 className="todo-completion">
         {completedCount}/{totalCount} completed
       </h3>
       <div className="todo-list">
@@ -211,24 +211,26 @@ export default function TodoCanvas({
       )}
       {adding && (
         <div className="todo-add-block">
-          <form
-            className="todo-add-form"
-            onSubmit={e => {
+          <div className="todo-add-wrapper">
+            <form
+              className="todo-add-form"
+              onSubmit={e => {
               e.preventDefault()
               if (!newTitle.trim()) return
               handleCreateTodo(newTitle.trim())
               setNewTitle('')
-            }}
-          >
-            <input
-              type="text"
-              className="todo-add-input"
-              placeholder="New todo"
-              value={newTitle}
-              onChange={e => setNewTitle(e.target.value)}
-            />
-            <button type="submit" className="todo-add-button">Add</button>
-          </form>
+              }}
+            >
+              <input
+                type="text"
+                className="todo-add-input"
+                placeholder="New todo"
+                value={newTitle}
+                onChange={e => setNewTitle(e.target.value)}
+              />
+              <button type="submit" className="todo-add-button">Add</button>
+            </form>
+          </div>
           <div className="done-link" onClick={() => setAdding(false)}>
             done adding todos
           </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2268,7 +2268,9 @@ hr {
 }
 
 .todo-canvas-wrapper {
-  padding: 2rem;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
   text-align: center;
   display: flex;
   flex-direction: column;
@@ -2282,9 +2284,12 @@ hr {
 }
 
 .todo-title {
-  font-size: 1.8rem;
+  font-size: 2rem;
   font-weight: 700;
+  text-align: center;
+  margin-top: 0.5rem;
   margin-bottom: 0.25rem;
+  color: #1f1f1f;
 }
 
 .todo-description {
@@ -3357,11 +3362,11 @@ hr {
   margin: 1.5rem 0 0.75rem;
 }
 
-.todo-progress {
-  font-size: 1.1rem;
+.todo-completion {
   font-weight: 600;
-  margin: 0.5rem 0 1rem;
-  color: var(--color-primary);
+  color: #ffa726;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
 }
 
 .todo-list {
@@ -3422,22 +3427,17 @@ hr {
 }
 
 .todo-block {
-  max-width: 600px;
-  width: 100%;
-  margin: 0 auto 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
-  background: radial-gradient(circle at top left, #fafdff, #ffffff);
-  border: 1px solid #e0e7ff;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-  transition: background 0.3s ease;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  background: #f9faff;
+  border: 1px solid #e3e8f0;
+  margin-bottom: 0.5rem;
+  transition: background 0.2s;
 
   &:hover {
-    background: #f0f6ff;
-    box-shadow: 0 0 8px rgba(0, 153, 255, 0.15);
+    background: #f1f6ff;
   }
 
   &.completed .todo-text {
@@ -3472,27 +3472,26 @@ hr {
 .todo-icons {
   display: flex;
   gap: 5px;
-  margin-left: 1rem;
-  flex-shrink: 0;
+  margin-left: auto;
 }
 
 .circle-icon {
   width: 36px;
   height: 36px;
-  background: #2e2e2e;
+  background: #3a3a3a;
   color: #dcdcdc;
   border-radius: 50%;
   border: none;
-  font-size: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 16px;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.2s ease;
 }
 
 .circle-icon:hover {
-  background: #444;
+  background: #4a4a4a;
 }
 
 .circle-icon span {
@@ -3505,16 +3504,20 @@ hr {
   text-align: center;
 }
 
+.todo-add-wrapper {
+  max-width: 600px;
+  margin: 1.5rem auto 0.75rem;
+}
+
 .todo-add-form {
   display: flex;
-  max-width: 600px;
-  margin: 1rem auto;
+  width: 100%;
   gap: 0.5rem;
 }
 
 .todo-add-input {
-  flex-grow: 1;
-  padding: 0.5rem 0.75rem;
+  flex: 1;
+  padding: 0.6rem 1rem;
   font-size: 1rem;
   border: 1px solid #ccc;
   border-radius: 8px;
@@ -3526,7 +3529,7 @@ hr {
   font-weight: 600;
   border: none;
   border-radius: 8px;
-  padding: 0 1.25rem;
+  padding: 0 1.5rem;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- refine todo builder canvas styles
- adjust add form markup with width wrapper
- modernize icon buttons
- brighten todo list styling and completion count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68853b70b90c8327a5ac287627b9768e