### PR TITLE
Use UUID for admin session

### DIFF
--- a/netlify/functions/auth.ts
+++ b/netlify/functions/auth.ts
@@ -5,6 +5,8 @@ import cookie from 'cookie'
 import { createHash } from 'crypto'
 import { pool } from './db-client.js'
 
+const ADMIN_ID = '00000000-0000-0000-0000-000000000000'
+
 export interface SessionPayload {
   userId: string
   email?: string
@@ -79,8 +81,8 @@ export async function login(email: string, password: string): Promise<string> {
     if (password !== adminPassword) {
       throw new Error('Invalid password')
     }
-    // Admin sessions are created like regular user sessions
-    return createSession('admin', adminEmail, 'admin')
+    // Admin sessions are created like regular user sessions with a fixed UUID
+    return createSession(ADMIN_ID, adminEmail, 'admin')
   }
 
   const { userId, role } = await authenticateUser(email, password)

--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -3,6 +3,8 @@ import { getClient } from './db-client.js'
 import { jsonResponse } from '../lib/response.js'
 import { extractToken, verifySession } from './auth.js'
 
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL?.toLowerCase()
+
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
     const token = extractToken(event)
@@ -13,7 +15,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
     const payload = await verifySession(token)
     const userEmail = payload.email?.toLowerCase()
 
-    if (payload.role === 'admin') {
+    if (payload.role === 'admin' || userEmail === ADMIN_EMAIL) {
       return jsonResponse(200, {
         success: true,
         data: {


### PR DESCRIPTION
## Summary
- assign a fixed UUID to admin logins to avoid cast errors
- bypass DB lookup in user-status for admin sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c2af643108327a6b994cab731382e