### PR TITLE
Fix kanban card move

### DIFF
--- a/netlify/functions/kanban-cards.ts
+++ b/netlify/functions/kanban-cards.ts
@@ -78,7 +78,7 @@ export const handler: Handler = async (event) => {
     }
 
     const path = event.path
-    const moveMatch = path.match(/kanban-cards\/([^/]+)\/move/)
+    const moveMatch = path.match(/cards\/([^/]+)\/move/)
     if (moveMatch) {
       const cardId = moveMatch[1]
       if (!event.body) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing body' }) }
@@ -102,7 +102,7 @@ export const handler: Handler = async (event) => {
       return { statusCode: 200, headers, body: JSON.stringify({ id: cardId }) }
     }
 
-    const match = path.match(/kanban-cards\/([^/]+)/)
+    const match = path.match(/cards\/([^/]+)/)
     const cardId = match?.[1]
     if (!cardId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing card id' }) }
 

--- a/netlify/functions/kanban-columns.ts
+++ b/netlify/functions/kanban-columns.ts
@@ -23,7 +23,7 @@ export const handler: Handler = async (event) => {
 
   const client = await getClient()
   try {
-    if (event.httpMethod === 'PATCH' && /kanban-columns$/.test(event.path)) {
+    if (event.httpMethod === 'PATCH' && /columns$/.test(event.path)) {
       if (!event.body) {
         return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing body' }) }
       }
@@ -65,7 +65,7 @@ export const handler: Handler = async (event) => {
       return { statusCode: 201, headers, body: JSON.stringify(res.rows[0]) }
     }
 
-    const match = event.path.match(/kanban-columns\/(.+)/)
+    const match = event.path.match(/columns\/(.+)/)
     const colId = match?.[1]
     if (!colId) {
       return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing column id' }) }


### PR DESCRIPTION
## Summary
- allow `/api/kanban/cards/:id/move` requests to match by relaxing regex
- update columns endpoint regex as well

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688703f284c88327ae72141e1bab0aca