### PR TITLE
Redirect user to new kanban board

### DIFF
--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -123,7 +123,7 @@ export default function DashboardPage(): JSX.Element {
           body: JSON.stringify({ title: form.title }),
         })
       } else {
-        await fetch('/.netlify/functions/boards', {
+        const res = await fetch('/.netlify/functions/boards', {
           method: 'POST',
           credentials: 'include', // Required for session cookie
           headers: {
@@ -131,6 +131,10 @@ export default function DashboardPage(): JSX.Element {
           },
           body: JSON.stringify({ title: form.title, description: form.description }),
         })
+        const data = await res.json()
+        if (data?.id) {
+          setTimeout(() => navigate(`/kanban/${data.id}`), 250)
+        }
       }
       setShowModal(false)
       setForm({ title: '', description: '' })
@@ -160,11 +164,15 @@ export default function DashboardPage(): JSX.Element {
           body: JSON.stringify({ title: form.title })
         })
       } else {
-        await fetch('/api/boards', {
+        const res = await fetch('/api/boards', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title: form.title })
         })
+        const data = await res.json()
+        if (data?.id) {
+          setTimeout(() => navigate(`/kanban/${data.id}`), 250)
+        }
       }
       setShowModal(false)
       setForm({ title: '', description: '' })

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -61,7 +61,12 @@ export default function KanbanBoardsPage(): JSX.Element {
       const data = await res.json()
       console.log('[Kanban] Board created:', data)
       setShowModal(false)
-      fetchBoards()
+      setForm({ title: '', description: '' })
+      if (data?.id) {
+        navigate(`/kanban/${data.id}`)
+      } else {
+        fetchBoards()
+      }
     } catch (err: any) {
       console.error('[Kanban Modal Save] Error:', err)
       alert(err.message)


### PR DESCRIPTION
## Summary
- redirect to new board when saving a board
- redirect to new board when creating from dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b143ceec8327b3c254e0a75c5d1d