### PR TITLE
Remove unused TEST node

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -726,12 +726,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                   </g>
                 )
               })}
-            <g transform="translate(500, 500)">
-              <circle r="20" fill="red" />
-              <text textAnchor="middle" dy=".35em" fontSize={14}>
-                TEST
-              </text>
-            </g>
           </motion.g>
         </svg>
         {Array.isArray(uniqueNodes) &&


### PR DESCRIPTION
## Summary
- remove hardcoded TEST node from the mindmap canvas

## Testing
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68898f60c5a88327aada7a722d08251c