### PR TITLE
Fix first node creation with mindmapId

### DIFF
--- a/mindmapTypes.ts
+++ b/mindmapTypes.ts
@@ -6,6 +6,7 @@ export interface NodeData {
   description?: string
   parentId?: string | null
   todoId?: string | null
+  mindmapId?: string
 }
 
 export interface EdgeData {

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -145,7 +145,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       const rect = containerRef.current.getBoundingClientRect()
       void rect // reference to avoid lint warnings, not used currently
 
-      const node = {
+      const node: NodeData = {
         id,
         x: CANVAS_SIZE / 2,
         y: CANVAS_SIZE / 2,
@@ -155,7 +155,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         todoId: null,
         mindmapId,
       }
-
       console.log('[MindmapCanvas] Creating node with data:', node)
       addNode(node)
       onAddNode?.(node)
@@ -176,11 +175,13 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       const newNode = {
         x: parent.x + 150,
         y: parent.y + 50 * (siblingCount + 1),
-        label: newName || 'New Node',
-        description: newDesc || '',
+        label: newName.trim() || 'General',
+        description: newDesc.trim() || '',
         parentId: addParentId,
         mindmapId,
       }
+
+      console.log('[MindmapCanvas] Posting child node payload:', newNode)
 
       authFetch('/.netlify/functions/nodes', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- include `mindmapId` in `NodeData`
- ensure first node payload includes the map id
- trim child node labels/descriptions and log payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885478307548327ae470aef577c3816