### PR TITLE
Add mindmap link to todo list page

### DIFF
--- a/TodoCanvas.tsx
+++ b/TodoCanvas.tsx
@@ -20,6 +20,7 @@ export interface TodoCanvasProps {
   list_id?: string
   listTitle?: string
   listDescription?: string
+  mindmapId?: string
 }
 
 export default function TodoCanvas({
@@ -29,6 +30,7 @@ export default function TodoCanvas({
   list_id,
   listTitle,
   listDescription,
+  mindmapId,
 }: TodoCanvasProps): JSX.Element {
   const [todos, setTodos] = useState<TodoItem[]>(initialTodos)
   const [newTitle, setNewTitle] = useState('')
@@ -215,6 +217,11 @@ export default function TodoCanvas({
         <>
           <img src="/assets/logo.png" alt="MindXdo" className="todo-logo" />
           <h1 className="todo-title">{listTitle}</h1>
+          {mindmapId && (
+            <a href={`/maps/${mindmapId}`} className="todo-map-link">
+              View Mindmap
+            </a>
+          )}
         </>
       )}
       {listDescription && (

--- a/src/TodosCanvasPage.tsx
+++ b/src/TodosCanvasPage.tsx
@@ -15,6 +15,7 @@ interface TodoList {
   title: string
   description?: string
   todos: TodoItem[]
+  mindmap_id?: string | null
 }
 
 export default function TodosCanvasPage(): JSX.Element {
@@ -49,6 +50,7 @@ export default function TodosCanvasPage(): JSX.Element {
             list_id={id}
             listTitle={list?.title}
             listDescription={list?.description}
+            mindmapId={list?.mindmap_id || undefined}
           />
         )}
       </main>


### PR DESCRIPTION
## Summary
- include mindmap id when querying todo lists
- return mindmap id in todo list creation
- expose optional mindmapId to TodoCanvas
- show link to view mindmap on todo list page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6a72ed448327b1a2616b91f54e00