### PR TITLE
Improve kanban scrolling

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -79,17 +79,6 @@ export default function InteractiveKanbanBoard({
   const [commenting, setCommenting] = useState<{ laneId: string; card: Card } | null>(null)
   const autoScrollRightRef = useRef<HTMLDivElement | null>(null)
 
-  const scrollByColumn = (dir: number) => {
-    const container = autoScrollRightRef.current
-    if (!container) return
-    const lane = container.querySelector<HTMLElement>('.lane-wrapper')
-    const laneWidth = lane?.offsetWidth || 300
-    const gap = parseInt(
-      getComputedStyle(container.querySelector('.kanban-board') as HTMLElement).gap || '0'
-    )
-    container.scrollBy({ left: dir * (laneWidth + gap), behavior: 'smooth' })
-  }
-
   useEffect(() => {
     if (!columns) return
     const colMap = new Map<string, Card[]>()
@@ -355,20 +344,6 @@ export default function InteractiveKanbanBoard({
           <button className="settings-button" aria-label="Settings">⋯</button>
         </div>
       </header>
-      <button
-        className="scroll-btn left"
-        aria-label="Scroll left"
-        onClick={() => scrollByColumn(-1)}
-      >
-        ‹
-      </button>
-      <button
-        className="scroll-btn right"
-        aria-label="Scroll right"
-        onClick={() => scrollByColumn(1)}
-      >
-        ›
-      </button>
       <DragDropContext onDragEnd={handleDragEnd}>
         <Droppable droppableId="board" type="COLUMN" direction="horizontal">
           {provided => (

--- a/src/global.scss
+++ b/src/global.scss
@@ -2763,30 +2763,10 @@ hr {
 }
 
 .kanban-scroll-spacer {
-  min-width: 150px;
+  min-width: 2rem;
   flex-shrink: 0;
 }
 
-.scroll-btn {
-  position: fixed;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1000;
-  background: var(--color-bg);
-  border: none;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
-  border-radius: 50%;
-  padding: 0.25rem 0.5rem;
-  cursor: pointer;
-}
-
-.scroll-btn.left {
-  left: 0.25rem;
-}
-
-.scroll-btn.right {
-  right: 0.25rem;
-}
 
 .kanban-board {
   display: flex;
@@ -2794,8 +2774,8 @@ hr {
   align-items: flex-start;
   gap: 1rem;
   min-width: max-content;
-  padding-right: 150px;
-  padding-bottom: 150px;
+  padding-right: 2rem;
+  padding-bottom: 2rem;
   min-height: calc(100vh - 80px);
 }
 


### PR DESCRIPTION
## Summary
- remove arrow buttons from the kanban board
- rely on scrollbars for navigation
- shrink padding and spacer for better scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886e98582648327995eb58a77e6a697