### PR TITLE
Fix default node creation

### DIFF
--- a/mindmapTypes.ts
+++ b/mindmapTypes.ts
@@ -1,12 +1,15 @@
-export interface NodeData {
-  id: string
+export interface NodePayload {
+  mindmapId: string
   x: number
   y: number
   label?: string
   description?: string
   parentId?: string | null
+}
+
+export interface NodeData extends NodePayload {
+  id: string
   todoId?: string | null
-  mindmapId?: string
 }
 
 export interface EdgeData {

--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -1,21 +1,29 @@
-import { Pool, PoolClient } from 'pg'
+import { Pool as PgPool, PoolClient } from 'pg'
+import { Pool as NeonPool } from '@neondatabase/serverless'
 
-const { DATABASE_URL: LOCAL_DB, NETLIFY_DATABASE_URL } = process.env
-const connectionString = LOCAL_DB || NETLIFY_DATABASE_URL
+const { DATABASE_URL: LOCAL_DB, NETLIFY_DATABASE_URL, NEON_DATABASE_URL } = process.env
+const connectionString = LOCAL_DB || NETLIFY_DATABASE_URL || NEON_DATABASE_URL
 
 if (!connectionString) {
   throw new Error('Missing DATABASE_URL')
 }
 
-console.info(
-  `db-client using ${LOCAL_DB ? 'DATABASE_URL' : 'NETLIFY_DATABASE_URL'} connection`
-)
+const source = LOCAL_DB
+  ? 'DATABASE_URL'
+  : NETLIFY_DATABASE_URL
+    ? 'NETLIFY_DATABASE_URL'
+    : 'NEON_DATABASE_URL'
+console.info(`db-client using ${source} connection`)
 
-export const pool = new Pool({
-  connectionString,
-  ssl:
-    process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : undefined,
-})
+const useNeon = !!NEON_DATABASE_URL && !LOCAL_DB
+
+export const pool = useNeon
+  ? new NeonPool({ connectionString })
+  : new PgPool({
+      connectionString,
+      ssl:
+        process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : undefined,
+    })
 
 export async function getClient(): Promise<PoolClient> {
   return pool.connect()

--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -3,21 +3,13 @@ import { getClient } from './db-client.js'
 import type { PoolClient } from 'pg'
 import { validate as isUuid } from 'uuid'
 import { requireAuth } from './middleware.js'
+import type { NodePayload } from './types.js'
 
 // Node creation rules:
 // - A mindmap may contain only one root node (parentId null).
 // - The first root node defaults to the canvas center if no coordinates are
 //   provided.
 // - Child nodes require a parentId and coordinates relative to that parent.
-
-interface NodePayload {
-  mindmapId: string
-  x: number
-  y: number
-  label?: string
-  description?: string
-  parentId?: string | null
-}
 
 async function isFirstNodeForMindmap(
   client: PoolClient,

--- a/netlify/functions/types.ts
+++ b/netlify/functions/types.ts
@@ -17,6 +17,15 @@ export interface TodoList {
   updated_at: string
 }
 
+export interface NodePayload {
+  mindmapId: string
+  x: number
+  y: number
+  label?: string
+  description?: string
+  parentId?: string | null
+}
+
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 
 export interface HandlerResponse {

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { useState, useEffect, useCallback } from 'react'
 import MindmapCanvas from './MindmapCanvas'
-import type { NodeData, EdgeData } from '../mindmapTypes'
+import type { NodeData, NodePayload, EdgeData } from '../mindmapTypes'
 import { authFetch } from '../authFetch'
 import LoadingSpinner from '../loadingspinner'
 
@@ -149,7 +149,7 @@ export default function MapEditorPage(): JSX.Element {
       const rootX = 400
       const rootY = 300
 
-      const generalNode = {
+      const generalNode: NodePayload = {
         x: rootX,
         y: rootY,
         label: 'General',


### PR DESCRIPTION
## Summary
- add shared NodePayload type and extend NodeData
- use NodePayload for auto creation in MapEditorPage
- update nodes function to import shared type
- improve database client to detect Neon URLs and use `@neondatabase/serverless`

## Testing
- `npm test`
- `npm run compile:functions` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6886096d0090832797d08919323e46fb