### PR TITLE
Separate Kanban/Todo comment payloads

### DIFF
--- a/netlify/functions/kanban-card-comments.ts
+++ b/netlify/functions/kanban-card-comments.ts
@@ -42,7 +42,10 @@ export const handler: Handler = async (event) => {
     console.debug('kanban-card-comments raw body:', event.body)
 
     if (event.httpMethod === 'GET') {
-      const cardId = event.queryStringParameters?.cardId
+      const { cardId, todoId } = event.queryStringParameters || {}
+      if (todoId) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'todoId not allowed' }) }
+      }
       if (!cardId || !isUuid(cardId)) {
         return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing or invalid cardId' }) }
       }
@@ -83,7 +86,10 @@ export const handler: Handler = async (event) => {
         return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid JSON' }) }
       }
       console.debug('kanban-card-comments parsed body:', parsed, 'userId:', userId)
-      const { cardId, comment } = parsed as { cardId?: string; comment?: string }
+      const { cardId, comment, todoId } = parsed as { cardId?: string; todoId?: string; comment?: string }
+      if (todoId) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'todoId not allowed' }) }
+      }
       const commentText = (comment || '').trim()
       if (
         !cardId ||

--- a/netlify/functions/todo-comments.ts
+++ b/netlify/functions/todo-comments.ts
@@ -42,7 +42,10 @@ export const handler: Handler = async (event) => {
     console.debug('todo-comments raw body:', event.body)
 
     if (event.httpMethod === 'GET') {
-      const todoId = event.queryStringParameters?.todoId
+      const { todoId, cardId } = event.queryStringParameters || {}
+      if (cardId) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'cardId not allowed' }) }
+      }
       if (!todoId || !isUuid(todoId)) {
         return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing or invalid todoId' }) }
       }
@@ -83,7 +86,10 @@ export const handler: Handler = async (event) => {
         return { statusCode: 400, headers, body: JSON.stringify({ error: 'Invalid JSON' }) }
       }
       console.debug('todo-comments parsed body:', parsed, 'userId:', userId)
-      const { todoId, comment } = parsed as { todoId?: string; comment?: string }
+      const { todoId, comment, cardId } = parsed as { todoId?: string; cardId?: string; comment?: string }
+      if (cardId) {
+        return { statusCode: 400, headers, body: JSON.stringify({ error: 'cardId not allowed' }) }
+      }
       const commentText = (comment || '').trim()
       if (
         !todoId ||


### PR DESCRIPTION
## Summary
- tighten validation in comment functions
- reject todoId on kanban-card-comments requests
- reject cardId on todo-comments requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889c0bfd72083279f4a0053105f59e6