### PR TITLE
Fix CommentsModal jsx typo

### DIFF
--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -89,7 +89,7 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
                 <div className="comment-body">{highlightMentions((c as any).comment || c.text)}</div>
               </div>
             )
-          })
+          })}
         </div>
         <div className="comment-input-bar">
           <textarea


### PR DESCRIPTION
## Summary
- close expression for `comments.map` in `CommentsModal.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887064a11c8832798e439030a2fab33