### PR TITLE
Propagate child node position to parent state

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -308,6 +308,12 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           .then(nodeId => {
             if (nodeId) {
               replaceNodeId(tempId, nodeId)
+              onAddNode?.({
+                ...newNode,
+                id: nodeId,
+                todoId: null,
+                direction,
+              })
             } else {
               console.error('[MindmapCanvas] Failed to create node', newNode)
             }


### PR DESCRIPTION
## Summary
- notify parent when a new node is created so MapEditorPage keeps server coordinates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688910b69f08832780862915d7ed8640