### PR TITLE
Fix sidebar visibility on canvas pages

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -382,7 +382,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const containerWidth =
       typeof width === 'number'
         ? `${width}px`
-        : width ?? '100vw'
+        : width ?? '100%'
     const containerHeight =
       typeof height === 'number'
         ? `${height}px`


### PR DESCRIPTION
## Summary
- adjust `MindmapCanvas` default container width so sidebar shows correctly on dashboards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885cd2cc8bc832783c2678dcf2e6c4d