### PR TITLE
Fix nodes id default

### DIFF
--- a/migrations/037_confirm_nodes_id_default.sql
+++ b/migrations/037_confirm_nodes_id_default.sql
@@ -1,0 +1,12 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'nodes'
+      AND column_name = 'id'
+      AND column_default IS NOT NULL
+  ) THEN
+    ALTER TABLE nodes ALTER COLUMN id SET DEFAULT gen_random_uuid();
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- make sure node creation uses `mindmapId` variable consistently
- add a migration to confirm the `nodes.id` default exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886cf81a5c0832792377061e869d4de