### PR TITLE
Fix tile layout

### DIFF
--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -171,18 +171,6 @@ export default function KanbanBoardsPage(): JSX.Element {
                   <header className="tile-header">
                     <h2>{b.title || 'Board'}</h2>
                     <div className="tile-actions">
-                      <button
-                        className="btn btn-primary"
-                        onClick={() => {
-                          localStorage.setItem(
-                            `board_last_viewed_${b.id}`,
-                            Date.now().toString()
-                          )
-                          navigate(`/kanban/${b.id}`)
-                        }}
-                      >
-                        Open
-                      </button>
                       <a
                         href="#"
                         className="tile-link delete-link"
@@ -196,6 +184,18 @@ export default function KanbanBoardsPage(): JSX.Element {
                     </div>
                   </header>
                   <section className="tile-body">
+                    <button
+                      className="btn btn-primary"
+                      onClick={() => {
+                        localStorage.setItem(
+                          `board_last_viewed_${b.id}`,
+                          Date.now().toString()
+                        )
+                        navigate(`/kanban/${b.id}`)
+                      }}
+                    >
+                      Open
+                    </button>
                     <p>Board details coming soon...</p>
                   </section>
                 </div>

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -180,18 +180,6 @@ export default function MindmapsPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{m.title || m.data?.title || 'Untitled Map'}</h2>
                   <div className="tile-actions">
-                    <button
-                      className="btn btn-primary"
-                      onClick={() => {
-                        localStorage.setItem(
-                          `mindmap_last_viewed_${m.id}`,
-                          Date.now().toString()
-                        )
-                        navigate(`/maps/${m.id}`)
-                      }}
-                    >
-                      Open
-                    </button>
                     <a
                       href="#"
                       className="tile-link delete-link"
@@ -205,6 +193,18 @@ export default function MindmapsPage(): JSX.Element {
                   </div>
                 </header>
                 <section className="tile-body">
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => {
+                      localStorage.setItem(
+                        `mindmap_last_viewed_${m.id}`,
+                        Date.now().toString()
+                      )
+                      navigate(`/maps/${m.id}`)
+                    }}
+                  >
+                    Open
+                  </button>
                   <p>{m.data?.description || 'Map details coming soon...'}</p>
                 </section>
               </div>

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -179,9 +179,6 @@ export default function TodosPage(): JSX.Element {
                 <header className="tile-header">
                   <h2>{list.title}</h2>
                   <div className="tile-actions">
-                    <button className="btn btn-primary" onClick={() => navigate(`/todos/${list.id}`)}>
-                      Open
-                    </button>
                     {list.id && (
                       <a
                         href="#"
@@ -197,6 +194,9 @@ export default function TodosPage(): JSX.Element {
                   </div>
                 </header>
                 <section className="tile-body">
+                  <button className="btn btn-primary" onClick={() => navigate(`/todos/${list.id}`)}>
+                    Open
+                  </button>
                   {list.id === null ? (
                     <ul className="todo-items">
                       {list.todos.map(t => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -1704,6 +1704,8 @@ hr {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: var(--spacing-lg);
+  grid-auto-rows: 1fr;
+  align-items: stretch;
 }
 
 .dashboard-tile {
@@ -1717,8 +1719,8 @@ hr {
   flex-direction: column;
   justify-content: space-between;
   gap: var(--spacing-sm);
-  max-height: 240px;
   min-height: 200px;
+  height: 100%;
   overflow-y: hidden;
 }
 
@@ -1775,6 +1777,7 @@ hr {
   align-items: flex-start;
   gap: var(--spacing-md);
   min-height: 120px;
+  height: 100%;
   color: var(--color-text-inverse);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   backdrop-filter: blur(8px);
@@ -2091,6 +2094,18 @@ hr {
 .open-tile {
   border: 1px dashed #fbd8a8;
   background: linear-gradient(135deg, #f8f8f8, #fff8ec);
+}
+
+.open-tile .tile-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.open-tile .tile-body p {
+  margin-top: 0.5rem;
 }
 
 .tile-header-center {


### PR DESCRIPTION
## Summary
- force each dashboard row to stretch tiles to the same height
- center the open action within open tiles and reposition placeholder text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886a5abad34832793bce26238336200