### PR TITLE
Implement simulated purchase flow

### DIFF
--- a/set-password.tsx
+++ b/set-password.tsx
@@ -9,6 +9,7 @@ export default function SetPasswordPage(): JSX.Element {
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
   const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
 
   const validate = () => {
     if (password.length < 8) {
@@ -37,7 +38,8 @@ export default function SetPasswordPage(): JSX.Element {
         body: JSON.stringify({ userId, password })
       })
       if (!res.ok) throw new Error('Failed')
-      navigate('/login')
+      setSuccess(true)
+      setTimeout(() => navigate('/login'), 1000)
     } catch {
       setError('Failed to set password.')
     }
@@ -57,6 +59,11 @@ export default function SetPasswordPage(): JSX.Element {
           </ul>
         </div>
         {error && <div className="text-red-600 mb-4">{error}</div>}
+        {success && (
+          <div className="text-green-600 mb-4" role="status">
+            Password set! Redirecting to login...
+          </div>
+        )}
         <form onSubmit={handleSubmit} noValidate>
           <div className="form-field">
             <label htmlFor="password" className="form-label">Password</label>

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -11,10 +11,16 @@ const PurchasePage = () => {
 
   const navigate = useNavigate()
 
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    setLoading(true)
     setMessage('')
+    if (!emailRegex.test(email)) {
+      setMessage('Please enter a valid email address.')
+      return
+    }
+    setLoading(true)
     try {
       const res = await fetch('/api/simulate-purchase', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- add email validation on the purchase page
- show success notice after setting password

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b3fb2e00832787a790b2187d07a3