### PR TITLE
Add horizontal scroll to kanban canvas

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2341,8 +2341,8 @@ hr {
   position: relative;
   flex-direction: column;
   min-height: calc(100vh - 80px);
-  /* allow horizontal scrolling when many lanes are present */
-  overflow-x: auto;
+  /* contain scrollbars to the board container */
+  overflow-x: hidden;
   overflow-y: hidden;
 }
 
@@ -2754,6 +2754,8 @@ hr {
   flex: 1;
   overflow-x: auto;
   overflow-y: hidden;
+  display: flex;
+  align-items: flex-start;
   white-space: nowrap;
   padding: 0 1rem 0.5rem;
   scrollbar-gutter: stable;


### PR DESCRIPTION
## Summary
- confine scrollbars to the board container
- ensure kanban board container is flex and scrollable horizontally

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68870d4b9e7483278e9693622720aedb