### PR TITLE
Fix issuer normalization for Auth0 token verification

### DIFF
--- a/netlify/lib/auth.ts
+++ b/netlify/lib/auth.ts
@@ -1,13 +1,19 @@
 import { jwtVerify, createRemoteJWKSet } from 'jose'
 
-const ISSUER = process.env.AUTH0_ISSUER as string
+const ISSUER_RAW = process.env.AUTH0_ISSUER as string
 const AUDIENCE = process.env.AUTH0_AUDIENCE as string
+
+// Normalize issuer so verification works whether or not the env variable
+// includes a trailing slash.
+const ISSUER = ISSUER_RAW.replace(/\/+$/, '') + '/'
 
 if (!ISSUER || !AUDIENCE) {
   throw new Error('Missing Auth0 issuer or audience')
 }
 
-const jwks = createRemoteJWKSet(new URL(`${ISSUER}/.well-known/jwks.json`))
+// Remove the trailing slash when constructing the JWKS URL
+const jwksIssuer = ISSUER.replace(/\/+$/, '')
+const jwks = createRemoteJWKSet(new URL(`${jwksIssuer}/.well-known/jwks.json`))
 
 export async function verifyAuth0Token(request: Request) {
   const auth = request.headers.get('authorization') || ''


### PR DESCRIPTION
## Summary
- normalize `AUTH0_ISSUER` so verification works regardless of trailing slash
- build JWKS URL without a trailing slash to prevent `//.well-known` paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ac79575408327a1007b5bc38f0b3f