### PR TITLE
Fix POST body handling

### DIFF
--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -75,6 +75,13 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
     }
 
     if (event.httpMethod === 'POST') {
+      if (!event.body) {
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Missing body' }),
+        }
+      }
       let payload: any
       try {
         payload = JSON.parse(event.body)


### PR DESCRIPTION
## Summary
- prevent JSON.parse error when event body is null in nodes function

## Testing
- `npm run compile:functions` *(fails: Cannot find module '@neondatabase/serverless' etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d493fee88327be52817ff5b32fa5