### PR TITLE
Enforce strict JWT session validation for user endpoints

### DIFF
--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -3,24 +3,18 @@ import { getClient } from './db-client.js'
 import { jsonResponse } from '../lib/response.js'
 import { requireAuth } from '../lib/auth.js'
 
-const { ADMIN_EMAIL, ADMIN_PASSWORD } = process.env
+const { ADMIN_EMAIL } = process.env
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
-    let userEmail: string | undefined
-
+    const { email: authEmail } = requireAuth(event)
     const qs = event.queryStringParameters || {}
-    if (
-      ADMIN_EMAIL &&
-      ADMIN_PASSWORD &&
-      qs.email === ADMIN_EMAIL &&
-      qs.password === ADMIN_PASSWORD
-    ) {
-      userEmail = ADMIN_EMAIL
+
+    let userEmail: string | undefined
+    if (ADMIN_EMAIL && authEmail === ADMIN_EMAIL) {
+      userEmail = qs.email || authEmail
     } else {
-      const { email } = requireAuth(event)
-      const headerEmail = (event.headers['x-user-email'] || event.headers['X-User-Email']) as string | undefined
-      userEmail = email || headerEmail
+      userEmail = authEmail
     }
 
     if (!userEmail) {


### PR DESCRIPTION
## Summary
- verify sessions from cookies in `me` endpoint before returning authenticated user info
- gate `user-status` via JWT payload and query subscription data from the database

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c192643a88327a94ff10fb38407c5