### PR TITLE
Run pending migrations on first database connection

### DIFF
--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -1,4 +1,7 @@
 import { Pool as PgPool, PoolClient } from 'pg'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 const { NETLIFY_DATABASE_URL } = process.env
 
@@ -13,6 +16,50 @@ export const pool = new PgPool({
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : undefined,
 })
 
+let migrationPromise: Promise<void> | null = null
+
+async function runMigrations() {
+  const client = await pool.connect()
+  try {
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version TEXT PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+    `)
+
+    const migrationsDir = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      '../../migrations'
+    )
+    const files = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort()
+
+    for (const file of files) {
+      const already = await client.query('SELECT 1 FROM schema_migrations WHERE version = $1', [file])
+      if (already.rowCount > 0) continue
+
+      const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8')
+      try {
+        await client.query('BEGIN')
+        await client.query(sql)
+        await client.query(`INSERT INTO schema_migrations (version) VALUES ($1)`, [file])
+        await client.query('COMMIT')
+        console.log(`✅ Applied ${file}`)
+      } catch (err) {
+        await client.query('ROLLBACK')
+        console.error(`❌ Error applying ${file}:`, err)
+        throw err
+      }
+    }
+  } finally {
+    client.release()
+  }
+}
+
 export async function getClient(): Promise<PoolClient> {
+  if (!migrationPromise) {
+    migrationPromise = runMigrations()
+  }
+  await migrationPromise
   return pool.connect()
 }


### PR DESCRIPTION
## Summary
- apply pending SQL migrations automatically when obtaining a DB client to keep schema current

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c0761337c83279b24fc66e336df30