### PR TITLE
Add scroll buttons

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -79,6 +79,17 @@ export default function InteractiveKanbanBoard({
   const [commenting, setCommenting] = useState<{ laneId: string; card: Card } | null>(null)
   const autoScrollRightRef = useRef<HTMLDivElement | null>(null)
 
+  const scrollByColumn = (dir: number) => {
+    const container = autoScrollRightRef.current
+    if (!container) return
+    const lane = container.querySelector<HTMLElement>('.lane-wrapper')
+    const laneWidth = lane?.offsetWidth || 300
+    const gap = parseInt(
+      getComputedStyle(container.querySelector('.kanban-board') as HTMLElement).gap || '0'
+    )
+    container.scrollBy({ left: dir * (laneWidth + gap), behavior: 'smooth' })
+  }
+
   useEffect(() => {
     if (!columns) return
     const colMap = new Map<string, Card[]>()
@@ -344,6 +355,20 @@ export default function InteractiveKanbanBoard({
           <button className="settings-button" aria-label="Settings">⋯</button>
         </div>
       </header>
+      <button
+        className="scroll-btn left"
+        aria-label="Scroll left"
+        onClick={() => scrollByColumn(-1)}
+      >
+        ‹
+      </button>
+      <button
+        className="scroll-btn right"
+        aria-label="Scroll right"
+        onClick={() => scrollByColumn(1)}
+      >
+        ›
+      </button>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">
           {provided => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -2329,10 +2329,9 @@ hr {
 
 .kanban-canvas {
   display: flex;
+  position: relative;
   flex-direction: column;
   min-height: calc(100vh - 80px);
-  /* extend width to enable scrolling */
-  width: 200%;
   /* allow horizontal scrolling as lanes overflow */
   overflow-x: auto;
 }
@@ -2760,6 +2759,27 @@ hr {
 .kanban-scroll-spacer {
   min-width: 150px;
   flex-shrink: 0;
+}
+
+.scroll-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  background: var(--color-bg);
+  border: none;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+  border-radius: 50%;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.scroll-btn.left {
+  left: 0.25rem;
+}
+
+.scroll-btn.right {
+  right: 0.25rem;
 }
 
 .kanban-board {


### PR DESCRIPTION
## Summary
- remove fixed width from kanban canvas and make it relative positioned
- add left/right scroll buttons for the kanban board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886d05e1c3c8327bda5cc72706f0bcc