### PR TITLE
Stub team management and simplify profile page

### DIFF
--- a/profile.tsx
+++ b/profile.tsx
@@ -6,11 +6,10 @@ import MindmapArm from './MindmapArm'
 interface Profile {
   name: string
   email: string
-  address: string
 }
 
 export default function ProfilePage(): JSX.Element {
-  const [profile, setProfile] = useState<Profile>({ name: '', email: '', address: '' })
+  const [profile, setProfile] = useState<Profile>({ name: '', email: '' })
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<boolean>(false)
@@ -21,9 +20,9 @@ export default function ProfilePage(): JSX.Element {
     fetch('/api/profile', { credentials: 'include', signal: controller.signal })
       .then(res => {
         if (!res.ok) throw new Error('Failed to load profile')
-        return res.json() as Promise<Profile>
+        return res.json() as Promise<any>
       })
-      .then(data => setProfile(data))
+      .then(data => setProfile({ name: data.name || '', email: data.email || '' }))
       .catch(err => {
         if (err.name !== 'AbortError') setError(err.message || 'Unknown error')
       })
@@ -31,7 +30,7 @@ export default function ProfilePage(): JSX.Element {
     return () => controller.abort()
   }, [])
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     setProfile(prev => ({ ...prev, [name]: value }))
   }
@@ -62,11 +61,6 @@ export default function ProfilePage(): JSX.Element {
       <FaintMindmapBackground />
       <div className="form-card text-center profile-page">
         <h1 className="text-2xl font-semibold mb-4">Update Profile</h1>
-        <img
-          src="./assets/profile-header.png"
-          alt="Profile header"
-          className="profile-image w-32 mx-auto mb-4"
-        />
         {error && <div className="text-red-600 mb-4">{error}</div>}
         {success && <div className="text-green-600 mb-4">Profile updated!</div>}
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -91,17 +85,6 @@ export default function ProfilePage(): JSX.Element {
             onChange={handleChange}
             className="form-input"
             required
-          />
-        </div>
-        <div className="form-field">
-          <label htmlFor="address" className="form-label">Address</label>
-          <textarea
-            id="address"
-            name="address"
-            value={profile.address}
-            onChange={handleChange}
-            rows={3}
-            className="form-input"
           />
         </div>
         <button

--- a/teammembers.tsx
+++ b/teammembers.tsx
@@ -1,61 +1,7 @@
-import { useEffect, useState } from 'react'
-import { authFetch } from './authFetch'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
 
-interface Member {
-  id: string
-  email: string
-  name?: string
-}
-
 export default function TeamMembers() {
-  const [members, setMembers] = useState<Member[]>([])
-  const [name, setName] = useState('')
-  const [email, setEmail] = useState('')
-  const [error, setError] = useState<string | null>(null)
-
-  async function removeMember(id: string) {
-    setMembers(list => list.filter(m => m.id !== id))
-  }
-
-  async function updateMember(id: string) {
-    console.log('update', id)
-  }
-
-  async function loadMembers() {
-      try {
-        const res = await authFetch('/.netlify/functions/team-members')
-      if (!res.ok) throw new Error('Failed to load members')
-      const data = await res.json()
-      setMembers(data.members)
-    } catch (err: any) {
-      setError(err.message)
-    }
-  }
-
-  async function addMember(e: React.FormEvent) {
-    e.preventDefault()
-    setError(null)
-      try {
-        const res = await authFetch('/.netlify/functions/team-members', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email }),
-      })
-      if (!res.ok) throw new Error('Failed to add member')
-      setName('')
-      setEmail('')
-      loadMembers()
-    } catch (err: any) {
-      setError(err.message)
-    }
-  }
-
-  useEffect(() => {
-    loadMembers()
-  }, [])
-
   return (
     <section className="section relative overflow-hidden">
       <MindmapArm side="right" />
@@ -63,61 +9,7 @@ export default function TeamMembers() {
       <div className="team-page">
         <div className="form-container text-center">
           <h1 className="mb-4">Team Members</h1>
-          {error && <div className="text-red-600 mb-2">{error}</div>}
-          <form onSubmit={addMember} className="mb-4 space-y-4">
-          <div className="form-field text-left">
-            <label htmlFor="name" className="form-label">
-              Name
-            </label>
-            <input
-              id="name"
-              type="text"
-              value={name}
-              onChange={e => setName(e.target.value)}
-              className="form-input"
-              required
-            />
-          </div>
-          <div className="form-field text-left">
-            <label htmlFor="email" className="form-label">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              className="form-input"
-              required
-            />
-          </div>
-          <button type="submit" className="btn w-full">
-            Add
-          </button>
-        </form>
-        <div className="four-col-grid mt-6">
-          {members.map(m => (
-            <div className="tile" key={m.id}>
-              <header className="tile-header">
-                <h2>{m.name || m.email}</h2>
-                <div className="tile-actions">
-                  <button onClick={() => updateMember(m.id)}>Update</button>
-                  <button onClick={() => removeMember(m.id)} className="tile-link">Delete</button>
-                </div>
-              </header>
-              <section className="tile-body">
-                {m.name && <p>{m.email}</p>}
-              </section>
-            </div>
-          ))}
-        </div>
-        {members.length < 3 && (
-          <div className="placeholder-row">
-            {Array.from({ length: 3 - members.length }).map((_, i) => (
-              <div className="placeholder-tile" key={`ghost-${i}`}></div>
-            ))}
-          </div>
-        )}
+          <p className="mt-4">Team management coming soon.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- replace team members logic with a Coming Soon message
- slim down profile page so users can update only name and email

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885791cbc508327a4b21ed4829db0a8