### PR TITLE
Use Auth0 audience env variable

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <Auth0Provider
         domain={import.meta.env.VITE_AUTH0_DOMAIN}
         clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
-        authorizationParams={{ redirect_uri: window.location.origin }}
+        authorizationParams={{
+          redirect_uri: window.location.origin,
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE
+        }}
       >
         <App />
       </Auth0Provider>


### PR DESCRIPTION
## Summary
- include `import.meta.env.VITE_AUTH0_AUDIENCE` in the Auth0Provider parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a7806e0e48327a0b2be1510d07378