### PR TITLE
feat: make header login a button

### DIFF
--- a/mobilemenu.tsx
+++ b/mobilemenu.tsx
@@ -19,9 +19,15 @@ const DesktopMenu = (): JSX.Element => (
         </li>
       ))}
     </ul>
-    <a href="/login" className="desktop-menu__login">
+    <button
+      type="button"
+      className="desktop-menu__login"
+      onClick={() => {
+        window.location.href = '/login'
+      }}
+    >
       Login
-    </a>
+    </button>
   </nav>
 )
 
@@ -115,9 +121,16 @@ const MobileMenu = (): JSX.Element => {
               </li>
             ))}
           </ul>
-          <a href="/login" className="mobile-menu__login" onClick={toggleMenu}>
+          <button
+            type="button"
+            className="mobile-menu__login"
+            onClick={() => {
+              toggleMenu()
+              window.location.href = '/login'
+            }}
+          >
             Login
-          </a>
+          </button>
           <button
             type="button"
             className="mobile-menu__close"

--- a/src/global.scss
+++ b/src/global.scss
@@ -771,6 +771,12 @@ hr {
   gap: 15px;
 }
 
+@media (max-width: 1024px) {
+  .header__actions--marketing {
+    gap: 30px;
+  }
+}
+
 
 .header__nav-list {
   display: flex;

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -227,6 +227,7 @@ const Header = (): JSX.Element => {
           ) : (
             <>
               <button
+                type="button"
                 className="header__login-link"
                 onClick={e => {
                   e.preventDefault()


### PR DESCRIPTION
## Summary
- turn login links in desktop and mobile menus into buttons
- add `type="button"` to header login button for consistency
- widen hamburger/login spacing on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c30b5923c832783998d77484d21d7