### PR TITLE
Add New column check for Kanban

### DIFF
--- a/migrations/040_unique_kanban_column_titles.sql
+++ b/migrations/040_unique_kanban_column_titles.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS unique_kanban_column_titles
+  ON kanban_columns(board_id, title);

--- a/netlify/functions/kanban-utils.ts
+++ b/netlify/functions/kanban-utils.ts
@@ -2,7 +2,7 @@ import type { PoolClient } from 'pg'
 
 export async function ensureNewColumn(client: PoolClient, boardId: string): Promise<string> {
   let { rows } = await client.query(
-    "SELECT id FROM kanban_columns WHERE board_id=$1 AND title='New'",
+    "SELECT id FROM kanban_columns WHERE board_id=$1 AND lower(title)='new'",
     [boardId]
   )
   let newColId = rows[0]?.id as string | undefined


### PR DESCRIPTION
## Summary
- enforce unique column titles per board via migration
- make `ensureNewColumn` case-insensitive when locating the "New" column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68885861f6f88327a3f3fbeb888a7975