### PR TITLE
Fix mindmap deletion CORS

### DIFF
--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -11,7 +11,7 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
   const headers = {
     'Content-Type': 'application/json',
     'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   }
 


### PR DESCRIPTION
## Summary
- add DELETE to `Access-Control-Allow-Methods` header for mindmaps API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e47d32c0832793e7a5ddd69be69e