### PR TITLE
Separate comment modals for todos and kanban

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -6,7 +6,7 @@ import {
   DropResult,
 } from 'react-beautiful-dnd'
 import CardModal, { Card } from './CardModal'
-import CommentsModal from './CommentsModal'
+import KanbanCommentsModal from './KanbanCommentsModal'
 import { authFetch } from './authFetch'
 
 const API_BASE = '/api/kanban'
@@ -458,7 +458,7 @@ export default function InteractiveKanbanBoard({
           if (editing) removeCard(editing.laneId, card.id)
         }}
       />
-      <CommentsModal
+      <KanbanCommentsModal
         card={commenting?.card || null}
         onClose={() => setCommenting(null)}
         onAdd={comment => {

--- a/KanbanCommentsModal.tsx
+++ b/KanbanCommentsModal.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect, useRef } from 'react'
+import Modal from './modal'
+import type { Card, Comment } from './CardModal'
+
+interface Props {
+  card: Card | null
+  onClose: () => void
+  onAdd: (comment: Comment) => void
+  currentUser?: { name: string }
+}
+
+export default function KanbanCommentsModal({ card, onClose, onAdd, currentUser }: Props) {
+  const [text, setText] = useState('')
+  const [comments, setComments] = useState<Comment[]>([])
+  const feedRef = useRef<HTMLDivElement>(null)
+
+  const submitComment = async () => {
+    if (!card || !text.trim()) return
+    const endpoint = '/.netlify/functions/kanban-card-comments'
+    const body = { cardId: card.id, comment: text.trim() }
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        const newComment = Array.isArray(data) || typeof data !== 'object' ? {
+          comment: body.comment,
+          author: 'You',
+          created_at: new Date().toISOString(),
+        } : data
+        setComments(prev => [...prev, newComment])
+        onAdd(newComment)
+        setText('')
+      } else {
+        console.error('Failed to submit comment:', await res.text())
+      }
+    } catch (err) {
+      console.error('Failed to submit comment:', err)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      submitComment()
+    }
+  }
+
+  useEffect(() => {
+    if (!card) return
+    const endpoint = `/.netlify/functions/kanban-card-comments?cardId=${card.id}`
+    fetch(endpoint, {
+      credentials: 'include',
+    })
+      .then(async res => {
+        if (!res.ok) {
+          const text = await res.text()
+          throw new Error(text || res.statusText)
+        }
+        return res.json()
+      })
+      .then(data => {
+        if (Array.isArray(data)) {
+          setComments(data)
+        } else {
+          console.error('Invalid comments response', data)
+          setComments([])
+        }
+      })
+      .catch(err => {
+        console.error('Failed to fetch comments:', err)
+        setComments([])
+      })
+  }, [card?.id])
+
+  useEffect(() => {
+    const el = feedRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [comments])
+
+  if (!card) return null
+
+  const highlightMentions = (text: string) => {
+    // Split on @mentions and return parts with spans for styling
+    return text.split(/(@[-\w]+)/g).map((part, idx) => {
+      if (/^@/.test(part)) {
+        return (
+          <span key={idx} className="mention">
+            {part}
+          </span>
+        )
+      }
+      return <span key={idx}>{part}</span>
+    })
+  }
+
+  return (
+    <Modal isOpen={!!card} onClose={onClose} ariaLabel={`Comments for ${card.title}`}>
+      <div className="comment-modal">
+        <h2 className="mb-2 text-lg font-semibold">Comments for "{card.title}"</h2>
+        <div className="comment-feed" ref={feedRef}>
+          {comments.map((c, i) => {
+            const isMine = c.author === currentUser?.name
+            const name = isMine ? 'Me' : c.author || 'Anon'
+
+            return (
+              <div
+                key={i}
+                className={`comment-bubble ${isMine ? 'me' : 'other'} fade-item`}
+              >
+                <div className="comment-meta">
+                  <span className="comment-author">{name}</span>
+                  <span className="comment-time">
+                    {new Date((c as any).created_at || c.createdAt).toLocaleString()}
+                  </span>
+                </div>
+                <div className="comment-body">
+                  {highlightMentions((c as any).comment || c.text)}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+        <div className="comment-input-bar">
+          <textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder="Type a comment..."
+            onKeyDown={handleKeyDown}
+          />
+          <button className="send-button" onClick={submitComment} disabled={!text.trim()}>Send</button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import CommentsModal from './CommentsModal'
+import TodoCommentsModal from './TodoCommentsModal'
 import TodoModal from './TodoModal'
 import Modal from './modal'
 import type { Comment } from './CardModal'
@@ -281,8 +281,8 @@ export default function TodoCanvas({
         onClose={() => setEditingTodo(null)}
         onSave={handleModalSave}
       />
-      <CommentsModal
-        card={commentingTodo ? { ...commentingTodo, comments: commentingTodo.comments || [], id: commentingTodo.id, title: commentingTodo.title } : null}
+      <TodoCommentsModal
+        todo={commentingTodo}
         onClose={() => setCommentingTodo(null)}
         onAdd={c => {
           if (commentingTodo) {

--- a/TodoCommentsModal.tsx
+++ b/TodoCommentsModal.tsx
@@ -1,28 +1,24 @@
 import React, { useState, useEffect, useRef } from 'react'
 import Modal from './modal'
-import type { Card, Comment } from './CardModal'
+import type { Comment } from './CardModal'
+import type { TodoItem } from './TodoCanvas'
 
 interface Props {
-  card: Card | null
+  todo: TodoItem | null
   onClose: () => void
   onAdd: (comment: Comment) => void
   currentUser?: { name: string }
 }
 
-export default function CommentsModal({ card, onClose, onAdd, currentUser }: Props) {
+export default function TodoCommentsModal({ todo, onClose, onAdd, currentUser }: Props) {
   const [text, setText] = useState('')
   const [comments, setComments] = useState<Comment[]>([])
   const feedRef = useRef<HTMLDivElement>(null)
 
   const submitComment = async () => {
-    if (!card || !text.trim()) return
-    const isTodo = !!card.todoId
-    const endpoint = isTodo
-      ? '/.netlify/functions/todo-comments'
-      : '/.netlify/functions/kanban-card-comments'
-    const body = isTodo
-      ? { todoId: card.todoId, comment: text.trim() }
-      : { cardId: card.id, comment: text.trim() }
+    if (!todo || !text.trim()) return
+    const endpoint = '/.netlify/functions/todo-comments'
+    const body = { todoId: todo.id, comment: text.trim() }
     try {
       const res = await fetch(endpoint, {
         method: 'POST',
@@ -56,12 +52,8 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
   }
 
   useEffect(() => {
-    if (!card) return
-    const isTodo = !!card.todoId
-    const id = isTodo ? card.todoId : card.id
-    const endpoint = isTodo
-      ? `/.netlify/functions/todo-comments?todoId=${id}`
-      : `/.netlify/functions/kanban-card-comments?cardId=${id}`
+    if (!todo) return
+    const endpoint = `/.netlify/functions/todo-comments?todoId=${todo.id}`
     fetch(endpoint, {
       credentials: 'include',
     })
@@ -84,7 +76,7 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
         console.error('Failed to fetch comments:', err)
         setComments([])
       })
-  }, [card?.todoId, card?.id])
+  }, [todo?.id])
 
   useEffect(() => {
     const el = feedRef.current
@@ -92,7 +84,7 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
     el.scrollTop = el.scrollHeight
   }, [comments])
 
-  if (!card) return null
+  if (!todo) return null
 
   const highlightMentions = (text: string) => {
     // Split on @mentions and return parts with spans for styling
@@ -109,9 +101,9 @@ export default function CommentsModal({ card, onClose, onAdd, currentUser }: Pro
   }
 
   return (
-    <Modal isOpen={!!card} onClose={onClose} ariaLabel={`Comments for ${card.title}`}>
+    <Modal isOpen={!!todo} onClose={onClose} ariaLabel={`Comments for ${todo.title}`}>
       <div className="comment-modal">
-        <h2 className="mb-2 text-lg font-semibold">Comments for "{card.title}"</h2>
+        <h2 className="mb-2 text-lg font-semibold">Comments for "{todo.title}"</h2>
         <div className="comment-feed" ref={feedRef}>
           {comments.map((c, i) => {
             const isMine = c.author === currentUser?.name


### PR DESCRIPTION
## Summary
- split `CommentsModal` into dedicated `KanbanCommentsModal` and `TodoCommentsModal`
- wire kanban views to the kanban modal
- wire todo views to the todo modal

## Testing
- `npm test` *(fails: Cannot find module '/workspace/mindmapx/dist/constants.js')*
- `npm run compile:functions` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6889ac891aa08327ae0ad823b769b595