### PR TITLE
Remove hero logo images

### DIFF
--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -212,10 +212,6 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
 
           <section className="about-section reveal">
             <MindmapArm side="left" />
-            <img
-              src="./assets/marketing_square_ai_connecting.png"
-              alt="Vision Meets Action"
-            />
             <div>
               <motion.h2
                 className="marketing-text-large"

--- a/src/global.scss
+++ b/src/global.scss
@@ -724,22 +724,12 @@ hr {
   font-weight: 800;
   margin-bottom: var(--spacing-md);
   gap: var(--spacing-sm);
-}
-
-.hero-title .hero-logo {
-  height: 100px;
-  vertical-align: middle;
+  @media (max-width: 640px) {
+    flex-direction: column;
+  }
 }
 
 @media (max-width: 640px) {
-  .hero-title {
-    flex-direction: column;
-  }
-
-  .hero-title .hero-logo {
-    margin-bottom: var(--spacing-sm);
-  }
-
   .hero-banner {
     margin-top: -70px;
   }

--- a/tododemo.tsx
+++ b/tododemo.tsx
@@ -170,10 +170,6 @@ export default function TodoDemo(): JSX.Element {
 
       <section className="about-section reveal">
         <MindmapArm side="left" />
-        <img
-          src="./assets/marketing_square_ai_connecting.png"
-          alt="Vision Meets Action"
-        />
         <div>
           <motion.h2
             className="marketing-text-large"


### PR DESCRIPTION
## Summary
- remove marketing logo image before `Vision Meets Action` headings
- clean up unused `.hero-logo` styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688594bc11d88327a15f546f5731134d