### PR TITLE
Fix null body handling in nodes.ts

### DIFF
--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -67,6 +67,13 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
     }
 
     if (event.httpMethod === 'POST') {
+      if (!event.body) {
+        return {
+          statusCode: 400,
+          headers,
+          body: JSON.stringify({ error: 'Missing body' }),
+        }
+      }
       let payload: any
       try {
         payload = JSON.parse(event.body)


### PR DESCRIPTION
## Summary
- ensure POST requests to `nodes` validate that a body exists before parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68869c278e588327919ab3492a7162eb