### PR TITLE
Add horizontal scroll to Kanban board

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2334,6 +2334,8 @@ hr {
   display: flex;
   flex-direction: column;
   min-height: calc(100vh - 80px);
+  /* allow horizontal scrolling as lanes overflow */
+  overflow-x: auto;
 }
 
 .kanban-canvas .card-form {


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in Kanban canvas so columns stay reachable as more lanes are created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b2fea3c8832780f05d877cade2e5