### PR TITLE
Add purchase-specific registration

### DIFF
--- a/purchase-register.tsx
+++ b/purchase-register.tsx
@@ -1,0 +1,116 @@
+import { useState, FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import FaintMindmapBackground from './FaintMindmapBackground'
+import { authFetch } from './authFetch'
+
+export default function PurchaseRegister() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+  const navigate = useNavigate()
+
+  const validate = () => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      setError('Valid email required.')
+      return false
+    }
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters long.')
+      return false
+    }
+    if (password !== confirm) {
+      setError('Passwords do not match.')
+      return false
+    }
+    return true
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError('')
+    if (!validate()) return
+    setLoading(true)
+    try {
+      const res = await fetch('/.netlify/functions/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const data = await res.json().catch(() => null)
+      if (res.status === 201) {
+        localStorage.setItem('emailForPurchase', email)
+        const checkoutRes = await authFetch('/.netlify/functions/createCheckoutSession', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+        const checkout = await checkoutRes.json().catch(() => null)
+        if (checkoutRes.ok && checkout?.url) {
+          window.location.href = checkout.url as string
+          return
+        }
+        setError(checkout?.message || 'Failed to start checkout')
+        return
+      }
+      if (res.status === 409) {
+        setError('Account already exists. Please log in.')
+      } else {
+        setError(data?.error || 'Failed to register.')
+      }
+    } catch {
+      setError('Failed to register.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <section className="section login-page relative overflow-x-visible">
+      <FaintMindmapBackground />
+      <div className="form-card text-center login-form">
+        <h2 className="text-2xl font-bold mb-6 text-center">Step 1: Create Account</h2>
+        {error && <div className="text-red-600 mb-4">{error}</div>}
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="form-field">
+            <label htmlFor="email" className="form-label">Email</label>
+            <input
+              id="email"
+              type="email"
+              className="form-input"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="password" className="form-label">Password</label>
+            <input
+              id="password"
+              type="password"
+              className="form-input"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="confirm" className="form-label">Confirm Password</label>
+            <input
+              id="confirm"
+              type="password"
+              className="form-input"
+              value={confirm}
+              onChange={e => setConfirm(e.target.value)}
+              required
+            />
+          </div>
+          <button type="submit" className="btn w-full" disabled={loading}>
+            {loading ? 'Processing...' : 'Register'}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import CheckoutPage from '../checkout'
 import TrialExpired from '../trialexpired'
 import SetPassword from '../set-password'
 import TrialRegister from '../trial-register'
+import PurchaseRegister from '../purchase-register'
 
 import LoginPage from '../login'
 import DashboardPage from './DashboardPage'
@@ -58,6 +59,7 @@ function AppRoutes() {
       <Route path="/privacy" element={<PrivacyPolicy />} />
       <Route path="/terms" element={<TermsOfService />} />
       <Route path="/register" element={<TrialRegister />} />
+      <Route path="/purchase-register" element={<PurchaseRegister />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
       <Route path="/team-members" element={<ProtectedRoute><TeamMembers /></ProtectedRoute>} />

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -16,7 +16,7 @@ export default function PurchasePage() {
       const meRes = await fetch('/.netlify/functions/me', { credentials: 'include' })
       const me = await meRes.json().catch(() => null)
       if (!me?.authenticated) {
-        navigate('/register?next=/purchase')
+        navigate('/purchase-register?next=/purchase')
         return
       }
 


### PR DESCRIPTION
## Summary
- add `purchase-register` page for sign-ups from purchase flow
- route new page in the app and use it when the purchase page needs authentication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688be062867083278a1c91ba24d04d47