### PR TITLE
Redirect Auth0 login to dashboard

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         domain={import.meta.env.VITE_AUTH0_DOMAIN}
         clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
         authorizationParams={{
-          redirect_uri: window.location.origin,
+          redirect_uri: `${window.location.origin}/dashboard`,
           audience: import.meta.env.VITE_AUTH0_AUDIENCE
         }}
       >


### PR DESCRIPTION
## Summary
- send Auth0 login callback to `/dashboard`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688a92f0958c8327b3e16ca39f84f5af