### PR TITLE
Add links from kanban cards to todo lists

### DIFF
--- a/CardModal.tsx
+++ b/CardModal.tsx
@@ -204,7 +204,7 @@ export default function CardModal({
                 {card.todoId && (
                   <span>
                     🔗 Linked ToDo:{' '}
-                    <a href={`/todo/${card.todoListId}`}>View</a>
+                    <a href={`/todos/${card.todoListId}`}>View</a>
                   </span>
                 )}
                 {card.mindmapId && (

--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -103,6 +103,7 @@ export default function InteractiveKanbanBoard({
           comments: [],
           position: c.position,
           todoId: c.linked_todo_id || undefined,
+          todoListId: c.todo_list_id || undefined,
         })
       }
     })
@@ -588,6 +589,15 @@ function Lane({
                     >
                       💬
                     </button>
+                    {card.todoListId && (
+                      <a
+                        href={`/todos/${card.todoListId}`}
+                        className="action-button todo-link"
+                        title="View Todo List"
+                      >
+                        🔗
+                      </a>
+                    )}
                   </div>
                 </div>
               )}

--- a/netlify/functions/kanban-board-data.ts
+++ b/netlify/functions/kanban-board-data.ts
@@ -102,9 +102,11 @@ export const handler: Handler = async (event) => {
 
     const { rows: cards } = await client.query(
       `SELECT c.id, c.column_id, c.title, c.description, c.status, c.priority,
-              c.due_date, c.assignee_id, c.position, c.linked_todo_id
+              c.due_date, c.assignee_id, c.position, c.linked_todo_id,
+              t.list_id AS todo_list_id
          FROM kanban_cards c
          JOIN kanban_columns col ON c.column_id=col.id
+         LEFT JOIN todos t ON c.linked_todo_id=t.id
         WHERE col.board_id=$1
         ORDER BY c.position`,
       [boardId]

--- a/src/global.scss
+++ b/src/global.scss
@@ -2563,6 +2563,12 @@ hr {
   background-color: #e6ffe6;
 }
 
+.kanban-actions .todo-link {
+  text-decoration: none;
+  font-size: 1rem;
+  margin-left: 0.25rem;
+}
+
 .kanban-title {
   font-weight: 600;
   margin-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- include todo list id when loading kanban board data
- map todo list id into kanban card state and show a link on each card
- fix card modal link to point at `/todos/:id`
- style new todo list link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a6ac228788327868443d30557dfb9