### PR TITLE
Fix mind map node placement

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -664,9 +664,10 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                       e.stopPropagation()
                       handleNodeClick(node.id)
                     }}
-                    initial={{ opacity: 0, x: node.x, y: node.y }}
-                    animate={{ opacity: 1, x: node.x, y: node.y }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
                     transition={{ duration: 0.5, delay: i * 0.05 }}
+                    transform={`translate(${node.x}, ${node.y})`}
                   >
                 <circle
                   className="mindmap-node-circle"


### PR DESCRIPTION
## Summary
- adjust node `<motion.g>` to use `translate(x, y)` transform for SVG positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f2d1adf48327b396d49f2bdf9112