### PR TITLE
Remove path animation from mindmap

### DIFF
--- a/FaintMindmapBackground.tsx
+++ b/FaintMindmapBackground.tsx
@@ -50,27 +50,28 @@ export default function FaintMindmapBackground({ className = '' }: BgProps): JSX
           const x = 110 * Math.cos(rad)
           const y = 110 * Math.sin(rad)
           return (
-            <g key={i}>
-              <motion.line
+            <motion.g
+              key={i}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.8 }}
+            >
+              <line
                 x1="0"
                 y1="0"
                 x2={x}
                 y2={y}
                 stroke="var(--mindmap-color)"
                 strokeWidth="1.5"
-                initial={{ pathLength: 0 }}
-                animate={{ pathLength: 1 }}
-                transition={{ duration: 0.8 }}
               />
-              <motion.circle
+              <circle
                 r="20"
                 fill="none"
                 stroke="var(--mindmap-color)"
-                initial={{ scale: 0, cx: 0, cy: 0 }}
-                animate={{ scale: 1, cx: x, cy: y }}
-                transition={{ duration: 0.8 }}
+                cx={x}
+                cy={y}
               />
-            </g>
+            </motion.g>
           )
         })}
       </svg>

--- a/MindmapArm.tsx
+++ b/MindmapArm.tsx
@@ -26,18 +26,20 @@ export default function MindmapArm({ side = 'left' }: { side?: 'left' | 'right' 
         y2="50"
         stroke="var(--mindmap-color)"
         strokeWidth="6"
-        animate={inView ? { pathLength: 1 } : { pathLength: 0 }}
-        transition={{ duration: 4, delay: 0.5 }}
+        initial={{ opacity: 0 }}
+        animate={inView ? { opacity: 1 } : { opacity: 0 }}
+        transition={{ duration: 1, delay: 0.5 }}
       />
       <motion.circle
-        cx={startX}
+        cx={endX}
         cy="50"
         r="30"
         fill="none"
         stroke="var(--mindmap-color)"
         strokeWidth="6"
-        animate={inView ? { scale: 1, cx: endX } : { scale: 0, cx: startX }}
-        transition={{ duration: 4, delay: 0.5 }}
+        initial={{ opacity: 0 }}
+        animate={inView ? { opacity: 1 } : { opacity: 0 }}
+        transition={{ duration: 1, delay: 0.5 }}
       />
     </motion.svg>
   )

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -646,8 +646,8 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                     } ${to.x},${to.y}`}
                     fill="none"
                     vectorEffect="non-scaling-stroke"
-                    initial={{ pathLength: 0 }}
-                    animate={{ pathLength: 1 }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
                     transition={{ duration: 0.5, delay: i * 0.05 }}
                   />
                 )
@@ -655,9 +655,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
             {Array.isArray(safeNodes) &&
               safeNodes.length > 0 &&
               safeNodes.map((node, i) => {
-                const parent = node.parentId ? nodeMap.get(node.parentId) : null
-                const startX = parent ? parent.x : node.x
-                const startY = parent ? parent.y : node.y
                 return (
                   <motion.g
                     key={node.id}
@@ -667,8 +664,8 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                       e.stopPropagation()
                       handleNodeClick(node.id)
                     }}
-                    initial={{ opacity: 0, scale: 0.8, x: startX, y: startY }}
-                    animate={{ opacity: 1, scale: 1, x: node.x, y: node.y }}
+                    initial={{ opacity: 0, x: node.x, y: node.y }}
+                    animate={{ opacity: 1, x: node.x, y: node.y }}
                     transition={{ duration: 0.5, delay: i * 0.05 }}
                   >
                 <circle

--- a/mindmapdemo.tsx
+++ b/mindmapdemo.tsx
@@ -111,29 +111,28 @@ export default function MindmapDemo({ compact = false }: MindmapDemoProps): JSX.
                     <motion.line
                       x1={startX}
                       y1={startY}
-                      animate={{ x2: visible ? lineX : startX, y2: visible ? lineY : startY }}
+                      x2={lineX}
+                      y2={lineY}
                       stroke="var(--color-border)"
                       strokeWidth="2"
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: visible ? 1 : 0 }}
                       transition={{ duration: 0.6 }}
                     />
                     <motion.circle
                       r="25"
                       fill="orange"
                       stroke="var(--color-border)"
-                      initial={{ cx: startX, cy: startY, opacity: 0 }}
-                      animate={{
-                        cx: visible ? x : startX,
-                        cy: visible ? y : startY,
-                        opacity: visible ? 1 : 0,
-                      }}
+                      initial={{ cx: x, cy: y, opacity: 0 }}
+                      animate={{ cx: x, cy: y, opacity: visible ? 1 : 0 }}
                       transition={{ type: 'spring', stiffness: 120, damping: 20 }}
                     />
                     <motion.text
                       textAnchor="middle"
                       dominantBaseline="middle"
                       className="node-text"
-                      initial={{ x: startX, y: startY, opacity: 0 }}
-                      animate={{ x: visible ? x : startX, y: visible ? y : startY, opacity: visible ? 1 : 0 }}
+                      initial={{ x: x, y: y, opacity: 0 }}
+                      animate={{ x: x, y: y, opacity: visible ? 1 : 0 }}
                       transition={{ duration: 0.4, delay: 0.6, ease: 'easeOut' }}
                     >
                       {item.text}

--- a/src/global.scss
+++ b/src/global.scss
@@ -3416,7 +3416,7 @@ hr {
 /* Mindmap Canvas Styling */
 .mindmap-node {
   opacity: 0;
-  animation: pop-in 0.5s var(--transition-ease) forwards;
+  animation: fade-in 0.5s var(--transition-ease) forwards;
   cursor: pointer;
   transform-origin: center;
 }
@@ -3458,16 +3458,6 @@ hr {
   stroke-opacity: 0.6;
 }
 
-@keyframes pop-in {
-  0% {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
 
 /* Generic modal styling used across the app */
 .modal-backdrop {


### PR DESCRIPTION
## Summary
- fade in mindmap background elements instead of drawing them
- fade in marketing arm line and circle
- simplify edge and node animations to opacity only
- update marketing demo to fade elements
- switch CSS pop-in to fade animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688877b53ee08327ad75d5c3205b1ff3