### PR TITLE
Improve mobile sidebar behavior

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -28,16 +28,34 @@ export default function SidebarNav(): JSX.Element {
     navigate('/login')
   }
 
-  const SIDEBAR_WIDTH = 200
+  const DESKTOP_WIDTH = 200
+  const MOBILE_PERCENT = 0.35
+
+  const [sidebarWidth, setSidebarWidth] = useState(DESKTOP_WIDTH)
+
+  useEffect(() => {
+    const updateWidth = () => {
+      if (window.innerWidth <= 768) {
+        setSidebarWidth(window.innerWidth * MOBILE_PERCENT)
+      } else {
+        setSidebarWidth(DESKTOP_WIDTH)
+      }
+    }
+
+    updateWidth()
+    window.addEventListener('resize', updateWidth)
+    return () => window.removeEventListener('resize', updateWidth)
+  }, [])
 
   const sidebarVariants = {
     open: { x: 0 },
-    closed: { x: -SIDEBAR_WIDTH }
+    closed: { x: -sidebarWidth }
   }
 
   return (
     <motion.aside
       className={`app-sidebar${open ? '' : ' closed'}`}
+      style={{ width: sidebarWidth }}
       animate={open ? 'open' : 'closed'}
       variants={sidebarVariants}
       transition={{ duration: 0.3 }}

--- a/src/global.scss
+++ b/src/global.scss
@@ -1496,6 +1496,31 @@ hr {
   overflow: hidden;
 }
 
+@media (max-width: 768px) {
+  .app-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 35vw;
+    height: 100%;
+    z-index: 1000;
+    padding-top: 60px;
+  }
+
+  .app-sidebar nav > ul:first-of-type > li:first-child {
+    margin-top: 50px;
+  }
+
+  .sidebar-drawer-toggle {
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    right: auto;
+    transform: none;
+    z-index: 1100;
+  }
+}
+
 
 .app-sidebar.closed {
   overflow: visible;


### PR DESCRIPTION
## Summary
- make sidebar width responsive to screen size and position toggle to top-left on mobile
- keep mobile sidebar fixed so the toggle is always available
- push the dashboard item down so the toggle doesn't overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b298afdc8327a9d13e8ee27397f9