### PR TITLE
Fix Kanban board scrolling

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect } from 'react'
-import useDragScroll from './useDragScroll'
 import {
   DragDropContext,
   Droppable,
@@ -80,9 +79,6 @@ export default function InteractiveKanbanBoard({
   const [commenting, setCommenting] = useState<{ laneId: string; card: Card } | null>(null)
   const autoScrollRightRef = useRef<HTMLDivElement | null>(null)
   const boardRef = useRef<HTMLDivElement | null>(null)
-  const canvasRef = useRef<HTMLDivElement | null>(null)
-  useDragScroll(boardRef)
-  useDragScroll(canvasRef)
 
   useEffect(() => {
     if (!columns) return
@@ -348,7 +344,7 @@ export default function InteractiveKanbanBoard({
   }
 
   return (
-    <div className="kanban-canvas" ref={canvasRef}>
+    <div className="kanban-canvas">
       <header className="kanban-header">
         <div className="header-left">
           <div className="kanban-icon" aria-hidden="true">🗂️</div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2754,7 +2754,6 @@ hr {
   scrollbar-width: 25px;
   scrollbar-color: #c1c1c1 #f1f1f1;
   -ms-overflow-style: scrollbar;
-  cursor: grab;
 }
 
 .kanban-board-container::-webkit-scrollbar {
@@ -2781,9 +2780,6 @@ hr {
   background: #f1f1f1;
 }
 
-.kanban-board-container.drag-scroll-active {
-  cursor: grabbing;
-}
 
 @media (max-width: 768px) {
   .kanban-board-container {


### PR DESCRIPTION
## Summary
- remove the drag-scroll hook from the interactive Kanban board
- clean up CSS so the board no longer shows a grab cursor
- rely on scrollbars for navigating wide boards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688705e4ea3083278ca00da6e6c29cb2