### PR TITLE
Update sidebar animation and toggle

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -28,9 +28,11 @@ export default function SidebarNav(): JSX.Element {
     navigate('/login')
   }
 
+  const SIDEBAR_WIDTH = 200
+
   const sidebarVariants = {
-    open: { width: 200 },
-    closed: { width: 20 }
+    open: { x: 0 },
+    closed: { x: -SIDEBAR_WIDTH }
   }
 
   return (
@@ -46,7 +48,6 @@ export default function SidebarNav(): JSX.Element {
         aria-label={open ? 'Collapse sidebar' : 'Expand sidebar'}
         aria-expanded={open}
         onClick={() => setOpen(o => !o)}
-        style={{ left: open ? '175px' : '-5px' }}
       >
         <span>{open ? '‹' : '›'}</span>
       </button>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1496,10 +1496,8 @@ hr {
   overflow: hidden;
 }
 
+
 .app-sidebar.closed {
-  width: 20px;
-  padding-left: 0;
-  padding-right: 0;
   overflow: visible;
 }
 
@@ -1508,8 +1506,9 @@ hr {
 }
 
 .sidebar-drawer-toggle {
-  position: fixed;
+  position: absolute;
   top: 50%;
+  right: -25px;
   transform: translateY(-50%);
   width: 50px;
   height: 50px;
@@ -1522,7 +1521,6 @@ hr {
   cursor: pointer;
   border: none;
   z-index: 1000;
-  transition: left 0.3s ease;
 }
 .sidebar-drawer-toggle span {
   font-size: 24px;


### PR DESCRIPTION
## Summary
- slide sidebar in/out instead of resizing
- position sidebar toggle inside the sidebar
- remove width change styles for collapsed sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885add34f7c83279d86f5dc6c03f3aa