### PR TITLE
Align todo-add input width

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -3711,8 +3711,7 @@ hr {
   .todo-list,
   .todo-block,
   .todo-add-form,
-  .todo-add-wrapper,
-  .todo-add-input {
+  .todo-add-wrapper {
     width: 70%;
   }
 }


### PR DESCRIPTION
## Summary
- ensure `.todo-add-input` retains full width in responsive styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886dbbcb0c88327ab7073562a5cd605