### PR TITLE
Fix AI message param type mismatch

### DIFF
--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai"
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions"
 
 const openai = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,
@@ -8,7 +9,7 @@ const openai = new OpenAI({
 const MODEL = "openai/gpt-4o-mini"
 
 export async function generateAIResponse(prompt: string, systemPrompt?: string) {
-  const messages = [
+  const messages: ChatCompletionMessageParam[] = [
     ...(systemPrompt ? [{ role: "system", content: systemPrompt }] : []),
     { role: "user", content: prompt }
   ]


### PR DESCRIPTION
## Summary
- align ai-generate.ts messages array with `ChatCompletionMessageParam`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885859c2c54832797d9a1f226d84c4c