### PR TITLE
Fix Kanban scroll overflow

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -385,6 +385,7 @@ export default function InteractiveKanbanBoard({
                 <div className="lane kanban-lane add-lane" onClick={addLane}>
                   <button className="add-lane-button">+ Add Lane</button>
                 </div>
+                <div className="kanban-scroll-spacer" />
               </div>
             </div>
           )}

--- a/src/global.scss
+++ b/src/global.scss
@@ -2650,13 +2650,20 @@ hr {
 
 .scroll-container {
   width: 100%;
-  overflow: visible;
-  padding: 0 1rem;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  padding: 0 1rem 16px;
   scrollbar-gutter: stable;
 }
 
 .scroll-container::-webkit-scrollbar {
   height: 6px;
+}
+
+.kanban-scroll-spacer {
+  min-width: 100px;
+  flex-shrink: 0;
 }
 
 .kanban-board {


### PR DESCRIPTION
## Summary
- enable scroll area overflow-x and spacer in Kanban board
- insert spacer div in interactive board for 100px extra scroll space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68855453cb10832794449e7f344eb67d