### PR TITLE
Fix node alignment in mindmap canvas

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -664,9 +664,10 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                       e.stopPropagation()
                       handleNodeClick(node.id)
                     }}
-                    initial={{ opacity: 0, x: node.x, y: node.y }}
-                    animate={{ opacity: 1, x: node.x, y: node.y }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
                     transition={{ duration: 0.5, delay: i * 0.05 }}
+                    transform={`translate(${node.x}, ${node.y})`}
                   >
                 <circle
                   className="mindmap-node-circle"


### PR DESCRIPTION
## Summary
- fix node transforms so their position is anchored to the edge endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888eccb24a883278d8f0864e596e2d3