### PR TITLE
Add helper for New column when sending todos

### DIFF
--- a/netlify/functions/kanban-utils.ts
+++ b/netlify/functions/kanban-utils.ts
@@ -1,0 +1,17 @@
+import type { PoolClient } from 'pg'
+
+export async function ensureNewColumn(client: PoolClient, boardId: string): Promise<string> {
+  let { rows } = await client.query(
+    "SELECT id FROM kanban_columns WHERE board_id=$1 AND title='New'",
+    [boardId]
+  )
+  let newColId = rows[0]?.id as string | undefined
+  if (!newColId) {
+    const res = await client.query(
+      "INSERT INTO kanban_columns (board_id, title, position) VALUES ($1,'New',0) RETURNING id",
+      [boardId]
+    )
+    newColId = res.rows[0].id
+  }
+  return newColId
+}


### PR DESCRIPTION
## Summary
- add helper `ensureNewColumn` to guarantee a "New" column exists
- use helper in `send-todo-to-kanban` and `send-todo-list-to-kanban`

## Testing
- `npm test`
- `npm run compile:functions` *(fails: Cannot find module '@netlify/functions' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688854218da88327b615b627ce122092