### PR TITLE
Move stats to account page and restore sidebar toggle

### DIFF
--- a/account.tsx
+++ b/account.tsx
@@ -14,6 +14,29 @@ export default function AccountPage(): JSX.Element {
         </p>
         <button className="bg-red-600 text-white px-4 py-2 rounded">Cancel Account</button>
       </div>
+      <div className="form-card limit-tile">
+        <h2 className="text-xl font-semibold mb-2 text-center">Usage Limits</h2>
+        <table className="sidebar-metrics">
+          <tbody>
+            <tr>
+              <td className="metric-label">Mindmaps</td>
+              <td className="metric-value">1/10</td>
+            </tr>
+            <tr>
+              <td className="metric-label">Todo Lists</td>
+              <td className="metric-value">0/100</td>
+            </tr>
+            <tr>
+              <td className="metric-label">Kanban Boards</td>
+              <td className="metric-value">0/10</td>
+            </tr>
+            <tr>
+              <td className="metric-label">AI Automations</td>
+              <td className="metric-value">0/25 this month</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   )
 }

--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -33,12 +33,6 @@ export default function SidebarNav(): JSX.Element {
 
   const [sidebarWidth, setSidebarWidth] = useState(DESKTOP_WIDTH)
 
-  const metrics = [
-    { label: 'Mindmaps', value: '1/10' },
-    { label: 'Todo Lists', value: '0/100' },
-    { label: 'Kanban Boards', value: '0/10' },
-    { label: 'AI Automations', value: '0/25 this month' }
-  ]
 
   useEffect(() => {
     const updateWidth = () => {
@@ -76,16 +70,6 @@ export default function SidebarNav(): JSX.Element {
       >
         <span>{open ? '‹' : '›'}</span>
       </button>
-      <table className="sidebar-metrics">
-        <tbody>
-          {metrics.map(m => (
-            <tr key={m.label}>
-              <td className="metric-label">{m.label}</td>
-              <td className="metric-value">{m.value}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
       <nav>
         <ul>
           {mainLinks.map(link => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1514,7 +1514,7 @@ hr {
   .sidebar-drawer-toggle {
     position: absolute;
     top: 10px;
-    right: -40px;
+    right: -20px;
     left: auto;
     transform: none;
     z-index: 1100;
@@ -1533,7 +1533,7 @@ hr {
 .sidebar-drawer-toggle {
   position: absolute;
   top: 10px;
-  right: -40px;
+  right: -20px;
   left: auto;
   width: 40px;
   height: 40px;


### PR DESCRIPTION
## Summary
- move usage metrics from sidebar to a new tile on `/account`
- keep sidebar toggle visible when closed
- remove metrics from sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885cecfcfd08327823ecd789ffbee26