### PR TITLE
Fix missing parentheses in CommentsModal map

### DIFF
--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -115,7 +115,7 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
                 </div>
               </div>
             )
-          })
+          })}
         </div>
         <div className="comment-input-bar">
           <textarea


### PR DESCRIPTION
## Summary
- close JSX expression in CommentsModal map call

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889713d4cfc8327b28a9572d575da33