### PR TITLE
Adjust kanban scrolling

### DIFF
--- a/kanban.tsx
+++ b/kanban.tsx
@@ -87,8 +87,7 @@ export default function Kanban(): JSX.Element {
             <h1 className="marketing-text-large">Smooth Kanban Flow</h1>
             <p className="section-subtext">Kanban boards are perfect for executing your vision across a team, showing how mind map tasks move from to-do to done.</p>
           </div>
-          <div className="scroll-container">
-            <div className="kanban-board">
+          <div className="kanban-board">
               {lanes.map((lane, laneIndex) => {
               const laneVisible = step >= laneIndex
               return (
@@ -120,8 +119,7 @@ export default function Kanban(): JSX.Element {
                 </motion.div>
               )
             })}
-            </div>
-          </div>
+              </div>
           <div className="kanban-upgrade text-center">
             <Link to="/purchase" className="btn">
               Get Started

--- a/src/global.scss
+++ b/src/global.scss
@@ -927,6 +927,12 @@ hr {
   text-align: center;
 }
 
+.kanban-demo .kanban-board {
+  flex-wrap: wrap;
+  justify-content: center;
+  padding-right: 0;
+}
+
 .mindmap-demo {
   max-width: 1200px;
   margin: 0 auto;
@@ -2653,8 +2659,9 @@ hr {
   overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
-  padding: 0 1rem 16px;
+  padding: 0 1rem;
   scrollbar-gutter: stable;
+  height: calc(100vh - 80px);
 }
 
 .scroll-container::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- tweak kanban demo markup so columns no longer scroll
- allow demo board lanes to wrap
- make kanban board scroll area fill the viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856467d6e88327abff1d00e1244f2a