### PR TITLE
Streamline admin session handling

### DIFF
--- a/netlify/functions/me.ts
+++ b/netlify/functions/me.ts
@@ -2,6 +2,7 @@ import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { getClient } from './db-client.js'
 import type { PoolClient } from 'pg'
 import { verifySession, extractToken } from './auth.js'
+import { isAdmin } from '../lib/isAdmin.js'
 
 const allowedOrigin = process.env.CORS_ORIGIN || '*'
 const CORS_HEADERS = {
@@ -10,7 +11,6 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'Content-Type, Authorization',
   'Access-Control-Allow-Credentials': 'true'
 }
-const ADMIN_EMAIL = process.env.ADMIN_EMAIL
 
 async function columnExists(
   client: PoolClient,
@@ -50,7 +50,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
     const { email, userId, role } = await verifySession(token)
     console.log('✅ Verified token payload:', { email, userId, role })
 
-    if (role === 'admin' || (ADMIN_EMAIL && email === ADMIN_EMAIL)) {
+    if (isAdmin({ email, role })) {
       return {
         statusCode: 200,
         headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },

--- a/netlify/functions/user-status.ts
+++ b/netlify/functions/user-status.ts
@@ -2,6 +2,7 @@ import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { getClient } from './db-client.js'
 import { jsonResponse } from '../lib/response.js'
 import { extractToken, verifySession } from './auth.js'
+import { isAdmin } from '../lib/isAdmin.js'
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
@@ -11,10 +12,8 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
     }
 
     const payload = await verifySession(token)
-    const adminEmail = process.env.ADMIN_EMAIL?.toLowerCase()
-    const userEmail = payload.email?.toLowerCase()
 
-    if (payload.role === 'admin' || (adminEmail && userEmail === adminEmail)) {
+    if (isAdmin(payload)) {
       return jsonResponse(200, {
         success: true,
         data: {
@@ -25,6 +24,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
       })
     }
 
+    const userEmail = payload.email?.toLowerCase()
     if (!userEmail) {
       return jsonResponse(400, { success: false, message: 'Missing email' })
     }

--- a/netlify/lib/isAdmin.ts
+++ b/netlify/lib/isAdmin.ts
@@ -1,0 +1,10 @@
+export interface UserLike {
+  email?: string | null
+  role?: string | null
+}
+
+export function isAdmin(user: UserLike): boolean {
+  const adminEmail = process.env.ADMIN_EMAIL?.toLowerCase()
+  const email = user.email?.toLowerCase()
+  return user.role === 'admin' || (!!adminEmail && email === adminEmail)
+}

--- a/profile.tsx
+++ b/profile.tsx
@@ -1,22 +1,9 @@
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
-import { useState, useEffect } from 'react'
+import { useUser } from '@/lib/UserContext'
 
 export default function ProfilePage(): JSX.Element {
-  const [user, setUser] = useState<{ name?: string; email?: string; picture?: string } | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    fetch('/.netlify/functions/me', { credentials: 'include' })
-      .then(res => (res.ok ? res.json() : null))
-      .then(data => {
-        setUser(data?.user || null)
-        setLoading(false)
-      })
-      .catch(() => setLoading(false))
-  }, [])
-
-  if (loading) return <p>Loading...</p>
+  const { user } = useUser()
   if (!user) return <p>Please log in to view your profile.</p>
 
   return (

--- a/src/ProtectedRoute.tsx
+++ b/src/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useUser } from './lib/UserContext'
+import { isAdmin } from './lib/isAdmin'
 
 interface Status {
   subscription_status: string
@@ -41,7 +42,7 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
           return
         }
 
-        if (user.role === 'admin') {
+        if (isAdmin(user)) {
           setStatus({
             subscription_status: 'active',
             trial_start_date: null,
@@ -68,7 +69,7 @@ export default function ProtectedRoute({ children }: { children: ReactNode }) {
     check()
   }, [])
 
-  if (user?.role === 'admin') {
+  if (isAdmin(user)) {
     return <>{children}</>
   }
 

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -2,20 +2,20 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import { authFetch } from '../authFetch'
+import { useUser } from './lib/UserContext'
 
 export default function PurchasePage() {
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const navigate = useNavigate()
+  const { user } = useUser()
 
   const handlePurchase = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
     setLoading(true)
     try {
-      const meRes = await fetch('/.netlify/functions/me', { credentials: 'include' })
-      const me = await meRes.json().catch(() => null)
-      if (!me?.authenticated) {
+      if (!user) {
         navigate('/purchase-register?next=/purchase')
         return
       }

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { Link, NavLink, useNavigate, useLocation } from 'react-router-dom'
 import { Drawer } from '../drawer'
 import { useUser } from './lib/UserContext'
+import { isAdmin } from './lib/isAdmin'
 
 const normalizePath = (path: string): string =>
   path.replace(/\/+$/, '') || '/'
@@ -36,11 +37,11 @@ const Header = (): JSX.Element => {
         { label: 'Dashboard', route: '/dashboard' },
         { label: 'Mindmaps', route: '/mindmaps' },
         { label: 'Todos', route: '/todos' },
-        ...(user.role === 'admin'
+        ...(isAdmin(user)
           ? [
               { label: 'Users', route: '/admin/users' },
               { label: 'Payments', route: '/admin/payments' },
-          { label: 'Analytics', route: '/admin/analytics' },
+              { label: 'Analytics', route: '/admin/analytics' },
             ]
           : []),
       ]

--- a/src/lib/UserContext.tsx
+++ b/src/lib/UserContext.tsx
@@ -11,7 +11,6 @@ export interface User {
 interface UserContextValue {
   user: User | null
   setUser: React.Dispatch<React.SetStateAction<User | null>>
-  fetchUser: () => Promise<void>
 }
 
 const UserContext = createContext<UserContextValue | undefined>(undefined)
@@ -19,22 +18,8 @@ const UserContext = createContext<UserContextValue | undefined>(undefined)
 export function UserProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
 
-  const fetchUser = async () => {
-    try {
-      const res = await fetch('/.netlify/functions/me', { credentials: 'include' })
-      if (res.ok) {
-        const data = await res.json().catch(() => null)
-        setUser(data?.user || null)
-      } else {
-        setUser(null)
-      }
-    } catch {
-      setUser(null)
-    }
-  }
-
   return (
-    <UserContext.Provider value={{ user, setUser, fetchUser }}>
+    <UserContext.Provider value={{ user, setUser }}>
       {children}
     </UserContext.Provider>
   )

--- a/src/lib/isAdmin.ts
+++ b/src/lib/isAdmin.ts
@@ -1,0 +1,5 @@
+import type { User } from './UserContext'
+
+export function isAdmin(user?: User | null): boolean {
+  return user?.role === 'admin'
+}

--- a/trialexpired.tsx
+++ b/trialexpired.tsx
@@ -2,19 +2,19 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import { authFetch } from './authFetch'
+import { useUser } from '@/lib/UserContext'
 
 export default function TrialExpired(): JSX.Element {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const navigate = useNavigate()
+  const { user } = useUser()
 
   const startCheckout = async () => {
     setLoading(true)
     setError('')
     try {
-      const meRes = await fetch('/.netlify/functions/me', { credentials: 'include' })
-      const me = await meRes.json().catch(() => null)
-      if (!me?.authenticated) {
+      if (!user) {
         navigate('/register?next=/trial-expired')
         return
       }


### PR DESCRIPTION
## Summary
- centralize admin detection with shared `isAdmin` utilities
- skip database lookups for admin in `/user-status` and `/me`
- rely on global user context for profile and checkout pages

## Testing
- `npm test`
- `npm run compile:functions`


------
https://chatgpt.com/codex/tasks/task_e_688c417f89bc8327b4531ff3bdd9fa1f