### PR TITLE
Add send todo to kanban

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -303,15 +303,13 @@ export default function TodoCanvas({
                 disabled={!selectedBoard}
                 onClick={async () => {
                   if (!sendingTodo) return
-                  await fetch('/.netlify/functions/kanban-cards', {
+                  await fetch('/.netlify/functions/send-todo-to-kanban', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     credentials: 'include',
                     body: JSON.stringify({
-                      title: sendingTodo.title,
-                      description: sendingTodo.description,
-                      list_id: selectedBoard,
-                      metadata: { from: 'todo', todo_id: sendingTodo.id },
+                      todoId: sendingTodo.id,
+                      boardId: selectedBoard,
                     }),
                   })
                   setSendingTodo(null)

--- a/netlify/functions/send-todo-to-kanban.ts
+++ b/netlify/functions/send-todo-to-kanban.ts
@@ -1,0 +1,88 @@
+import type { Handler } from '@netlify/functions'
+import { getClient } from './db-client.js'
+import { extractToken, verifySession } from './auth.js'
+
+const headers = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization'
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers }
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method Not Allowed' }) }
+  }
+
+  const token = extractToken(event)
+  if (!token) return { statusCode: 401, headers, body: JSON.stringify({ error: 'Unauthorized' }) }
+  let userId: string
+  try {
+    const session = await verifySession(token) as { userId: string }
+    userId = session.userId
+  } catch {
+    return { statusCode: 401, headers, body: JSON.stringify({ error: 'Invalid token' }) }
+  }
+
+  if (!event.body) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing body' }) }
+  let data: { todoId?: string; boardId?: string }
+  try { data = JSON.parse(event.body) } catch { data = {} as any }
+  const { todoId, boardId } = data
+  if (!todoId || !boardId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing todoId or boardId' }) }
+
+  const client = await getClient()
+  try {
+    // get todo
+    const { rows: todos } = await client.query(
+      'SELECT id, title FROM todos WHERE id=$1 AND user_id=$2 AND linked_kanban_card_id IS NULL',
+      [todoId, userId]
+    )
+    const todo = todos[0]
+    if (!todo) return { statusCode: 404, headers, body: JSON.stringify({ error: 'Todo not found' }) }
+
+    // ensure New column
+    let { rows: cols } = await client.query(
+      "SELECT id FROM kanban_columns WHERE board_id=$1 AND title='New'",
+      [boardId]
+    )
+    let newColId = cols[0]?.id
+    if (!newColId) {
+      const res = await client.query(
+        "INSERT INTO kanban_columns (board_id, title, position) VALUES ($1,'New',0) RETURNING id",
+        [boardId]
+      )
+      newColId = res.rows[0].id
+    }
+
+    // determine next position
+    const { rows: posRows } = await client.query(
+      'SELECT COALESCE(MAX(position),0)+1 AS pos FROM kanban_cards WHERE column_id=$1',
+      [newColId]
+    )
+    const position = posRows[0]?.pos ?? 0
+
+    // create card
+    const cardRes = await client.query(
+      'INSERT INTO kanban_cards (column_id, title, position, linked_todo_id) VALUES ($1,$2,$3,$4) RETURNING id',
+      [newColId, todo.title, position, todo.id]
+    )
+    const cardId = cardRes.rows[0].id
+
+    await client.query(
+      'UPDATE todos SET linked_kanban_card_id=$1 WHERE id=$2',
+      [cardId, todo.id]
+    )
+    await client.query(
+      'INSERT INTO canvas_links (todo_id, board_id) VALUES ($1,$2) ON CONFLICT DO NOTHING',
+      [todo.id, boardId]
+    )
+
+    return { statusCode: 200, headers, body: JSON.stringify({ cardId }) }
+  } catch (err) {
+    console.error('send-todo-to-kanban', err)
+    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Server error' }) }
+  } finally {
+    client.release()
+  }
+}


### PR DESCRIPTION
## Summary
- add new `send-todo-to-kanban` Netlify function
- send a single todo to the board's **New** column from the UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688851ca7968832782c3bb1eed8b2379