### PR TITLE
Enable horizontal scrolling for Kanban canvas

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2341,8 +2341,8 @@ hr {
   position: relative;
   flex-direction: column;
   min-height: calc(100vh - 80px);
-  /* contain scrollbars to the board container */
-  overflow-x: hidden;
+  /* allow horizontal overflow so board can scroll */
+  overflow-x: auto;
   overflow-y: hidden;
 }
 


### PR DESCRIPTION
## Summary
- allow the Kanban canvas container to scroll horizontally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688711e84e3483279a18bf31fda75baa