### PR TITLE
Fix comments modal crash when API errors occur

### DIFF
--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -49,8 +49,16 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
     fetch(`/.netlify/functions/todo-comments?todoId=${todoId}`, {
       credentials: 'include',
     })
-      .then(res => res.json())
+      .then(async res => {
+        if (!res.ok) throw new Error('Failed to load comments')
+        const data = await res.json()
+        return Array.isArray(data) ? data : []
+      })
       .then(setComments)
+      .catch(err => {
+        console.error('Error fetching comments:', err)
+        setComments([])
+      })
   }, [card?.todoId, card?.id])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- handle fetch errors gracefully in CommentsModal so the UI does not crash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889030276b083278a2d50fd17c80d87