### PR TITLE
feat: track subscription status

### DIFF
--- a/migrations/046_add_user_subscription_columns.sql
+++ b/migrations/046_add_user_subscription_columns.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS subscription_status TEXT DEFAULT 'trialing',
+  ADD COLUMN IF NOT EXISTS trial_start_date TIMESTAMP DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS paid_thru_date TIMESTAMP;
+
+-- +migrate Down
+ALTER TABLE users
+  DROP COLUMN IF EXISTS subscription_status,
+  DROP COLUMN IF EXISTS trial_start_date,
+  DROP COLUMN IF EXISTS paid_thru_date;

--- a/netlify/functions/register.ts
+++ b/netlify/functions/register.ts
@@ -87,8 +87,8 @@ export const handler = async (
         parseInt(BCRYPT_SALT_ROUNDS)
       )
       await client.query(
-        `INSERT INTO users (email, password_hash, subscription_status, trial_start_date)
-       VALUES ($1, $2, 'trialing', now())`,
+        `INSERT INTO users (email, password_hash, subscription_status, trial_start_date, paid_thru_date)
+       VALUES ($1, $2, 'trialing', now(), NULL)`,
         [email, passwordHash]
       )
       return {


### PR DESCRIPTION
## Summary
- ensure user table has subscription fields
- include trial defaults when registering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c4c4347048327ba1386823271027b