### PR TITLE
feat: add checkout button and messaging for subscription

### DIFF
--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -22,7 +22,8 @@ export default function PurchasePage() {
 
       const res = await authFetch('/.netlify/functions/createCheckoutSession', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email })
       })
       const data = await res.json().catch(() => null)
       if (res.ok && data?.url) {
@@ -41,12 +42,16 @@ export default function PurchasePage() {
     <section className="section relative overflow-x-visible">
       <FaintMindmapBackground />
       <div className="container text-center">
-        <h1 className="mb-md">Build Your Vision</h1>
+        <h1 className="mb-md">Upgrade Required</h1>
+        <p className="mb-md">
+          To continue using MindMapX you need to purchase a monthly subscription.
+        </p>
+        {user?.email && <p className="mb-md">Signed in as {user.email}</p>}
         <p className="total-charge">$7.95 per month</p>
         <form onSubmit={handlePurchase} className="purchase-form mb-lg">
           {error && <p className="mb-md text-error">{error}</p>}
           <button type="submit" className="btn" disabled={loading}>
-            {loading ? 'Processing...' : 'Purchase'}
+            {loading ? 'Redirecting…' : 'Purchase Monthly Access'}
           </button>
         </form>
         <div className="features-grid mb-md">

--- a/trialexpired.tsx
+++ b/trialexpired.tsx
@@ -21,7 +21,8 @@ export default function TrialExpired(): JSX.Element {
 
       const res = await authFetch('/.netlify/functions/createCheckoutSession', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email })
       })
       const data = await res.json().catch(() => null)
       if (res.ok && data?.url) {
@@ -40,11 +41,15 @@ export default function TrialExpired(): JSX.Element {
     <section className="section text-center relative overflow-hidden">
       <FaintMindmapBackground />
       <div className="form-card">
-        <h1 className="text-2xl font-bold mb-4">Trial Expired</h1>
-        <p className="mb-4">Your trial has ended. Purchase to continue using the app.</p>
+        <h1 className="text-2xl font-bold mb-4">Access Required</h1>
+        <p className="mb-4">
+          Your trial has ended. To keep using the app you need to purchase monthly
+          access.
+        </p>
+        {user?.email && <p className="mb-4">Signed in as {user.email}</p>}
         {error && <p className="text-error mb-2">{error}</p>}
         <button onClick={startCheckout} className="btn" disabled={loading}>
-          {loading ? 'Processing...' : 'Purchase'}
+          {loading ? 'Redirecting…' : 'Purchase Monthly Access'}
         </button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- clarify that a subscription is required after the trial and show the signed-in email
- direct users to Stripe checkout with their email included in the payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c69ba462c832792f3c7bcccba6eaf