### PR TITLE
Fix todo input width

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -3622,7 +3622,8 @@ hr {
 }
 
 .todo-add-input {
-  flex: 1;
+  width: 100%;
+  flex-shrink: 0;
   padding: 0.6rem 1rem;
   font-size: 1rem;
   border: 1px solid #ccc;
@@ -3689,7 +3690,8 @@ hr {
   .todo-list,
   .todo-block,
   .todo-add-form,
-  .todo-add-wrapper {
+  .todo-add-wrapper,
+  .todo-add-input {
     width: 70%;
   }
 }


### PR DESCRIPTION
## Summary
- match the width of the add-todo input with other todo blocks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886d15ac59c8327b72efd430f7d7471