### PR TITLE
Add trial registration page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import TermsOfService from '../terms'
 import CheckoutPage from '../checkout'
 import TrialExpired from '../trialexpired'
 import SetPassword from '../set-password'
+import TrialRegister from '../trial-register'
 
 import LoginPage from './LoginPage'
 import DashboardPage from './DashboardPage'
@@ -56,6 +57,7 @@ function AppRoutes() {
       <Route path="/set-password" element={<SetPassword />} />
       <Route path="/privacy" element={<PrivacyPolicy />} />
       <Route path="/terms" element={<TermsOfService />} />
+      <Route path="/register" element={<TrialRegister />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
       <Route path="/team-members" element={<ProtectedRoute><TeamMembers /></ProtectedRoute>} />

--- a/src/LoginPage.tsx
+++ b/src/LoginPage.tsx
@@ -48,6 +48,10 @@ const LoginPage = () => {
               {error.message}
             </p>
           )}
+          <div className="mb-4">
+            <p className="mb-2 font-semibold">Free 3-Day Trial</p>
+            <a href="/register" className="btn w-full">Start Free Trial</a>
+          </div>
           <button className="btn w-full mb-4" onClick={signup}>
             Signup
           </button>

--- a/trial-register.tsx
+++ b/trial-register.tsx
@@ -1,0 +1,89 @@
+import { useState, FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import FaintMindmapBackground from './FaintMindmapBackground'
+
+export default function TrialRegister() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const navigate = useNavigate()
+
+  const validate = () => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      setError('Valid email required.')
+      return false
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters long.')
+      return false
+    }
+    return true
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+    if (!validate()) return
+    setLoading(true)
+    try {
+      const res = await fetch('/.netlify/functions/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const data = await res.json().catch(() => null)
+      if (res.status === 201) {
+        navigate('/login')
+        return
+      }
+      if (res.status === 409) {
+        setError('Account already exists. Please log in.')
+      } else {
+        setError(data?.error || 'Failed to register.')
+      }
+    } catch {
+      setError('Failed to register.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="section login-page relative overflow-x-visible">
+      <FaintMindmapBackground />
+      <div className="form-card text-center login-form">
+        <h2 className="text-2xl font-bold mb-6 text-center">Free 3-Day Trial</h2>
+        {error && <div className="text-red-600 mb-4">{error}</div>}
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="form-field">
+            <label htmlFor="email" className="form-label">Email</label>
+            <input
+              id="email"
+              type="email"
+              className="form-input"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="password" className="form-label">Password</label>
+            <input
+              id="password"
+              type="password"
+              className="form-input"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <button type="submit" className="btn w-full" disabled={loading}>
+            {loading ? 'Registering...' : 'Register'}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add TrialRegister page for free 3-day trial signup
- link from login page
- route new page in App

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bb7faee64832796b764c07de24fcc