### PR TITLE
Improve register function error handling

### DIFF
--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -17,106 +17,109 @@ export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {
-  const {
-    NETLIFY_DATABASE_URL,
-    JWT_SECRET,
-    BCRYPT_SALT_ROUNDS = '10',
-    SESSION_EXPIRY_HOURS = '24',
-  } = process.env
-
-  if (!NETLIFY_DATABASE_URL) {
-    console.error('❌ Missing NETLIFY_DATABASE_URL')
-    throw new Error('Missing NETLIFY_DATABASE_URL')
-  }
-  if (!JWT_SECRET) {
-    console.error('❌ Missing JWT_SECRET')
-    throw new Error('Missing JWT_SECRET')
-  }
-  if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 204,
-      headers: corsHeaders,
-      body: '',
-    }
-  }
-  if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers: { ...corsHeaders, Allow: 'POST' },
-      body: JSON.stringify({ error: 'Method Not Allowed' }),
-    }
-  }
-  if (!event.body) {
-    return {
-      statusCode: 400,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: 'Missing request body' }),
-    }
-  }
-  let body
   try {
-    body = JSON.parse(event.body || '{}')
-  } catch (err) {
-    return {
-      statusCode: 400,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: 'Invalid request body' }),
-    }
-  }
+    const {
+      NETLIFY_DATABASE_URL,
+      JWT_SECRET,
+      BCRYPT_SALT_ROUNDS = '10',
+      SESSION_EXPIRY_HOURS = '24',
+    } = process.env
 
-  const { email, password } = body as any
-
-  if (!email || !password) {
-    return {
-      statusCode: 400,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: 'Missing email or password' }),
+    if (!NETLIFY_DATABASE_URL) {
+      console.error('❌ Missing NETLIFY_DATABASE_URL')
+      throw new Error('Missing NETLIFY_DATABASE_URL')
     }
-  }
-  const client = await getClient()
-  try {
-    const existingUser = await client.query(
-      'SELECT id FROM users WHERE email = $1',
-      [email]
-    )
-    const count = existingUser.rowCount ?? 0
-    if (count > 0) {
+    if (!JWT_SECRET) {
+      console.error('❌ Missing JWT_SECRET')
+      throw new Error('Missing JWT_SECRET')
+    }
+    if (event.httpMethod === 'OPTIONS') {
       return {
-        statusCode: 409,
+        statusCode: 204,
         headers: corsHeaders,
-        body: JSON.stringify({ error: 'Email already registered' }),
+        body: '',
       }
     }
-    const passwordHash = await bcrypt.hash(
-      password,
-      parseInt(BCRYPT_SALT_ROUNDS)
-    )
-    const result = await client.query(
-      `INSERT INTO users (email, password_hash, subscription_status, trial_start_date)
+    if (event.httpMethod !== 'POST') {
+      return {
+        statusCode: 405,
+        headers: { ...corsHeaders, Allow: 'POST' },
+        body: JSON.stringify({ error: 'Method Not Allowed' }),
+      }
+    }
+    if (!event.body) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: 'Missing request body' }),
+      }
+    }
+    let body
+    try {
+      body = JSON.parse(event.body || '{}')
+    } catch (err) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: 'Invalid request body' }),
+      }
+    }
+
+    const { email, password } = body as any
+
+    if (!email || !password) {
+      return {
+        statusCode: 400,
+        headers: corsHeaders,
+        body: JSON.stringify({ error: 'Missing email or password' }),
+      }
+    }
+
+    const client = await getClient()
+    try {
+      const existingUser = await client.query(
+        'SELECT id FROM users WHERE email = $1',
+        [email]
+      )
+      const count = existingUser.rowCount ?? 0
+      if (count > 0) {
+        return {
+          statusCode: 409,
+          headers: corsHeaders,
+          body: JSON.stringify({ error: 'Email already registered' }),
+        }
+      }
+      const passwordHash = await bcrypt.hash(
+        password,
+        parseInt(BCRYPT_SALT_ROUNDS)
+      )
+      const result = await client.query(
+        `INSERT INTO users (email, password_hash, subscription_status, trial_start_date)
        VALUES ($1, $2, 'trialing', now())
        RETURNING id`,
-      [email, passwordHash]
-    )
-    const newUserId = result.rows[0].id
-    const token = jwt.sign(
-      { userId: newUserId },
-      JWT_SECRET as string,
-      { expiresIn: `${SESSION_EXPIRY_HOURS}h` }
-    )
-    return {
-      statusCode: 201,
-      headers: corsHeaders,
-      body: JSON.stringify({ token }),
+        [email, passwordHash]
+      )
+      const newUserId = result.rows[0].id
+      const token = jwt.sign(
+        { userId: newUserId },
+        JWT_SECRET as string,
+        { expiresIn: `${SESSION_EXPIRY_HOURS}h` }
+      )
+      return {
+        statusCode: 201,
+        headers: corsHeaders,
+        body: JSON.stringify({ token }),
+      }
+    } finally {
+      client.release()
     }
-  } catch (error) {
-    console.error('Registration error:', error)
+  } catch (err: any) {
+    console.error('🔥 Registration failure:', err)
     return {
       statusCode: 500,
       headers: corsHeaders,
       body: JSON.stringify({ error: 'Internal server error' }),
     }
-  } finally {
-    client.release()
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap registration logic in a try/catch block
- provide detailed logging when registration fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bf181e7e88327b399a9fae5b08138