### PR TITLE
Update todo link in kanban cards

### DIFF
--- a/InteractiveKanbanBoard.tsx
+++ b/InteractiveKanbanBoard.tsx
@@ -592,10 +592,10 @@ function Lane({
                     {card.todoListId && (
                       <a
                         href={`/todos/${card.todoListId}`}
-                        className="action-button todo-link"
+                        className="todo-link"
                         title="View Todo List"
                       >
-                        🔗
+                        View Todo
                       </a>
                     )}
                   </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -2592,8 +2592,8 @@ hr {
 
 .kanban-actions .todo-link {
   text-decoration: none;
-  font-size: 1rem;
-  margin-left: 0.25rem;
+  font-size: 0.8rem;
+  margin-left: auto;
 }
 
 .kanban-title {


### PR DESCRIPTION
## Summary
- show a "View Todo" link on kanban cards when a todo list is linked
- style the link to sit on the bottom-right of the card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688aaf839b048327b40e1565681c612e