### PR TITLE
Fix Auth0 token retrieval

### DIFF
--- a/account.tsx
+++ b/account.tsx
@@ -51,7 +51,11 @@ export default function AccountPage(): JSX.Element {
     setError(null)
     setMsg(null)
     try {
-      const token = await getAccessTokenSilently()
+      const token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: import.meta.env.VITE_AUTH0_AUDIENCE
+        }
+      })
       const res = await fetch('/.netlify/functions/cancelSubscription', {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -14,13 +14,17 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<Status | null>(null)
 
   useEffect(() => {
-    const check = async () => {
-      if (!isAuthenticated) return
-      try {
-        const token = await getAccessTokenSilently()
-        const res = await fetch('/.netlify/functions/user-status', {
-          headers: { Authorization: `Bearer ${token}` }
-        })
+      const check = async () => {
+        if (!isAuthenticated) return
+        try {
+          const token = await getAccessTokenSilently({
+            authorizationParams: {
+              audience: import.meta.env.VITE_AUTH0_AUDIENCE
+            }
+          })
+          const res = await fetch('/.netlify/functions/user-status', {
+            headers: { Authorization: `Bearer ${token}` }
+          })
         if (res.ok) {
           const json = await res.json()
           setStatus(json.data as Status)


### PR DESCRIPTION
## Summary
- pass the API audience when requesting access tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688abbc0bf708327bf4c343bc234b137