### PR TITLE
Adjust marketing header hamburger placement

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -775,6 +775,10 @@ hr {
   gap: var(--spacing-md);
 }
 
+.header__actions--marketing {
+  gap: 15px;
+}
+
 
 .header__nav-list {
   display: flex;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -119,18 +119,20 @@ const Header = (): JSX.Element => {
               />
             </Link>
           </div>
-          <button
-            className="header__toggle"
-            type="button"
-            onClick={() => setMenuOpen(open => !open)}
-            aria-label="Toggle navigation"
-            aria-expanded={isMenuOpen}
-            aria-controls="mobile-navigation"
-          >
-            <span className="header__toggle-bar" />
-            <span className="header__toggle-bar" />
-            <span className="header__toggle-bar" />
-          </button>
+          {user && (
+            <button
+              className="header__toggle"
+              type="button"
+              onClick={() => setMenuOpen(open => !open)}
+              aria-label="Toggle navigation"
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-navigation"
+            >
+              <span className="header__toggle-bar" />
+              <span className="header__toggle-bar" />
+              <span className="header__toggle-bar" />
+            </button>
+          )}
 
           <nav className="header__nav" aria-label="Primary">
             <ul className="header__nav-list">
@@ -154,7 +156,21 @@ const Header = (): JSX.Element => {
               ))}
             </ul>
           </nav>
-          <div className="header__actions">
+          <div className={`header__actions${user ? '' : ' header__actions--marketing'}`}>
+          {!user && (
+            <button
+              className="header__toggle"
+              type="button"
+              onClick={() => setMenuOpen(open => !open)}
+              aria-label="Toggle navigation"
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-navigation"
+            >
+              <span className="header__toggle-bar" />
+              <span className="header__toggle-bar" />
+              <span className="header__toggle-bar" />
+            </button>
+          )}
           {user ? (
             <div className="header__avatar-container" ref={avatarRef}>
               <button


### PR DESCRIPTION
## Summary
- move hamburger into the actions section when not logged in
- add marketing-specific spacing so the button sits 15px from Login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885689f86348327beebcfe4dfe2d986