### PR TITLE
Fix root node default positions

### DIFF
--- a/netlify/functions/constants.js
+++ b/netlify/functions/constants.js
@@ -1,0 +1,2 @@
+export const DEFAULT_ROOT_X = 400;
+export const DEFAULT_ROOT_Y = 300;

--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -1,5 +1,6 @@
 import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions'
 import { getClient } from './db-client.js'
+import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from './constants.js'
 import { extractToken, verifySession } from './auth.js'
 import { validate as isUuid } from 'uuid'
 import { randomUUID } from 'crypto'
@@ -205,8 +206,8 @@ export async function createMindmapFromNodes(
 
     const queue: Array<{ node: TmpNode; depth: number }> = []
     roots.forEach(root => {
-      root.x = 0
-      root.y = 0
+      root.x = DEFAULT_ROOT_X
+      root.y = DEFAULT_ROOT_Y
       queue.push({ node: root, depth: 0 })
     })
 

--- a/netlify/functions/nodes.ts
+++ b/netlify/functions/nodes.ts
@@ -4,6 +4,7 @@ import type { PoolClient } from 'pg'
 import { validate as isUuid } from 'uuid'
 import { requireAuth } from './middleware.js'
 import type { NodePayload } from './types.js'
+import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from './constants.js'
 
 // Node creation rules:
 // - A mindmap may contain only one root node (parentId null).
@@ -158,14 +159,21 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
       }
 
       // Default values and type checks
+      const isRootPayload = !payload.parentId
+      const xValid = typeof payload.x === 'number' && Number.isFinite(payload.x)
+      const yValid = typeof payload.y === 'number' && Number.isFinite(payload.y)
       const x =
-        typeof payload.x === 'number' && Number.isFinite(payload.x)
-          ? payload.x
-          : 0
+        isRootPayload && !xValid
+          ? DEFAULT_ROOT_X
+          : xValid
+            ? payload.x
+            : 0
       const y =
-        typeof payload.y === 'number' && Number.isFinite(payload.y)
-          ? payload.y
-          : 0
+        isRootPayload && !yValid
+          ? DEFAULT_ROOT_Y
+          : yValid
+            ? payload.y
+            : 0
       const label =
         typeof payload.label === 'string' && payload.label.trim() !== ''
           ? payload.label.trim()

--- a/tests/root-node-default.test.js
+++ b/tests/root-node-default.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from '../netlify/functions/constants.js';
+
+test('default root coordinates are centered', () => {
+  assert.strictEqual(DEFAULT_ROOT_X, 400);
+  assert.strictEqual(DEFAULT_ROOT_Y, 300);
+});


### PR DESCRIPTION
## Summary
- default root nodes to canvas center in `nodes` and `mindmaps` functions
- expose center values via `constants.js`
- test that the defaults are 400x300

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68890fda7480832792a5889a77ed12db