### PR TITLE
Clear auth state on logout

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -1,6 +1,7 @@
 import { NavLink, useNavigate } from 'react-router-dom'
 import React, { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
+import { useUser } from './lib/UserContext'
 
 const mainLinks = [
   { to: '/dashboard', label: 'Dashboard' },
@@ -18,13 +19,16 @@ const accountLinks = [
 
 export default function SidebarNav(): JSX.Element {
   const navigate = useNavigate()
+  const { setUser } = useUser()
 
   const [open, setOpen] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth > 768 : true
   )
 
   const handleSignOut = () => {
-    document.cookie = 'session=; Max-Age=0; Path=/'
+    document.cookie = 'token=; Max-Age=0; path=/'
+    document.cookie = 'session=; Max-Age=0; path=/'
+    setUser(null)
     navigate('/login')
   }
 

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -19,7 +19,7 @@ const Header = (): JSX.Element => {
 
   const navigate = useNavigate()
   const location = useLocation()
-  const { user } = useUser()
+  const { user, setUser } = useUser()
 
   const isAuthenticated = !!user
   const marketingItems: NavItem[] = [
@@ -217,7 +217,9 @@ const Header = (): JSX.Element => {
                     role="menuitem"
                     className="header__dropdown-item"
                     onClick={() => {
-                      document.cookie = 'session=; Max-Age=0; Path=/'
+                      document.cookie = 'token=; Max-Age=0; path=/'
+                      document.cookie = 'session=; Max-Age=0; path=/'
+                      setUser(null)
                       handleNavSelect('/login')
                     }}
                   >


### PR DESCRIPTION
## Summary
- reset sidebar logout to remove token and session cookies and clear user context
- ensure header sign-out removes auth cookies and resets user state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c44bf92208327b6bfc5a49005876f