### PR TITLE
Enable kanban horizontal scroll

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -347,12 +347,15 @@ export default function InteractiveKanbanBoard({
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">
           {provided => (
-            <div className="scroll-container" ref={autoScrollRightRef}>
-              <div
-                className="kanban-board"
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-              >
+            <div
+              className="scroll-container"
+              ref={el => {
+                autoScrollRightRef.current = el
+                provided.innerRef(el)
+              }}
+              {...provided.droppableProps}
+            >
+              <div className="kanban-board">
                 {sortedLanes.map((lane, i) => (
                   <Draggable key={lane.id} draggableId={lane.id} index={i} isDragDisabled={lane.title === 'Done'}>
                     {providedLane => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -2748,7 +2748,7 @@ hr {
   overflow-x: auto;
   overflow-y: auto;
   white-space: nowrap;
-  padding: 0 1rem;
+  padding: 0 1rem 0.5rem;
   scrollbar-gutter: stable;
 }
 


### PR DESCRIPTION
## Summary
- attach droppable ref to the scroll container so horizontal overflow works
- give scroll container bottom padding so the scrollbar is visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b647ec7c8327b0f3003509fcd12e