### PR TITLE
Fix node positions

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -668,7 +668,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
             {Array.isArray(safeNodes) &&
               safeNodes.length > 0 &&
               safeNodes.map((node, i) => {
-                console.log(`Rendering node ${node.label} at`, node.x, node.y)
+                console.log(`[RENDER] Node ${node.label} - x: ${node.x}, y: ${node.y}`)
                 return (
                   <g
                     key={node.id}

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -120,8 +120,8 @@ export default function MapEditorPage(): JSX.Element {
             : []
         const validNodes = rawNodes.map((n: any) => ({
           ...n,
-          x: typeof n.x === 'string' ? parseFloat(n.x) : n.x ?? 0,
-          y: typeof n.y === 'string' ? parseFloat(n.y) : n.y ?? 0,
+          x: typeof n.x === 'string' ? parseFloat(n.x) : n.x,
+          y: typeof n.y === 'string' ? parseFloat(n.y) : n.y,
         }))
         if (!Array.isArray(data?.nodes) && !Array.isArray(data)) {
           setNodesError('Invalid nodes data')


### PR DESCRIPTION
## Summary
- preserve node coordinates when fetching nodes
- log node coordinates before rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68891e7d4264832794b939c7dec762c4