### PR TITLE
Fix null checks for rowCount

### DIFF
--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -103,7 +103,7 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
           'SELECT id FROM mindmaps WHERE id = $1',
           [payload.mindmapId]
         )
-        const count = result.rowCount ?? 0
+        const count = typeof result.rowCount === 'number' ? result.rowCount : 0
         if (count > 0) {
           mindmapExists = true
           break
@@ -125,7 +125,8 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
           'SELECT id FROM mindmaps WHERE id = $1',
           [payload.mindmapId]
         )
-        const finalCount = finalCheck.rowCount ?? 0
+        const finalCount =
+          typeof finalCheck.rowCount === 'number' ? finalCheck.rowCount : 0
         mindmapExists = finalCount > 0
       }
 


### PR DESCRIPTION
## Summary
- prevent TypeScript errors about possible `null` rowCount in the nodes function

## Testing
- `npm run compile:functions` *(fails: Cannot find module '@netlify/functions', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6886bb517d248327a64df4c6b1cfd533