### PR TITLE
Fix missing imports in layout components

### DIFF
--- a/layout.tsx
+++ b/layout.tsx
@@ -1,3 +1,10 @@
+import { useState, useRef, useEffect, type ReactNode, type KeyboardEvent } from 'react'
+import { NavLink } from 'react-router-dom'
+
+interface LayoutProps {
+  children: ReactNode
+}
+
 const Layout = ({ children }: LayoutProps): JSX.Element => {
   const [menuOpen, setMenuOpen] = useState(false);
   const navId = 'primary-navigation';

--- a/savemapbutton.tsx
+++ b/savemapbutton.tsx
@@ -1,4 +1,13 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { authFetch } from './authFetch'
+
+// Placeholder toast hook to avoid runtime errors if no library is integrated
+function useToast() {
+  return {
+    success: (msg: string) => console.log('toast success:', msg),
+    error: (msg: string) => console.error('toast error:', msg)
+  }
+}
 
 function isSaveMapResponse(obj: any): obj is SaveMapResponse {
   return obj != null && typeof obj.id === 'string'


### PR DESCRIPTION
## Summary
- add missing React imports to `layout.tsx`
- add React hooks and placeholder toast hook in `savemapbutton.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c32f06408327897d27b8ac711025