### PR TITLE
Improve Kanban board scrolling

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2332,8 +2332,9 @@ hr {
   position: relative;
   flex-direction: column;
   min-height: calc(100vh - 80px);
-  /* allow horizontal scrolling as lanes overflow */
+  /* allow scrolling when board overflows */
   overflow-x: auto;
+  overflow-y: auto;
 }
 
 .kanban-canvas .card-form {
@@ -2762,10 +2763,10 @@ hr {
 }
 
 .scroll-btn {
-  position: absolute;
+  position: fixed;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 10;
+  z-index: 1000;
   background: var(--color-bg);
   border: none;
   box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
## Summary
- add vertical scrolling to the Kanban canvas
- keep scroll buttons fixed to viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886d9cea83483278b3204791aa9051c