### PR TITLE
Auto-create root node on map load

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -70,7 +70,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     }, [initialTransform])
     const svgRef = useRef<SVGSVGElement | null>(null)
     const containerRef = useRef<HTMLDivElement | null>(null)
-    const [initialNodeCreated, setInitialNodeCreated] = useState(false)
 
     useEffect(() => {
       setNodes(safePropNodes)
@@ -79,33 +78,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     useEffect(() => {
       setEdges(safePropEdges)
     }, [propEdges])
-
-    useEffect(() => {
-      if (
-        !initialNodeCreated &&
-        Array.isArray(nodes) &&
-        nodes.length === 0 &&
-        mindmapId
-      ) {
-        const id =
-          typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-            ? crypto.randomUUID()
-            : Math.random().toString(36).slice(2)
-        const node: NodeData = {
-          id,
-          x: CANVAS_SIZE / 2,
-          y: CANVAS_SIZE / 2,
-          label: 'General',
-          description: '',
-          parentId: null,
-          todoId: null,
-          mindmapId,
-        }
-        addNode(node)
-        onAddNode?.(node)
-        setInitialNodeCreated(true)
-      }
-    }, [nodes, initialNodeCreated, mindmapId, addNode, onAddNode])
 
     useEffect(() => {
       onTransformChange?.(transform)

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -141,6 +141,41 @@ export default function MapEditorPage(): JSX.Element {
     }
   }, [loadingMap, loadingNodes])
 
+  useEffect(() => {
+    if (
+      !loadingMap &&
+      !loadingNodes &&
+      Array.isArray(nodes) &&
+      nodes.length === 0 &&
+      mindmap?.id
+    ) {
+      const generalNode = {
+        x: window.innerWidth / 2,
+        y: window.innerHeight / 2,
+        label: 'General',
+        description: '',
+        parentId: null,
+        mindmapId: mindmap.id,
+      }
+
+      fetch('/.netlify/functions/nodes', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(generalNode),
+      })
+        .then(res => res.json())
+        .then(data => {
+          if (data.id) {
+            setNodes([{ ...generalNode, id: data.id }])
+          }
+        })
+        .catch(err => {
+          console.error('[AutoCreateGeneralNode] Failed to create node:', err)
+        })
+    }
+  }, [loadingMap, loadingNodes, nodes, mindmap])
+
   const safeNodes = Array.isArray(nodes) ? nodes : []
 
   const handleSaveLayout = useCallback(() => {


### PR DESCRIPTION
## Summary
- automatically create a `General` root node in `MapEditorPage`
- drop initial root creation logic from `MindmapCanvas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688552607be883279209b19b3e8a038f