### PR TITLE
Fix mobile sidebar initial state

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -21,7 +21,9 @@ export default function SidebarNav(): JSX.Element {
   const { logout } = useAuth()
   const navigate = useNavigate()
 
-  const [open, setOpen] = useState(true)
+  const [open, setOpen] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth > 768 : true
+  )
 
   const handleSignOut = () => {
     logout()


### PR DESCRIPTION
## Summary
- collapse sidebar by default on small screens to let mindmap canvas use full width

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887f951bdfc832795e52b800b34af8c