### PR TITLE
Fix failing test by adjusting import path

### DIFF
--- a/tests/root-node-default.test.js
+++ b/tests/root-node-default.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from '../dist/constants.js';
+// Use the source version in netlify/functions to avoid requiring a prebuilt dist
+import { DEFAULT_ROOT_X, DEFAULT_ROOT_Y } from '../netlify/functions/constants.js';
 
 test('default root coordinates are centered', () => {
   assert.strictEqual(DEFAULT_ROOT_X, 400);


### PR DESCRIPTION
## Summary
- correct import path for default root test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889bbc6a27c8327a9a6425b33443e58