### PR TITLE
Enable scrolling for kanban board

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1526,6 +1526,10 @@ hr {
   overflow: visible;
 }
 
+.app-sidebar.closed .sidebar-drawer-toggle {
+  z-index: 1200;
+}
+
 .app-sidebar.closed nav {
   display: none;
 }
@@ -2717,7 +2721,7 @@ hr {
 .scroll-container {
   width: 100%;
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: auto;
   white-space: nowrap;
   padding: 0 1rem;
   scrollbar-gutter: stable;


### PR DESCRIPTION
## Summary
- allow both vertical and horizontal scrolling in the kanban board canvas
- ensure the sidebar toggle remains visible when the drawer is closed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d66bae1c8327a54c41c4d02376a3