### PR TITLE
Refine auth flow and admin session handling

### DIFF
--- a/login.tsx
+++ b/login.tsx
@@ -8,7 +8,6 @@ import React, {
 import { useNavigate, Link } from 'react-router-dom'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
-import { useUser } from './src/lib/UserContext'
 
 interface LoginFormValues {
   email: string
@@ -22,7 +21,6 @@ const LoginPage = (): JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const navigate = useNavigate()
   const abortControllerRef = useRef<AbortController | null>(null)
-  const { fetchUser } = useUser()
 
   useEffect(() => {
     return () => {
@@ -102,9 +100,8 @@ const LoginPage = (): JSX.Element => {
       })
       .then(data => {
         if (data?.success) {
-          return fetchUser().then(() => {
-            navigate('/dashboard')
-          })
+          navigate('/dashboard')
+          return
         }
         throw new Error('Login failed')
       })

--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -20,8 +20,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
         data: {
           subscription_status: 'active',
           trial_start_date: null,
-          paid_thru_date: null,
-          role: 'admin'
+          paid_thru_date: null
         }
       })
     }

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -18,14 +18,7 @@ const Header = (): JSX.Element => {
 
   const navigate = useNavigate()
   const location = useLocation()
-  const { user, fetchUser } = useUser()
-  const [checking, setChecking] = useState(true)
-
-  useEffect(() => {
-    fetchUser().finally(() => setChecking(false))
-  }, [fetchUser])
-
-  if (checking) return null
+  const { user } = useUser()
 
   const isAuthenticated = !!user
   const marketingItems: NavItem[] = [


### PR DESCRIPTION
## Summary
- streamline ProtectedRoute to avoid redundant status checks, skip `/user-status` for admins, and prevent repeated login redirects
- remove extra user fetching from header and login, allowing ProtectedRoute to own authentication flow
- return static active status for admin sessions in `/user-status`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c392541108327b0d139ec54104a77