### PR TITLE
Fix compile errors in nodes function

### DIFF
--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -103,7 +103,8 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
           'SELECT id FROM mindmaps WHERE id = $1',
           [payload.mindmapId]
         )
-        if (result.rowCount > 0) {
+        const count = result.rowCount ?? 0
+        if (count > 0) {
           mindmapExists = true
           break
         }
@@ -124,7 +125,8 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
           'SELECT id FROM mindmaps WHERE id = $1',
           [payload.mindmapId]
         )
-        mindmapExists = finalCheck.rowCount > 0
+        const finalCount = finalCheck.rowCount ?? 0
+        mindmapExists = finalCount > 0
       }
 
       if (!mindmapExists) {


### PR DESCRIPTION
## Summary
- guard against null `rowCount` when checking if a mindmap exists

## Testing
- `npm test`
- `npm run compile:functions` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6886b9c201288327af3b9923f152ddc1