### PR TITLE
Fix duplicate node creation

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -28,7 +28,7 @@ interface MindmapCanvasProps {
   edges?: EdgeData[]
   width?: number | string
   height?: number | string
-  onAddNode?: (node: NodeData) => void
+  onAddNode?: (node: NodeData) => Promise<string | undefined> | string | undefined
   onMoveNode?: (node: NodeData) => void
   onUpdateNode?: (node: NodeData) => void
   initialTransform?: { x: number; y: number; k: number }
@@ -335,15 +335,17 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         })
 
         try {
+          let nodeId: string | undefined
           if (onAddNode) {
-            await onAddNode(newNode)
+            const result = await onAddNode(newNode)
+            if (typeof result === 'string') nodeId = result
           } else {
-            const nodeId = await createNode(newNode)
-            if (nodeId) {
-              replaceNodeId(tempId, nodeId)
-            } else {
-              console.error('[MindmapCanvas] Failed to create node', newNode)
-            }
+            nodeId = await createNode(newNode) || undefined
+          }
+          if (nodeId) {
+            replaceNodeId(tempId, nodeId)
+          } else {
+            console.error('[MindmapCanvas] Failed to create node', newNode)
           }
         } finally {
           creatingNodeRef.current = false

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -223,8 +223,8 @@ export default function MapEditorPage(): JSX.Element {
 
 
 
-  const handleAddNode = async (node: NodeData) => {
-    if (!id) return
+  const handleAddNode = async (node: NodePayload): Promise<string | undefined> => {
+    if (!id) return undefined
     const payload = { ...node, mindmapId: id }
     console.log('[handleAddNode] payload', payload)
 
@@ -239,8 +239,14 @@ export default function MapEditorPage(): JSX.Element {
 
         if (res.ok) {
           const data = await res.json()
-          setNodes(prev => [...prev, { ...node, id: data.id || node.id }])
-          return
+          const newId = typeof data?.id === 'string' ? data.id : undefined
+          if (newId) {
+            setNodes(prev => [
+              ...(Array.isArray(prev) ? prev : []),
+              { ...node, id: newId },
+            ])
+          }
+          return newId
         }
 
         const err = await res.json().catch(() => ({}))
@@ -264,12 +270,7 @@ export default function MapEditorPage(): JSX.Element {
       }
     }
 
-    // fallback to client-side id so the user can continue working
-    const fallbackId =
-      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-        ? crypto.randomUUID()
-        : Math.random().toString(36).slice(2)
-    setNodes(prev => [...prev, { ...node, id: node.id || fallbackId }])
+    return undefined
   }
 
 


### PR DESCRIPTION
## Summary
- return new id from `handleAddNode`
- replace temporary node when the id returns

## Testing
- `npm test` *(fails: cannot find module /workspace/mindmapx/dist/constants.js)*

------
https://chatgpt.com/codex/tasks/task_e_68899fd759848327a7d7574085d7f5f1