### PR TITLE
Implement usage limits and alerts

### DIFF
--- a/account.tsx
+++ b/account.tsx
@@ -5,7 +5,7 @@ import {
   LIMIT_MINDMAPS,
   LIMIT_TODO_LISTS,
   LIMIT_KANBAN_BOARDS,
-  TOTAL_AI_LIMIT,
+  LIMIT_AI_MONTHLY,
 } from './src/constants'
 
 interface Usage {
@@ -105,7 +105,7 @@ export default function AccountPage(): JSX.Element {
             <tr>
               <td className="metric-label">AI Automations</td>
               <td className="metric-value">
-                {usage.aiUsage}/{TOTAL_AI_LIMIT} this month
+                {usage.aiUsage}/{LIMIT_AI_MONTHLY} this month
               </td>
             </tr>
           </tbody>

--- a/netlify/functions/limits.ts
+++ b/netlify/functions/limits.ts
@@ -1,6 +1,8 @@
 export const LIMIT_MINDMAPS = 10
 export const LIMIT_TODO_LISTS = 100
 export const LIMIT_KANBAN_BOARDS = 10
-export const LIMIT_AI_MONTHLY = 20
+// Expose a monthly limit of 25 AI automations but keep a
+// server-side buffer of 5 extra attempts.
+export const LIMIT_AI_MONTHLY = 25
 export const AI_BUFFER = 5
 export const TOTAL_AI_LIMIT = LIMIT_AI_MONTHLY + AI_BUFFER

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -7,7 +7,7 @@ import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
 import Sparkline from './Sparkline'
 import DashboardTile, { DashboardItem } from './DashboardTile'
-import { LIMIT_MINDMAPS, LIMIT_TODO_LISTS, LIMIT_KANBAN_BOARDS, TOTAL_AI_LIMIT } from "./constants"
+import { LIMIT_MINDMAPS, LIMIT_TODO_LISTS, LIMIT_KANBAN_BOARDS, LIMIT_AI_MONTHLY } from "./constants"
 import {
   MapItem,
   BoardItem,
@@ -159,6 +159,10 @@ export default function DashboardPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
+    if (aiUsage >= LIMIT_AI_MONTHLY) {
+      alert('AI automation limit reached')
+      return
+    }
     setAiLoading(true)
     try {
       if (createType === 'map') {
@@ -402,6 +406,8 @@ export default function DashboardPage(): JSX.Element {
                   if (maps.length < LIMIT_MINDMAPS) {
                     setCreateType('map')
                     setShowModal(true)
+                  } else {
+                    alert('Mindmap limit reached')
                   }
                 }}
               />
@@ -415,6 +421,8 @@ export default function DashboardPage(): JSX.Element {
                   if (todoLists.length < LIMIT_TODO_LISTS) {
                     setCreateType('todo')
                     setShowModal(true)
+                  } else {
+                    alert('Todo list limit reached')
                   }
                 }}
               />
@@ -427,6 +435,8 @@ export default function DashboardPage(): JSX.Element {
                   if (boards.length < LIMIT_KANBAN_BOARDS) {
                     setCreateType('board')
                     setShowModal(true)
+                  } else {
+                    alert('Kanban board limit reached')
                   }
                 }}
               />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,9 @@
 export const LIMIT_MINDMAPS = 10
 export const LIMIT_TODO_LISTS = 100
 export const LIMIT_KANBAN_BOARDS = 10
-export const LIMIT_AI_MONTHLY = 20
+// Users can run 25 AI automations per month but we allow a
+// hidden buffer of 5 additional attempts.
+export const LIMIT_AI_MONTHLY = 25
 export const AI_BUFFER = 5
+// Total attempts allowed before blocking
 export const TOTAL_AI_LIMIT = LIMIT_AI_MONTHLY + AI_BUFFER


### PR DESCRIPTION
## Summary
- set monthly and server-side AI automation limits
- display AI usage using monthly limit
- alert user when creation limits are reached

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bccbdbaf483279850485d6fa4540a