### PR TITLE
fix: handle missing import meta in migrations path

### DIFF
--- a/netlify/functions/db-client.ts
+++ b/netlify/functions/db-client.ts
@@ -19,10 +19,14 @@ export const pool = new PgPool({
 let migrationPromise: Promise<void> | null = null
 
 async function runMigrations() {
-  const migrationsDir = path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    '../../../migrations'
-  )
+  let migrationsDir: string
+  try {
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+    migrationsDir = path.join(moduleDir, '../../../migrations')
+  } catch {
+    // Fallback when import.meta.url is unavailable (e.g. bundled CommonJS)
+    migrationsDir = path.join(process.cwd(), 'migrations')
+  }
 
   if (!fs.existsSync(migrationsDir)) {
     console.warn(`Migrations directory not found at ${migrationsDir}`)


### PR DESCRIPTION
## Summary
- avoid runtime crash when resolving migrations directory if `import.meta.url` is unavailable

## Testing
- `npm test`
- `npm run compile:functions`


------
https://chatgpt.com/codex/tasks/task_e_688c126de64083278b6a3c2618387f21