### PR TITLE
Enable horizontal scrolling on Kanban board

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import useDragScroll from './useDragScroll'
 import {
   DragDropContext,
   Droppable,
@@ -78,6 +79,8 @@ export default function InteractiveKanbanBoard({
   const [editing, setEditing] = useState<{ laneId: string; card: Card } | null>(null)
   const [commenting, setCommenting] = useState<{ laneId: string; card: Card } | null>(null)
   const autoScrollRightRef = useRef<HTMLDivElement | null>(null)
+  const boardRef = useRef<HTMLDivElement | null>(null)
+  useDragScroll(boardRef)
 
   useEffect(() => {
     if (!columns) return
@@ -362,6 +365,7 @@ export default function InteractiveKanbanBoard({
             <div
               className="kanban-board-container"
               ref={el => {
+                boardRef.current = el
                 autoScrollRightRef.current = el
                 provided.innerRef(el)
               }}

--- a/src/global.scss
+++ b/src/global.scss
@@ -2745,13 +2745,15 @@ hr {
 .kanban-board-container {
   width: 100%;
   flex: 1;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: hidden;
   white-space: nowrap;
   padding: 0 1rem 0.5rem;
   scrollbar-gutter: stable;
   scrollbar-width: 25px;
   scrollbar-color: #c1c1c1 #f1f1f1;
   -ms-overflow-style: scrollbar;
+  cursor: grab;
 }
 
 .kanban-board-container::-webkit-scrollbar {
@@ -2776,6 +2778,10 @@ hr {
 
 .kanban-board-container::-webkit-scrollbar-corner {
   background: #f1f1f1;
+}
+
+.kanban-board-container.drag-scroll-active {
+  cursor: grabbing;
 }
 
 @media (max-width: 768px) {

--- a/useDragScroll.ts
+++ b/useDragScroll.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react'
+
+export default function useDragScroll(ref: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    let isDragging = false
+    let startX = 0
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.pointerType === 'mouse' && e.button !== 0) return
+      isDragging = true
+      startX = e.clientX
+      el.classList.add('drag-scroll-active')
+      el.setPointerCapture(e.pointerId)
+    }
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!isDragging) return
+      const dx = e.clientX - startX
+      el.scrollLeft -= dx
+      startX = e.clientX
+    }
+
+    const endDrag = (e: PointerEvent) => {
+      if (!isDragging) return
+      isDragging = false
+      el.classList.remove('drag-scroll-active')
+      el.releasePointerCapture(e.pointerId)
+    }
+
+    el.addEventListener('pointerdown', onPointerDown)
+    el.addEventListener('pointermove', onPointerMove)
+    el.addEventListener('pointerup', endDrag)
+    el.addEventListener('pointercancel', endDrag)
+
+    return () => {
+      el.removeEventListener('pointerdown', onPointerDown)
+      el.removeEventListener('pointermove', onPointerMove)
+      el.removeEventListener('pointerup', endDrag)
+      el.removeEventListener('pointercancel', endDrag)
+    }
+  }, [ref])
+}


### PR DESCRIPTION
## Summary
- add a `useDragScroll` hook to allow grab-to-scroll interactions
- wire the hook into `InteractiveKanbanBoard`
- tweak Kanban board styles to show a scrollbar and dragging cursor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886fdd1cc708327b7e48cb44fed45a0