### PR TITLE
Fix user status 400 error

### DIFF
--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -8,7 +8,13 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
     const payload = await verifyAuth0Token(
       new Request('http://localhost', { headers: event.headers as any })
     )
-    const email = payload.email as string
+    let email = payload.email as string | undefined
+    if (!email) {
+      const headerEmail = event.headers['x-user-email'] || event.headers['X-User-Email']
+      if (headerEmail && typeof headerEmail === 'string') {
+        email = headerEmail
+      }
+    }
     if (!email) {
       return jsonResponse(400, { success: false, message: 'Missing email' })
     }

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -9,7 +9,7 @@ interface Status {
 }
 
 export default function ProtectedRoute({ children }: { children: ReactNode }) {
-  const { isAuthenticated, loginWithRedirect, isLoading, getAccessTokenSilently } = useAuth0()
+  const { isAuthenticated, loginWithRedirect, isLoading, getAccessTokenSilently, user } = useAuth0()
   const navigate = useNavigate()
   const [status, setStatus] = useState<Status | null>(null)
 
@@ -24,7 +24,10 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
             }
           })
           const res = await fetch('/.netlify/functions/user-status', {
-            headers: { Authorization: `Bearer ${token}` }
+            headers: {
+              Authorization: `Bearer ${token}`,
+              ...(user?.email ? { 'X-User-Email': user.email } : {})
+            }
           })
         if (res.ok) {
           const json = await res.json()


### PR DESCRIPTION
## Summary
- handle missing email gracefully by accepting `X-User-Email` header in the `user-status` serverless function
- include the Auth0 user email when requesting the status from the frontend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688af5808bdc8327905dab620304d81e