### PR TITLE
Enable comment creation

### DIFF
--- a/CommentsModal.tsx
+++ b/CommentsModal.tsx
@@ -26,14 +26,17 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
         body: JSON.stringify(body),
       })
       if (res.ok) {
-        const newComment = {
+        const data = await res.json()
+        const newComment = Array.isArray(data) || typeof data !== 'object' ? {
           comment: body.comment,
           author: 'You',
           created_at: new Date().toISOString(),
-        } as any
+        } : data
         setComments(prev => [...prev, newComment])
         onAdd(newComment)
         setText('')
+      } else {
+        console.error('Failed to submit comment:', await res.text())
       }
     } catch (err) {
       console.error('Failed to submit comment:', err)

--- a/tests/root-node-default.test.js
+++ b/tests/root-node-default.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from '../netlify/functions/constants.js';
+import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from '../dist/constants.js';
 
 test('default root coordinates are centered', () => {
   assert.strictEqual(DEFAULT_ROOT_X, 400);


### PR DESCRIPTION
## Summary
- return new comment details from the `todo-comments` API
- use returned data in `CommentsModal`
- fix unit test import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688987bbed588327b99f169cf9194129