### PR TITLE
Add migration for missing subscription column

### DIFF
--- a/migrations/043_add_subscription_status.sql
+++ b/migrations/043_add_subscription_status.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS subscription_status TEXT NOT NULL DEFAULT 'free' CHECK (subscription_status IN ('free','trialing','active','past_due','canceled','unpaid'));
+
+-- +migrate Down
+ALTER TABLE users
+  DROP COLUMN IF EXISTS subscription_status;


### PR DESCRIPTION
## Summary
- create migration to add `subscription_status` column to `users`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c0310fa9c8327bb8b30a2df4f615c