### PR TITLE
Fix closing brackets in MindmapCanvas

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -698,7 +698,8 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
               ) : null}
               {selectedId === node.id && null}
                 </motion.g>
-              ))}
+                )
+              })}
           </g>
         </svg>
         {Array.isArray(safeNodes) &&


### PR DESCRIPTION
## Summary
- fix unmatched parentheses/brace in `mindmapcanvas.tsx`

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68886cc444d483278b6946b129471193