### PR TITLE
Ensure secure session validation

### DIFF
--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -79,9 +79,8 @@ export async function login(email: string, password: string): Promise<string> {
     if (password !== adminPassword) {
       throw new Error('Invalid password')
     }
-    return jwt.sign({ userId: 'admin', email: adminEmail, role: 'admin' }, JWT_SECRET, {
-      expiresIn: `${SESSION_EXPIRY_HOURS}h`
-    })
+    // Admin sessions are created like regular user sessions
+    return createSession('admin', adminEmail, 'admin')
   }
 
   const { userId, role } = await authenticateUser(email, password)
@@ -90,17 +89,6 @@ export async function login(email: string, password: string): Promise<string> {
 
 export async function verifySession(token: string): Promise<SessionPayload> {
   const payload = verifyJwt(token)
-  const adminEmail = process.env.ADMIN_EMAIL
-  if (adminEmail && payload.email === adminEmail) {
-    return {
-      userId: payload.userId,
-      email: payload.email,
-      role: payload.role,
-      sessionStart: payload.sessionStart,
-      iat: payload.iat,
-      exp: payload.exp
-    }
-  }
   const tokenHash = createHash('sha256').update(token).digest('hex')
   const client = await pool.connect()
   try {

--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -7,15 +7,11 @@ const { ADMIN_EMAIL } = process.env
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
-    const { email: authEmail } = requireAuth(event)
+    const payload = requireAuth(event)
     const qs = event.queryStringParameters || {}
 
-    let userEmail: string | undefined
-    if (ADMIN_EMAIL && authEmail === ADMIN_EMAIL) {
-      userEmail = qs.email || authEmail
-    } else {
-      userEmail = authEmail
-    }
+    const userEmail =
+      ADMIN_EMAIL && payload.email === ADMIN_EMAIL ? qs.email || payload.email : payload.email
 
     if (!userEmail) {
       return jsonResponse(400, { success: false, message: 'Missing email' })


### PR DESCRIPTION
## Summary
- Create admin sessions during login and always verify JWT-backed sessions against the database
- Tighten user-status handler to check ADMIN_EMAIL and look up subscription fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c2002485883278d6001aaad563ca8