### PR TITLE
Fix todo add block width

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -3625,8 +3625,8 @@ hr {
 }
 
 .todo-add-block {
-  margin-top: 1rem;
-  margin-bottom: 2rem;
+  width: min(600px, 80%);
+  margin: 1rem auto 2rem;
   text-align: center;
 }
 
@@ -3643,8 +3643,7 @@ hr {
 }
 
 .todo-add-input {
-  width: 100%;
-  flex-shrink: 0;
+  flex: 1;
   padding: 0.6rem 1rem;
   font-size: 1rem;
   border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- align `.todo-add-block` width with `.todo-block`
- let `.todo-add-input` expand to fill available space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e0e361e88327aecc8cb0fbc73688