### PR TITLE
Fix ensureNewColumn return type

### DIFF
--- a/netlify/functions/kanban-utils.ts
+++ b/netlify/functions/kanban-utils.ts
@@ -1,17 +1,24 @@
 import type { PoolClient } from 'pg'
 
-export async function ensureNewColumn(client: PoolClient, boardId: string): Promise<string> {
-  let { rows } = await client.query(
+export async function ensureNewColumn(
+  client: PoolClient,
+  boardId: string
+): Promise<string> {
+  const { rows } = await client.query(
     "SELECT id FROM kanban_columns WHERE board_id=$1 AND lower(title)='new'",
     [boardId]
   )
-  let newColId = rows[0]?.id as string | undefined
-  if (!newColId) {
+
+  let newColId: string
+  if (rows[0]?.id) {
+    newColId = rows[0].id as string
+  } else {
     const res = await client.query(
       "INSERT INTO kanban_columns (board_id, title, position) VALUES ($1,'New',0) RETURNING id",
       [boardId]
     )
-    newColId = res.rows[0].id
+    newColId = res.rows[0].id as string
   }
+
   return newColId
 }


### PR DESCRIPTION
## Summary
- fix `ensureNewColumn` to always return a string

## Testing
- `npm run compile:functions` *(fails: Cannot find module '@netlify/functions')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68885a8aabb08327a01530fb89f5e9a0