### PR TITLE
Remove email field from purchase flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Pushing changes to the `main` branch triggers a Netlify production build that de
 The purchase flow uses Auth0 for authentication and Stripe Checkout for payment.
 
 1. **Frontend**
-   - `src/PurchasePage.tsx` collects an email and calls `createCheckoutSession`.
-   - After payment, users land on `set-password.tsx` to create their Auth0 account.
+   - `src/PurchasePage.tsx` shows a purchase button and calls `createCheckoutSession`.
+   - After payment, users land on `set-password.tsx` to create their Auth0 account. The email is looked up from the Stripe session.
 2. **Netlify Functions**
    - `createCheckoutSession.ts` creates the Stripe Checkout session.
+   - `getCheckoutSession.ts` fetches the Stripe session email after checkout.
    - `handleStripeWebhook.ts` listens for `checkout.session.completed` and records the email.
    - `createAuth0User.ts` creates the Auth0 user once the password is set.
    - `secure-function.ts` demonstrates a protected endpoint using `verifyAuth0Token` from `netlify/lib/auth.ts`.

--- a/netlify/functions/getCheckoutSession.ts
+++ b/netlify/functions/getCheckoutSession.ts
@@ -1,0 +1,19 @@
+import type { HandlerEvent, HandlerContext } from '@netlify/functions'
+import { stripe } from './stripeclient.js'
+import { jsonResponse } from '../lib/response.js'
+
+export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
+  const sessionId = event.queryStringParameters?.session_id
+  if (!sessionId) {
+    return jsonResponse(400, { success: false, message: 'Missing session_id' })
+  }
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId)
+    const email =
+      session.customer_details?.email || session.customer_email || null
+    return jsonResponse(200, { success: true, email })
+  } catch (err) {
+    console.error('Failed to retrieve checkout session', err)
+    return jsonResponse(500, { success: false, message: 'Internal Server Error' })
+  }
+}

--- a/set-password.tsx
+++ b/set-password.tsx
@@ -13,12 +13,33 @@ export default function SetPasswordPage(): JSX.Element {
   const [missingEmail, setMissingEmail] = useState(false)
 
   useEffect(() => {
+    const sessionId = searchParams.get('session_id')
     const fromQuery = searchParams.get('email')
     const stored = localStorage.getItem('emailForPurchase')
-    const found = fromQuery || stored || ''
-    setEmail(found)
-    if (!found) {
-      setMissingEmail(true)
+
+    if (sessionId) {
+      fetch(`/.netlify/functions/getCheckoutSession?session_id=${sessionId}`)
+        .then(res => res.json().catch(() => null))
+        .then(data => {
+          const found = data?.email || fromQuery || stored || ''
+          setEmail(found)
+          if (!found) {
+            setMissingEmail(true)
+          }
+        })
+        .catch(() => {
+          const fallback = fromQuery || stored || ''
+          setEmail(fallback)
+          if (!fallback) {
+            setMissingEmail(true)
+          }
+        })
+    } else {
+      const found = fromQuery || stored || ''
+      setEmail(found)
+      if (!found) {
+        setMissingEmail(true)
+      }
     }
   }, [searchParams])
 

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -2,25 +2,17 @@ import { useState } from 'react'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 
 export default function PurchasePage() {
-  const [email, setEmail] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
   const handlePurchase = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) {
-      setError('Valid email required')
-      return
-    }
     setLoading(true)
-    localStorage.setItem('emailForPurchase', email)
     try {
       const res = await fetch('/.netlify/functions/createCheckoutSession', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email })
+        headers: { 'Content-Type': 'application/json' }
       })
       const data = await res.json().catch(() => null)
       if (res.ok && data?.url) {
@@ -42,14 +34,6 @@ export default function PurchasePage() {
         <h1 className="mb-md">Build Your Vision</h1>
         <p className="total-charge">$4.95 per month</p>
         <form onSubmit={handlePurchase} className="purchase-form mb-lg">
-          <input
-            type="email"
-            required
-            placeholder="Email"
-            className="form-input mb-md"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-          />
           {error && <p className="mb-md text-error">{error}</p>}
           <button type="submit" className="btn" disabled={loading}>
             {loading ? 'Processing...' : 'Purchase'}


### PR DESCRIPTION
## Summary
- simplify `PurchasePage` to only show a purchase button
- fetch checkout email through new `getCheckoutSession` function
- adjust `set-password` page to retrieve email using the session id
- create checkout session without prefilling email
- document the updated flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688abe783dd4832787d24853b695440b