### PR TITLE
Fix quick create node payload

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -196,7 +196,11 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         console.log('[MindmapCanvas] Posting child node payload:', newNode)
 
         const nodeId = await createNode(newNode)
-        if (nodeId) addNode({ ...newNode, id: nodeId, todoId: null })
+        if (nodeId) {
+          addNode({ ...newNode, id: nodeId, todoId: null })
+        } else {
+          console.error('[MindmapCanvas] Failed to create node', newNode)
+        }
     }, [addNode, safeNodes, mindmapId, createNode])
 
     const openEditModal = useCallback((id: string) => {

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -158,6 +158,8 @@ export default function MapEditorPage(): JSX.Element {
         mindmapId: mindmap.id,
       }
 
+      console.log('[MapEditorPage] auto root node payload', generalNode)
+
       fetch('/.netlify/functions/nodes', {
         method: 'POST',
         credentials: 'include',


### PR DESCRIPTION
## Summary
- add console logging for auto root node creation
- warn when child node creation fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d67ca3f08327ad8540e688182987