### PR TITLE
Handle empty node inputs

### DIFF
--- a/mindmapTypes.ts
+++ b/mindmapTypes.ts
@@ -1,9 +1,9 @@
 export interface NodePayload {
   mindmapId: string
-  x: number
-  y: number
-  label?: string
-  description?: string
+  x?: number
+  y?: number
+  label?: string | null
+  description?: string | null
   parentId?: string | null
 }
 

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -39,10 +39,10 @@ interface MindmapCanvasHandle {
 
 interface NodePayload {
   mindmapId: string
-  x: number
-  y: number
-  label?: string
-  description?: string
+  x?: number
+  y?: number
+  label?: string | null
+  description?: string | null
   parentId?: string | null
 }
 

--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -86,7 +86,7 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       }
 
       // Validate mindmapId
-      if (!payload.mindmapId || !isUuid(payload.mindmapId)) {
+      if (typeof payload.mindmapId !== 'string' || !isUuid(payload.mindmapId)) {
         return {
           statusCode: 400,
           headers,
@@ -95,17 +95,25 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       }
 
       // Default values and type checks
-      const x = typeof payload.x === 'number' ? payload.x : 0
-      const y = typeof payload.y === 'number' ? payload.y : 0
+      const x =
+        typeof payload.x === 'number' && Number.isFinite(payload.x)
+          ? payload.x
+          : 0
+      const y =
+        typeof payload.y === 'number' && Number.isFinite(payload.y)
+          ? payload.y
+          : 0
       const label =
         typeof payload.label === 'string' && payload.label.trim() !== ''
           ? payload.label.trim()
-          : 'General'
+          : 'Untitled'
       const description =
-        typeof payload.description === 'string' ? payload.description.trim() : ''
+        typeof payload.description === 'string' && payload.description.trim() !== ''
+          ? payload.description.trim()
+          : null
 
       let parentId: string | null = null
-      if (payload.parentId !== undefined && payload.parentId !== null) {
+      if (payload.parentId) {
         if (typeof payload.parentId === 'string' && isUuid(payload.parentId)) {
           parentId = payload.parentId
         } else {

--- a/netlify/functions/types.ts
+++ b/netlify/functions/types.ts
@@ -19,10 +19,10 @@ export interface TodoList {
 
 export interface NodePayload {
   mindmapId: string
-  x: number
-  y: number
-  label?: string
-  description?: string
+  x?: number
+  y?: number
+  label?: string | null
+  description?: string | null
   parentId?: string | null
 }
 


### PR DESCRIPTION
## Summary
- loosen validation around mindmap node creation
- mark `description` and other fields optional in node payloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886a51415e08327a062c590673815e0