### PR TITLE
Persist edits for mindmap nodes

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -252,6 +252,11 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       if (!node) return
       const updated = { ...node, label: editTitle, description: editDesc }
       updateNode(updated)
+      authFetch(`/.netlify/functions/nodes/${editingId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: editTitle, description: editDesc })
+      }).catch(err => console.error('[MindmapCanvas] update failed', err))
       setEditingId(null)
       setEditTitle('')
       setEditDesc('')


### PR DESCRIPTION
## Summary
- add API call when saving edits in `MindmapCanvas`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886ffc9ec288327855431eeb019b406