### PR TITLE
Fix Auth0 login audience

### DIFF
--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -11,7 +11,14 @@ const LoginPage = () => {
     error,
   } = useAuth0()
 
-  const signup = () => login({ authorizationParams: { screen_hint: 'signup' } })
+  const signup = () =>
+    login({
+      authorizationParams: {
+        screen_hint: 'signup',
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        scope: 'openid profile email',
+      },
+    })
   const logout = () =>
     auth0Logout({ logoutParams: { returnTo: window.location.origin } })
 
@@ -44,7 +51,17 @@ const LoginPage = () => {
           <button className="btn w-full mb-4" onClick={signup}>
             Signup
           </button>
-          <button className="btn w-full" onClick={login}>
+          <button
+            className="btn w-full"
+            onClick={() =>
+              login({
+                authorizationParams: {
+                  audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+                  scope: 'openid profile email',
+                },
+              })
+            }
+          >
             Login
           </button>
         </div>

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -44,7 +44,12 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
 
   if (isLoading || !status) return null
   if (!isAuthenticated) {
-    loginWithRedirect()
+    loginWithRedirect({
+      authorizationParams: {
+        audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+        scope: 'openid profile email',
+      },
+    })
     return null
   }
   const now = Date.now()

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -237,7 +237,12 @@ const Header = (): JSX.Element => {
                 className="header__login-link"
                 onClick={e => {
                   e.preventDefault()
-                  login()
+                  login({
+                    authorizationParams: {
+                      audience: import.meta.env.VITE_AUTH0_AUDIENCE,
+                      scope: 'openid profile email',
+                    },
+                  })
                 }}
               >
                 Login

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
         authorizationParams={{
           redirect_uri: `${window.location.origin}/dashboard`,
+          scope: 'openid profile email',
           audience: import.meta.env.VITE_AUTH0_AUDIENCE
         }}
       >


### PR DESCRIPTION
## Summary
- ensure Auth0Provider requests the custom API audience
- pass audience when calling `loginWithRedirect`
- request same audience when redirecting unauthenticated users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b13bd27b48327985e8bbb89f9d6be