### PR TITLE
Finalize Todo canvas UI

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -189,7 +189,7 @@ export default function TodoCanvas({
   )
 
   return (
-    <div className="todo-canvas-wrapper">
+    <div className="todo-canvas">
       {listTitle && (
         <>
           <img src="/assets/logo.png" alt="MindXdo" className="todo-logo" />

--- a/src/global.scss
+++ b/src/global.scss
@@ -2267,7 +2267,7 @@ hr {
   border-radius: 4px;
 }
 
-.todo-canvas-wrapper {
+.todo-canvas {
   max-width: 720px;
   margin: 0 auto;
   padding: 2rem 1rem;
@@ -2284,10 +2284,9 @@ hr {
 }
 
 .todo-title {
-  font-size: 2rem;
+  font-size: 30px;
   font-weight: 700;
   text-align: center;
-  margin-top: 0.5rem;
   margin-bottom: 0.25rem;
   color: #1f1f1f;
 }
@@ -2342,7 +2341,7 @@ hr {
 
 .todo-add-form {
   display: flex;
-  max-width: 600px;
+  width: 600px;
   margin: 1rem auto;
   gap: 0.5rem;
 }
@@ -3427,13 +3426,15 @@ hr {
 }
 
 .todo-block {
+  width: 600px;
+  margin: 0 auto 0.5rem;
   display: flex;
   align-items: center;
   padding: 0.75rem 1rem;
   border-radius: 10px;
   background: #f9faff;
   border: 1px solid #e3e8f0;
-  margin-bottom: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   transition: background 0.2s;
 
   &:hover {
@@ -3478,8 +3479,8 @@ hr {
 .circle-icon {
   width: 36px;
   height: 36px;
-  background: #3a3a3a;
-  color: #dcdcdc;
+  background: #3b3b3b;
+  color: #e0e0e0;
   border-radius: 50%;
   border: none;
   display: flex;
@@ -3487,11 +3488,11 @@ hr {
   justify-content: center;
   font-size: 16px;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s;
 }
 
 .circle-icon:hover {
-  background: #4a4a4a;
+  background: #4c4c4c;
 }
 
 .circle-icon span {
@@ -3505,14 +3506,15 @@ hr {
 }
 
 .todo-add-wrapper {
-  max-width: 600px;
-  margin: 1.5rem auto 0.75rem;
+  width: 600px;
+  margin: 1.5rem auto 0.5rem;
 }
 
 .todo-add-form {
   display: flex;
-  width: 100%;
+  width: 600px;
   gap: 0.5rem;
+  margin: 0 auto;
 }
 
 .todo-add-input {


### PR DESCRIPTION
## Summary
- style todo-block with fixed width and box shadow
- center add todo form and items
- adjust icon styles and title font size
- rename canvas wrapper class in code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68854502fb688327bd1c576482e78a31