### PR TITLE
Fix mindmap node editing workflow

### DIFF
--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -291,6 +291,14 @@ export default function MapEditorPage(): JSX.Element {
     }).catch(() => {})
   }
 
+  const handleUpdateNode = useCallback((node: NodeData) => {
+    setNodes(prev =>
+      Array.isArray(prev)
+        ? prev.map(n => (n.id === node.id ? { ...n, ...node } : n))
+        : prev
+    )
+  }, [])
+
   const handleTransformChange = useCallback(
     (t: Transform) => {
       setTransform(t)
@@ -320,6 +328,7 @@ export default function MapEditorPage(): JSX.Element {
             edges={Array.isArray(edges) ? edges : []}
             onAddNode={handleAddNode}
             onMoveNode={handleMoveNode}
+            onUpdateNode={handleUpdateNode}
             initialTransform={transform}
             onTransformChange={handleTransformChange}
             showMiniMap


### PR DESCRIPTION
## Summary
- dedupe nodes by id inside `MindmapCanvas`
- notify parent page when nodes are edited
- update map editor state after edits

## Testing
- `npm test` *(fails: Cannot find module '/workspace/mindmapx/dist/constants.js')*
- `npm run compile:functions` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688992f6bc088327bf592cbc04648445