### PR TITLE
Fix horizontal scroll on kanban boards

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2344,7 +2344,9 @@ hr {
   display: flex;
   flex-direction: row;
   gap: 1rem;
-  overflow: visible;
+  /* show horizontal scrollbar when lanes overflow */
+  overflow-x: auto;
+  overflow-y: visible;
   scrollbar-gutter: stable;
 }
 


### PR DESCRIPTION
## Summary
- fix Kanban board overflow so lanes show a bottom scrollbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886bc83e91c83279518663aa38fefe4