### PR TITLE
Move send all button position in todo list

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -214,12 +214,12 @@ export default function TodoCanvas({
       <h3 className="todo-completion">
         {completedCount}/{totalCount} completed
       </h3>
-      <button className="btn-secondary" onClick={openSendAllDialog} style={{marginBottom:'8px'}}>
-        Send All To Kanban
-      </button>
       <div className="todo-list">
         {activeTodos.map(renderTodo)}
       </div>
+      <button className="btn-secondary" onClick={openSendAllDialog} style={{ marginBottom: '8px' }}>
+        Send All To Kanban
+      </button>
       {!adding && (
         <button className="todo-add-circle" onClick={() => setAdding(true)}>+
         </button>


### PR DESCRIPTION
## Summary
- place the "Send All To Kanban" button after the todo list items so it displays above the add-todo section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886dcbdad608327bbb7f19c818bb044