### PR TITLE
Fix mention regex

### DIFF
--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -78,7 +78,7 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
 
   const highlightMentions = (text: string) => {
     // Split on @mentions and return parts with spans for styling
-    return text.split(/(@[\w-]+)/g).map((part, idx) => {
+    return text.split(/(@[-\w]+)/g).map((part, idx) => {
       if (/^@/.test(part)) {
         return (
           <span key={idx} className="mention">


### PR DESCRIPTION
## Summary
- adjust regex used for splitting comments to avoid unterminated regex errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68892a17f10083279cade00b50c5b5c4