### PR TITLE
fix: guard null rowCount

### DIFF
--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -42,7 +42,7 @@ async function runMigrations() {
 
     for (const file of files) {
       const already = await client.query('SELECT 1 FROM schema_migrations WHERE version = $1', [file])
-      if (already.rowCount > 0) continue
+      if (already.rowCount !== null && already.rowCount > 0) continue
 
       const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8')
       try {


### PR DESCRIPTION
## Summary
- ensure `already.rowCount` is non-null before comparing

## Testing
- `npm test`
- `npm run compile:functions` (fails: Cannot find module '@netlify/functions' and others)
- `npm install` (fails: E403 Forbidden fetching @neondatabase/serverless)


------
https://chatgpt.com/codex/tasks/task_e_688c0e07fcf88327aeb5ee0fa1d373f0