### PR TITLE
Fix Kanban scrolling

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -80,7 +80,9 @@ export default function InteractiveKanbanBoard({
   const [commenting, setCommenting] = useState<{ laneId: string; card: Card } | null>(null)
   const autoScrollRightRef = useRef<HTMLDivElement | null>(null)
   const boardRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLDivElement | null>(null)
   useDragScroll(boardRef)
+  useDragScroll(canvasRef)
 
   useEffect(() => {
     if (!columns) return
@@ -346,7 +348,7 @@ export default function InteractiveKanbanBoard({
   }
 
   return (
-    <div className="kanban-canvas">
+    <div className="kanban-canvas" ref={canvasRef}>
       <header className="kanban-header">
         <div className="header-left">
           <div className="kanban-icon" aria-hidden="true">🗂️</div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2335,8 +2335,9 @@ hr {
   position: relative;
   flex-direction: column;
   min-height: calc(100vh - 80px);
-  /* scrolling handled by kanban-board-container */
-  overflow: hidden;
+  /* allow horizontal scrolling when many lanes are present */
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .kanban-canvas .card-form {


### PR DESCRIPTION
## Summary
- allow horizontal scrolling in the kanban canvas
- enable drag scrolling from anywhere in the canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886ff7ba6008327b8e1af8cd2a34c01