### PR TITLE
Expand Kanban canvas with horizontal scroll

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2315,6 +2315,12 @@ hr {
   margin-right: 4px;
 }
 
+.kanban-canvas {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 80px);
+}
+
 .kanban-canvas .card-form {
   margin-bottom: var(--spacing-sm);
 }
@@ -2721,12 +2727,12 @@ hr {
 
 .scroll-container {
   width: 100%;
+  flex: 1;
   overflow-x: auto;
   overflow-y: auto;
   white-space: nowrap;
   padding: 0 1rem;
   scrollbar-gutter: stable;
-  height: calc(100vh - 80px);
 }
 
 .scroll-container::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- let the Kanban canvas grow with content
- make the scroll container flex so horizontal scroll sits at the bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68869b88a21c83279d34104ae3c3df30