### PR TITLE
Fix mindmap canvas mobile sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>MindXdo</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -646,6 +646,8 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
 
     return (
       <div
+        id="mindmap-container"
+        className="mindmap-canvas-wrapper"
         ref={containerRef}
         onPointerDown={e => {
           if ((e.target as HTMLElement).closest('.node-toolbox')) return
@@ -665,6 +667,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         }}
       >
         <svg
+          className="mindmap-canvas"
           ref={svgRef}
           width={CANVAS_SIZE}
           height={CANVAS_SIZE}

--- a/src/global.scss
+++ b/src/global.scss
@@ -3841,3 +3841,26 @@ hr {
     width: 70%;
   }
 }
+
+/* Mindmap mobile canvas adjustments */
+@media (max-width: 1024px) {
+  #mindmap-container,
+  .mindmap-canvas-wrapper {
+    height: calc(100vh - 60px);
+    overflow: hidden;
+  }
+  .mindmap-canvas {
+    width: 100%;
+    height: 100%;
+    touch-action: pan-x pan-y;
+  }
+}
+
+@media (max-width: 768px) {
+  #mindmap-container,
+  .mindmap-canvas-wrapper {
+    height: calc(100vh - 60px);
+    padding: 0;
+    margin: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- make canvas wrapper identifiable
- add responsive styles so canvas fills the screen on mobile
- prevent viewport scaling on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889ed890600832790590f0e68387822