### PR TITLE
Add node todo list link

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -49,6 +49,7 @@ interface NodePayload {
   label?: string | null
   description?: string | null
   parentId?: string | null
+  linkedTodoListId?: string | null
 }
 
 const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
@@ -259,6 +260,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           label: `Child of ${parent.label || 'Node'}`,
           description: '',
           parentId: parent.id || null,
+          linkedTodoListId: null,
         }
 
         console.log('[MindmapCanvas] Posting child node payload:', newNode)

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -156,6 +156,7 @@ export default function MapEditorPage(): JSX.Element {
         description: '',
         parentId: null,
         mindmapId: mindmap.id,
+        linkedTodoListId: null,
       }
 
       console.log('[MapEditorPage] auto root node payload', generalNode)


### PR DESCRIPTION
## Summary
- include `linkedTodoListId` in the client-side `NodePayload` type
- send `linkedTodoListId: null` when creating nodes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888041d34a4832783501fa8e075c425