### PR TITLE
Fix sidebar toggle visibility

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -50,7 +50,7 @@ export default function SidebarNav(): JSX.Element {
 
   const sidebarVariants = {
     open: { x: 0 },
-    closed: { x: -(sidebarWidth - 20) }
+    closed: { x: -(sidebarWidth - 40) }
   }
 
   return (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1493,7 +1493,7 @@ hr {
   background-color: var(--color-bg-alt);
   padding: var(--spacing-lg) var(--spacing-md);
   position: relative;
-  overflow: hidden;
+  overflow: visible; // allow drawer toggle to remain fully visible
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- keep sidebar overflow visible so the toggle isn't clipped
- leave more space when the sidebar is closed so the toggle remains a circle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d16a56e48327ac2a64312ab8b336