### PR TITLE
Fix node id generation

### DIFF
--- a/migrations/036_verify_nodes_id_default.sql
+++ b/migrations/036_verify_nodes_id_default.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'nodes'
+      AND column_name = 'id'
+      AND column_default IS NOT NULL
+  ) THEN
+    ALTER TABLE nodes ALTER COLUMN id SET DEFAULT gen_random_uuid();
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- ensure nodes table has default uuid generator by verifying in migration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886cc88c3f88327a23aa50a63199783