### PR TITLE
Fix patching edited kanban cards

### DIFF
--- a/CardModal.tsx
+++ b/CardModal.tsx
@@ -25,14 +25,16 @@ export interface Card {
 
 interface Props {
   card: Card | null
+  laneId: string
   onClose: () => void
-  onSave: (card: Card) => void
+  onSave: (laneId: string, card: Card) => void
   onDelete: (card: Card) => void
   currentUser?: { name: string }
 }
 
 export default function CardModal({
   card,
+  laneId,
   onClose,
   onSave,
   onDelete,
@@ -82,7 +84,8 @@ export default function CardModal({
 
   const save = () => {
     if (!card) return
-    onSave({
+    console.log('Saving card with ID:', card.id)
+    onSave(laneId, {
       ...card,
       title,
       description,

--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -392,9 +392,14 @@ export default function InteractiveKanbanBoard({
       </DragDropContext>
       <CardModal
         card={editing?.card || null}
+        laneId={editing?.laneId || ''}
         onClose={() => setEditing(null)}
-        onSave={card => {
-          if (editing) updateCard(editing.laneId, card)
+        onSave={(laneId, card) => {
+          if (!card.id) {
+            console.error('Cannot save card: ID is missing')
+            return
+          }
+          updateCard(laneId, card)
         }}
         onDelete={card => {
           if (editing) removeCard(editing.laneId, card.id)


### PR DESCRIPTION
## Summary
- allow `CardModal` to receive the lane ID
- send lane ID from the modal when saving so `updateCard` gets a valid card ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688554a7f4508327b027a265761e3f22