### PR TITLE
docs: clarify Auth0 vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,11 @@ SESSION_EXPIRY_HOURS=24
 BCRYPT_SALT_ROUNDS=10
 VITE_AUTH0_DOMAIN=dev-8s7m3hg5gjlugoxd.us.auth0.com
 VITE_AUTH0_CLIENT_ID=IxXt9EC5IULulaRCfTpyEFtQlu4sHma0
+VITE_AUTH0_AUDIENCE=your-api-audience
+
+AUTH0_DOMAIN=your-auth0-domain
+AUTH0_CLIENT_ID=your-auth0-client-id
+AUTH0_CLIENT_SECRET=your-auth0-client-secret
+AUTH0_AUDIENCE=your-api-audience
+AUTH0_ISSUER=https://your-auth0-domain/
 PORT=443

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The purchase flow uses Auth0 for authentication and Stripe Checkout for payment.
 
 The flow is: `PurchasePage` → `createCheckoutSession` → Stripe Checkout → `handleStripeWebhook` → `set-password` → `createAuth0User` → protected routes.
 
-Environment variables include `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_AUDIENCE`, and `AUTH0_ISSUER`.
+Environment variables include `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_AUDIENCE`, `AUTH0_ISSUER`, and `VITE_AUTH0_AUDIENCE`.
 
 ## OpenAI Configuration
 


### PR DESCRIPTION
## Summary
- document Auth0 audience and issuer variables
- add example Auth0 variables to `.env.example`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ab524af708327b84acdc21c7026b2