### PR TITLE
Highlight nodes with linked todos

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -606,7 +606,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
               >
                 <circle
                   r={20 / transform.k}
-                  fill="#fff"
+                  fill={node.linkedTodoListId ? '#e6ffe6' : '#fff'}
                   stroke="#000"
                   strokeWidth={2 / transform.k}
                 />


### PR DESCRIPTION
## Summary
- make mindmap nodes light green when they have an associated todo list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888520754ec8327a16515341c4d9213