### PR TITLE
Highlight cards with todos

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -42,6 +42,7 @@ interface CardData {
   due_date?: string
   assignee_id?: string
   position: number
+  linked_todo_id?: string | null
 }
 
 interface Props {
@@ -101,6 +102,7 @@ export default function InteractiveKanbanBoard({
           assignee: c.assignee_id || '',
           comments: [],
           position: c.position,
+          todoId: c.linked_todo_id || undefined,
         })
       }
     })
@@ -544,7 +546,7 @@ function Lane({
                   {...providedCard.dragHandleProps}
                   className={`kanban-card ${
                     card.dueDate && isOverdue(card.dueDate) ? 'past-due' : ''
-                  }`}
+                  } ${card.todoId ? 'todo-linked' : ''}`}
                 >
                   <div className="kanban-title">{card.title || 'New Card'}</div>
                   <div className="kanban-meta">

--- a/netlify/functions/kanban-board-data.ts
+++ b/netlify/functions/kanban-board-data.ts
@@ -102,7 +102,7 @@ export const handler: Handler = async (event) => {
 
     const { rows: cards } = await client.query(
       `SELECT c.id, c.column_id, c.title, c.description, c.status, c.priority,
-              c.due_date, c.assignee_id, c.position
+              c.due_date, c.assignee_id, c.position, c.linked_todo_id
          FROM kanban_cards c
          JOIN kanban_columns col ON c.column_id=col.id
         WHERE col.board_id=$1

--- a/src/global.scss
+++ b/src/global.scss
@@ -2557,6 +2557,10 @@ hr {
   background-color: #ffe5e5;
 }
 
+.kanban-card.todo-linked {
+  background-color: #e6ffe6;
+}
+
 .kanban-title {
   font-weight: 600;
   margin-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- return `linked_todo_id` in board data API
- carry todo links into kanban card state
- highlight cards that are linked to todo items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68880d3dd45c8327afba9e7eb418dd40