### PR TITLE
Refine AI prompts for JSON output

### DIFF
--- a/netlify/functions/ai-create-board.ts
+++ b/netlify/functions/ai-create-board.ts
@@ -37,7 +37,9 @@ export const handler = async (
 
     if (prompt && typeof prompt === 'string' && prompt.trim()) {
       try {
-        await generateAIResponse(`Generate a JSON array of kanban column titles based on: "${prompt}"`)
+        await generateAIResponse(
+          `Generate a kanban board JSON from: "${prompt}". Limit to 40 cards total. There must be a column titled New that contains all generated cards. Respond only with JSON.\nExample:\n{"columns":[{"title":"New","cards":[{"title":"Sample"}]}]}`
+        )
       } catch (err) {
         console.error('AI error:', err)
       }

--- a/netlify/functions/ai-create-mindmap.ts
+++ b/netlify/functions/ai-create-mindmap.ts
@@ -28,7 +28,7 @@ export const handler = async (
   if (typeof title !== 'string' || !title.trim()) return { statusCode: 400, body: 'Invalid title' }
   if (!description) return { statusCode: 400, body: 'Missing description' }
 
-  const prompt = `Create a mindmap JSON based on: "${description}". Return an array of nodes with fields: id, title, parentId.`
+  const prompt = `Generate a mindmap as JSON from: "${description}". Limit to 40 nodes or fewer and include one root node with child and sub nodes. Each node should have fields id (uuid), title, and parentId (uuid or null). Return only valid JSON.\nExample:\n[{"id":"uuid","title":"Root","parentId":null},{"id":"uuid","title":"Child","parentId":"root-uuid"}]`
 
   let nodes: any[] = []
   try {

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -23,7 +23,10 @@ export const handler = async (
   if (!prompt || typeof prompt !== 'string') return { statusCode: 400, body: 'Invalid prompt' }
 
   try {
-    const content = await generateAIResponse(prompt, 'Generate a JSON array of todo items with title and optional description.')
+    const content = await generateAIResponse(
+      prompt,
+      'Generate a JSON array of todo items. Limit to 20 items, each with a title and note field. Respond only with JSON.\nExample:\n[{"title":"Sample","note":"Details"}]'
+    )
     let todos: unknown
     try { todos = JSON.parse(content) } catch { todos = [] }
     return {


### PR DESCRIPTION
## Summary
- include generic JSON examples for AI-generated mindmaps
- show example format for AI kanban board generation
- add sample JSON for todo list prompts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688590bb409083279ef977de92ef6b04