### PR TITLE
Enhance login and purchase flow

### DIFF
--- a/login.tsx
+++ b/login.tsx
@@ -5,7 +5,7 @@ import React, {
   ChangeEvent,
   FormEvent
 } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
 
@@ -163,6 +163,12 @@ const LoginPage = (): JSX.Element => {
           {isLoading ? 'Logging in...' : 'Login'}
         </button>
       </form>
+      <div className="trial-info mt-md">
+        <p className="mb-2">New here? Start a free 3-Day Trial.</p>
+        <Link to="/register" className="btn-secondary w-full">
+          Start Free Trial
+        </Link>
+      </div>
       </div>
     </section>
   )

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import FaintMindmapBackground from '../FaintMindmapBackground'
+import { authFetch } from '../authFetch'
 
 export default function PurchasePage() {
   const [error, setError] = useState('')
@@ -10,7 +11,7 @@ export default function PurchasePage() {
     setError('')
     setLoading(true)
     try {
-      const res = await fetch('/.netlify/functions/createCheckoutSession', {
+      const res = await authFetch('/.netlify/functions/createCheckoutSession', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
       })


### PR DESCRIPTION
## Summary
- add free trial link on the login page
- require authentication when purchasing
- remove extra message about requiring an account on the purchase page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bbd1d6eb08327bc00067e648eeb5b