### PR TITLE
Add Auth0 troubleshooting logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,36 @@ The flow is: `PurchasePage` → `createCheckoutSession` → Stripe Checkout → 
 
 Environment variables include `STRIPE_SECRET_KEY`, `STRIPE_PRICE_ID`, `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_AUDIENCE`, `AUTH0_ISSUER`, and `VITE_AUTH0_AUDIENCE`.
 
+## Auth0 Debug Checklist
+
+Use this checklist to troubleshoot `401 Unauthorized` errors when calling your
+Netlify functions:
+
+1. **Verify the token's audience**
+   - Paste the access token into [jwt.io](https://jwt.io/) and confirm the
+     `aud` field equals `https://mindxdo.netlify.app/api`.
+   - If it doesn't, pass `audience: "https://mindxdo.netlify.app/api"` when
+     calling `getAccessTokenSilently()` or configuring `Auth0Provider`.
+2. **Log the Authorization header**
+   ```ts
+   console.log('Incoming Authorization Header:', event.headers.authorization)
+   ```
+   Ensure the header exists, begins with `Bearer`, and matches the token you
+   inspected in step&nbsp;1.
+3. **Check issuer and audience in `verifyAuth0Token()`**
+   ```ts
+   audience: 'https://mindxdo.netlify.app/api',
+   issuer: 'https://dev-8s7m3hg5gjlugoxd.us.auth0.com/'
+   ```
+   A typo in either value will cause a 401 response.
+4. **Retrieve the access token before API calls**
+   ```ts
+   const token = await getAccessTokenSilently({
+     audience: 'https://mindxdo.netlify.app/api'
+   })
+   ```
+   Only call your API after the token is retrieved.
+
 ## OpenAI Configuration
 
 Set the following variables in your Netlify environment to enable AI powered features:

--- a/netlify/functions/cancelSubscription.ts
+++ b/netlify/functions/cancelSubscription.ts
@@ -9,6 +9,10 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
     return jsonResponse(405, { success: false, message: 'Method Not Allowed' })
   }
   try {
+    console.log(
+      'Incoming Authorization Header:',
+      event.headers.authorization
+    )
     const payload = await verifyAuth0Token(
       new Request(process.env.SITE_URL || 'https://mindxdo.netlify.app', {
         headers: event.headers as any

--- a/netlify/functions/secure-function.ts
+++ b/netlify/functions/secure-function.ts
@@ -4,6 +4,10 @@ import { jsonResponse } from '../lib/response.js'
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
+    console.log(
+      'Incoming Authorization Header:',
+      event.headers.authorization
+    )
     await verifyAuth0Token(
       new Request(process.env.SITE_URL || 'https://mindxdo.netlify.app', {
         headers: event.headers as any


### PR DESCRIPTION
## Summary
- document how to debug Auth0 audience issues
- log the `Authorization` header in `secure-function` and `cancelSubscription`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b0da68b548327893239e4c31ebabf