### PR TITLE
Update node colors based on todo status

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -708,7 +708,12 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
                 return (
                   <g
                     key={node.id}
-                    className={`mindmap-node${node.linkedTodoListId ? ' has-todo' : ''}`}
+                    className={(() => {
+                      if (!node.linkedTodoListId) return 'mindmap-node'
+                      const list = todoLists[node.id]
+                      const allDone = Array.isArray(list) && list.length > 0 && list.every(t => t.done)
+                      return `mindmap-node ${allDone ? 'todo-complete' : 'has-todo'}`
+                    })()}
                     data-id={node.id}
                     onPointerDown={e => {
                       e.stopPropagation()

--- a/src/global.scss
+++ b/src/global.scss
@@ -3433,8 +3433,15 @@ hr {
   stroke: var(--color-accent);
 }
 
-/* Highlight nodes that have an attached todo list */
+/* Highlight nodes with todos */
 .mindmap-node.has-todo .mindmap-node-circle {
+  /* light blue-purple with darker border */
+  fill: #e0e7ff;
+  stroke: #6366f1;
+}
+
+/* Nodes whose todo list is fully complete */
+.mindmap-node.todo-complete .mindmap-node-circle {
   fill: #d1fae5;
   stroke: var(--color-success);
 }


### PR DESCRIPTION
## Summary
- change mindmap node color styles
- highlight completed todo nodes in green
- render node classes based on todo completion status

## Testing
- `npm test` *(fails: test suite errors)*
- `npm run compile:functions` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68899e97426c8327b32202b50b20250a