### PR TITLE
Make tile metrics horizontal

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -1887,9 +1887,11 @@ hr {
   padding-top: var(--spacing-md);
   border-top: 1px solid var(--color-border);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: center;
   align-items: center;
   gap: var(--spacing-sm);
+  flex-wrap: wrap;
 }
 
 .metric-detail {


### PR DESCRIPTION
## Summary
- show dashboard tile stats in a row instead of stacked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e59108c0832799808441ac89d4f2