### PR TITLE
Keep todo input box open after adding

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -78,7 +78,6 @@ export default function TodoCanvas({
       if (!res.ok) throw new Error('Failed to save todo')
       const created: TodoItem = await res.json()
       setTodos(prev => [created, ...prev])
-      setAdding(false)
     } catch (err) {
       console.error(err)
       alert('Failed to create todo')


### PR DESCRIPTION
## Summary
- allow add form in todo canvas to stay visible after creating a todo

## Testing
- `npm test` *(fails: cannot find module `/workspace/mindmapx/dist/constants.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68899d2eb1408327902248940d8ef622