### PR TITLE
Fix kanban horizontal scrolling

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2752,6 +2752,7 @@ hr {
 .kanban-board-container {
   width: 100%;
   flex: 1;
+  min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
   display: flex;


### PR DESCRIPTION
## Summary
- allow `.kanban-board-container` to shrink so its content can overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688714afdadc83279df08eb42520cfbf