### PR TITLE
fix: resolve UserContext import

### DIFF
--- a/profile.tsx
+++ b/profile.tsx
@@ -1,6 +1,6 @@
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
-import { useUser } from '@/lib/UserContext'
+import { useUser } from './src/lib/UserContext'
 
 export default function ProfilePage(): JSX.Element {
   const { user } = useUser()

--- a/trialexpired.tsx
+++ b/trialexpired.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import { authFetch } from './authFetch'
-import { useUser } from '@/lib/UserContext'
+import { useUser } from './src/lib/UserContext'
 
 export default function TrialExpired(): JSX.Element {
   const [loading, setLoading] = useState(false)


### PR DESCRIPTION
## Summary
- fix broken alias import path for UserContext in profile and trial-expired pages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c4677ad848327aaad111adf074309