### PR TITLE
Shorten homepage hero text

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -105,7 +105,7 @@ const Homepage: React.FC = (): JSX.Element => {
             Vision Meets Action
           </h1>
           <p>
-            Build your ideas while AI builds mind maps and auto-creates todos so your vision becomes a complete plan. Every task stays connected to keep the big picture clear.
+            Mindmaps connect todos to boards, turning ideas into executed vision.
           </p>
           <Link to="/purchase" className="btn">
             Get Started


### PR DESCRIPTION
## Summary
- keep the homepage hero copy short and concise

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688565a711b483278f63b2380e3a684b