### PR TITLE
Fix mindmap node position handling

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -676,6 +676,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 return (
                   <g
                     key={node.id}
+                    transform={`translate(${nx}, ${ny})`}
                     className={`mindmap-node${node.linkedTodoListId ? ' has-todo' : ''}`}
                     data-id={node.id}
                     onPointerDown={e => {
@@ -685,15 +686,15 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   >
                     <circle
                       className="mindmap-node-circle"
-                      cx={nx}
-                      cy={ny}
+                      cx={0}
+                      cy={0}
                       r={20 / transform.k}
                       vectorEffect="non-scaling-stroke"
                     />
                     {node.label && (
                       <text
-                        x={nx}
-                        y={ny}
+                        x={0}
+                        y={0}
                         textAnchor="middle"
                         dy=".35em"
                         fontSize={14 / transform.k}
@@ -705,8 +706,8 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                     {todoLists[node.id]?.length ? (
                       <text
                         fontSize={12 / transform.k}
-                        x={nx + 14 / transform.k}
-                        y={ny + 14 / transform.k}
+                        x={14 / transform.k}
+                        y={14 / transform.k}
                       >
                         ✓
                       </text>

--- a/netlify/functions/constants.js
+++ b/netlify/functions/constants.js
@@ -1,0 +1,2 @@
+export const DEFAULT_ROOT_X = 400;
+export const DEFAULT_ROOT_Y = 300;


### PR DESCRIPTION
## Summary
- set node `<g>` element transform and draw children relative to the group
- add missing constants.js for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688987141e14832795eb2f8749c0c29a