### PR TITLE
feat: allow admin bypass for user status

### DIFF
--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -3,12 +3,25 @@ import { getClient } from './db-client.js'
 import { jsonResponse } from '../lib/response.js'
 import { requireAuth } from '../lib/auth.js'
 
+const { ADMIN_EMAIL, ADMIN_PASSWORD } = process.env
+
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
-    const { email } = requireAuth(event)
+    let userEmail: string | undefined
 
-    const headerEmail = (event.headers['x-user-email'] || event.headers['X-User-Email']) as string | undefined
-    const userEmail = email || headerEmail
+    const qs = event.queryStringParameters || {}
+    if (
+      ADMIN_EMAIL &&
+      ADMIN_PASSWORD &&
+      qs.email === ADMIN_EMAIL &&
+      qs.password === ADMIN_PASSWORD
+    ) {
+      userEmail = ADMIN_EMAIL
+    } else {
+      const { email } = requireAuth(event)
+      const headerEmail = (event.headers['x-user-email'] || event.headers['X-User-Email']) as string | undefined
+      userEmail = email || headerEmail
+    }
 
     if (!userEmail) {
       return jsonResponse(400, { success: false, message: 'Missing email' })


### PR DESCRIPTION
## Summary
- enable admin access in user status via ADMIN_EMAIL and ADMIN_PASSWORD query params before regular auth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bfdc138e483279677140dd0663f38