### PR TITLE
Fix nodes x/y positions

### DIFF
--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -64,20 +64,23 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       const mapId = event.queryStringParameters?.mindmapId
       if (!mapId) return { statusCode: 400, headers, body: JSON.stringify({ error: 'mindmapId required' }) }
       const { rows } = await client.query(
-        `SELECT id, parent_id, x, y, label, description, todo_id, linked_todo_list_id FROM nodes WHERE mindmap_id = $1 ORDER BY created_at`,
+        `SELECT id, parent_id, x, y, label, description, todo_id, linked_todo_list_id
+         FROM nodes WHERE mindmap_id = $1 ORDER BY created_at`,
         [mapId]
       )
+
       const nodes = rows.map(r => ({
         id: r.id,
         parentId: r.parent_id,
-        x: r.x,
-        y: r.y,
+        x: typeof r.x === 'string' ? parseFloat(r.x) : r.x,
+        y: typeof r.y === 'string' ? parseFloat(r.y) : r.y,
         label: r.label ?? undefined,
         description: r.description ?? undefined,
         todoId: r.todo_id ?? undefined,
         linkedTodoListId: r.linked_todo_list_id ?? undefined,
       }))
-      return { statusCode: 200, headers, body: JSON.stringify(nodes) }
+
+      return { statusCode: 200, headers, body: JSON.stringify({ nodes }) }
     }
 
     if (event.httpMethod === 'POST') {

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -126,6 +126,10 @@ export default function MapEditorPage(): JSX.Element {
         if (!Array.isArray(data?.nodes) && !Array.isArray(data)) {
           setNodesError('Invalid nodes data')
         }
+        console.log(
+          'Loaded nodes:',
+          validNodes.map(n => ({ id: n.id, x: n.x, y: n.y }))
+        )
         setNodes(validNodes)
       })
       .catch(err => {


### PR DESCRIPTION
## Summary
- include numeric `x` and `y` on nodes API
- log loaded node coordinates when fetching nodes in MapEditorPage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688902abc8d88327abf9f30846e36ce0