### PR TITLE
Fix mention regex in comment modal

### DIFF
--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -77,7 +77,7 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
   if (!card) return null
 
   const highlightMentions = (text: string) => {
-    return text.split(/(@[\w-]+)/g).map((part, idx) => {
+    return text.split(/(@[a-zA-Z0-9_-]+)/g).map((part, idx) => {
       if (/^@/.test(part)) {
         return (
           <span key={idx} className="mention">


### PR DESCRIPTION
## Summary
- tweak the regex used to detect @mentions

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688920d577508327af30a4f1bdf51b41