### PR TITLE
Integrate Stripe checkout with Auth0 sign‑up

### DIFF
--- a/migrations/042_create_user_access.sql
+++ b/migrations/042_create_user_access.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS user_access (
+  email TEXT PRIMARY KEY,
+  auth0_id TEXT,
+  has_access BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION trigger_set_user_access_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_user_access_updated_at ON user_access;
+CREATE TRIGGER set_user_access_updated_at
+BEFORE UPDATE ON user_access
+FOR EACH ROW EXECUTE PROCEDURE trigger_set_user_access_updated_at();

--- a/set-password.tsx
+++ b/set-password.tsx
@@ -10,15 +10,11 @@ export default function SetPasswordPage(): JSX.Element {
   const [confirm, setConfirm] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
-  const [missingEmail, setMissingEmail] = useState(false)
 
   useEffect(() => {
     const fromQuery = searchParams.get('email')
-    const stored = localStorage.getItem('emailForPurchase')
-    const found = fromQuery || stored || ''
-    setEmail(found)
-    if (!found) {
-      setMissingEmail(true)
+    if (fromQuery) {
+      setEmail(fromQuery)
     }
   }, [searchParams])
 
@@ -76,13 +72,19 @@ export default function SetPasswordPage(): JSX.Element {
       <FaintMindmapBackground />
       <div className="form-card text-center login-form">
         <h2 className="text-2xl font-bold mb-6 text-center">Set Password</h2>
-        {missingEmail && (
-          <div className="text-red-600 mb-4">
-            Missing email. Please start your purchase again.
-          </div>
-        )}
         {error && <div className="text-red-600 mb-4">{error}</div>}
         <form onSubmit={handleSubmit} noValidate>
+          <div className="form-field">
+            <label htmlFor="email" className="form-label">Email</label>
+            <input
+              id="email"
+              type="email"
+              className="form-input"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+            />
+          </div>
           <div className="form-field">
             <label htmlFor="password" className="form-label">Password</label>
             <input

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -2,25 +2,15 @@ import { useState } from 'react'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 
 export default function PurchasePage() {
-  const [email, setEmail] = useState('')
-  const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
-  const handlePurchase = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError('')
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) {
-      setError('Valid email required')
-      return
-    }
+  const handlePurchase = async () => {
     setLoading(true)
-    localStorage.setItem('emailForPurchase', email)
+    setError('')
     try {
       const res = await fetch('/.netlify/functions/createCheckoutSession', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email })
+        method: 'POST'
       })
       const data = await res.json().catch(() => null)
       if (res.ok && data?.url) {
@@ -40,20 +30,10 @@ export default function PurchasePage() {
       <FaintMindmapBackground />
       <div className="container text-center">
         <h1 className="mb-md">Purchase MindXdo</h1>
-        <form onSubmit={handlePurchase} className="purchase-form">
-          <input
-            type="email"
-            required
-            placeholder="Email"
-            className="form-input mb-md"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-          />
-          {error && <p className="mb-md text-error">{error}</p>}
-          <button type="submit" className="btn" disabled={loading}>
-            {loading ? 'Processing...' : 'Purchase Now'}
-          </button>
-        </form>
+        {error && <p className="mb-md text-error">{error}</p>}
+        <button onClick={handlePurchase} className="btn" disabled={loading}>
+          {loading ? 'Processing...' : 'Purchase Now'}
+        </button>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- simplify purchase page to a single Stripe checkout button
- relax email requirement when creating checkout sessions
- store completed purchase emails in new `user_access` table via webhook
- verify access before creating Auth0 users and record their `auth0_id`
- collect email on the set password page
- add migration creating `user_access` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a9913ff248327b421e14e7ab1009b