### PR TITLE
Implement basic onboarding purchase flow

### DIFF
--- a/set-password.tsx
+++ b/set-password.tsx
@@ -48,9 +48,14 @@ export default function SetPasswordPage(): JSX.Element {
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">
         <h2 className="text-2xl font-bold mb-6 text-center">Set Password</h2>
-        <p className="mb-md text-left text-sm">
-          Password must be at least 8 characters and include uppercase, lowercase and a number.
-        </p>
+        <div className="mb-md text-left text-sm">
+          <p className="mb-sm">Password requirements:</p>
+          <ul className="list-disc list-inside text-left">
+            <li>At least 8 characters long</li>
+            <li>Contains both uppercase and lowercase letters</li>
+            <li>Includes at least one number</li>
+          </ul>
+        </div>
         {error && <div className="text-red-600 mb-4">{error}</div>}
         <form onSubmit={handleSubmit} noValidate>
           <div className="form-field">

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -37,6 +37,7 @@ const PurchasePage = () => {
       <div className="container">
         <h1 className="text-center mb-md">Purchase MindXdo</h1>
         <p className="text-center mb-lg">$6.95 per month<br />(Mindmap + Todo + Kanban System)</p>
+        <p className="text-center text-sm mb-lg text-gray-600">This is a simulated checkout. No real charges will occur.</p>
         <div className="two-column purchase-grid">
           <div className="relative">
             <div className="offer-card text-center">


### PR DESCRIPTION
## Summary
- add simulated checkout notice on purchase page
- show password requirements on set password page in bullet list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6885b2b3e6ec83279c8ac117409974cf