### PR TITLE
Implement final auth flow improvements

### DIFF
--- a/netlify/functions/createAuth0User.ts
+++ b/netlify/functions/createAuth0User.ts
@@ -7,26 +7,26 @@ const CLIENT_SECRET = process.env.AUTH0_CLIENT_SECRET as string
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   if (event.httpMethod !== 'POST') {
-    return jsonResponse(405, { success: false, message: 'Method Not Allowed' })
+    return jsonResponse(405, { success: false, error: 'Method Not Allowed' })
   }
   if (!event.body) {
-    return jsonResponse(400, { success: false, message: 'Missing body' })
+    return jsonResponse(400, { success: false, error: 'Missing body' })
   }
   let data: { email?: string; password?: string }
   try {
     data = JSON.parse(event.body)
   } catch {
-    return jsonResponse(400, { success: false, message: 'Invalid JSON' })
+    return jsonResponse(400, { success: false, error: 'Invalid JSON' })
   }
   const { email, password } = data
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
   if (!email || !emailRegex.test(email) || !password) {
-    return jsonResponse(400, { success: false, message: 'Invalid email or password' })
+    return jsonResponse(400, { success: false, error: 'Invalid email or password' })
   }
 
   if (!DOMAIN || !CLIENT_ID || !CLIENT_SECRET) {
     console.error('Missing Auth0 configuration')
-    return jsonResponse(500, { success: false, message: 'Configuration error' })
+    return jsonResponse(500, { success: false, error: 'Configuration error' })
   }
 
   try {
@@ -43,7 +43,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
 
     if (!tokenRes.ok) {
       console.error('Auth0 token request failed', await tokenRes.text())
-      return jsonResponse(500, { success: false, message: 'Auth0 token error' })
+      return jsonResponse(500, { success: false, error: 'Auth0 token error' })
     }
     const { access_token } = await tokenRes.json()
 
@@ -64,12 +64,12 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
       return jsonResponse(201, { success: true })
     }
     if (userRes.status === 409) {
-      return jsonResponse(409, { success: false, message: 'User already exists' })
+      return jsonResponse(409, { success: false, error: 'User already exists' })
     }
     console.error('Auth0 create user error', await userRes.text())
-    return jsonResponse(500, { success: false, message: 'Auth0 error' })
+    return jsonResponse(500, { success: false, error: 'Auth0 error' })
   } catch (err) {
     console.error('Auth0 user creation failed', err)
-    return jsonResponse(500, { success: false, message: 'Internal Server Error' })
+    return jsonResponse(500, { success: false, error: 'Internal Server Error' })
   }
 }


### PR DESCRIPTION
## Summary
- return `error` property in `createAuth0User` responses
- improve `/set-password` page with loading and missing email handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a7cba18e88327b86f05fd8c547d54