### PR TITLE
Adjust sidebar toggle position

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -1,5 +1,6 @@
 import { NavLink, useNavigate } from 'react-router-dom'
 import React, { useState } from 'react'
+import { motion } from 'framer-motion'
 import { useAuth } from './useAuth'
 
 const mainLinks = [
@@ -27,14 +28,25 @@ export default function SidebarNav(): JSX.Element {
     navigate('/login')
   }
 
+  const sidebarVariants = {
+    open: { width: 200 },
+    closed: { width: 20 }
+  }
+
   return (
-    <aside className={`app-sidebar${open ? '' : ' closed'}`}>
+    <motion.aside
+      className={`app-sidebar${open ? '' : ' closed'}`}
+      animate={open ? 'open' : 'closed'}
+      variants={sidebarVariants}
+      transition={{ duration: 0.3 }}
+    >
       <button
         type="button"
         className="sidebar-drawer-toggle"
         aria-label={open ? 'Collapse sidebar' : 'Expand sidebar'}
         aria-expanded={open}
         onClick={() => setOpen(o => !o)}
+        style={{ left: open ? '175px' : '-5px' }}
       >
         <span>{open ? '‹' : '›'}</span>
       </button>
@@ -69,6 +81,6 @@ export default function SidebarNav(): JSX.Element {
           </li>
         </ul>
       </nav>
-    </aside>
+    </motion.aside>
   )
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -1493,7 +1493,6 @@ hr {
   background-color: var(--color-bg-alt);
   padding: var(--spacing-lg) var(--spacing-md);
   position: relative;
-  transition: width 0.3s ease;
   overflow: hidden;
 }
 
@@ -1509,12 +1508,11 @@ hr {
 }
 
 .sidebar-drawer-toggle {
-  position: absolute;
+  position: fixed;
   top: 50%;
-  right: -12px;
   transform: translateY(-50%);
-  width: 24px;
-  height: 24px;
+  width: 50px;
+  height: 50px;
   border-radius: 50%;
   background-color: #555;
   color: #ccc;
@@ -1523,9 +1521,11 @@ hr {
   justify-content: center;
   cursor: pointer;
   border: none;
+  z-index: 1000;
+  transition: left 0.3s ease;
 }
 .sidebar-drawer-toggle span {
-  font-size: 14px;
+  font-size: 24px;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- ensure sidebar menu toggle stays centered on screen
- make toggle button 50px round and fix to viewport
- animate sidebar open/close using framer-motion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885ab6076908327a75540be845a3639