### PR TITLE
Display trial day count and round upgrade button

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -27,6 +27,7 @@ export default function SidebarNav(): JSX.Element {
   )
 
   const [isTrial, setIsTrial] = useState(false)
+  const [trialDay, setTrialDay] = useState<number | null>(null)
 
   const handleSignOut = () => {
     document.cookie = 'token=; Max-Age=0; path=/'
@@ -91,6 +92,12 @@ export default function SidebarNav(): JSX.Element {
         const json = await res.json()
         if (json?.data?.subscription_status === 'trialing') {
           setIsTrial(true)
+          if (json.data.trial_start_date) {
+            const start = new Date(json.data.trial_start_date).getTime()
+            const day =
+              Math.floor((Date.now() - start) / (24 * 60 * 60 * 1000)) + 1
+            setTrialDay(day)
+          }
         }
       } catch {
         /* ignore */
@@ -147,7 +154,10 @@ export default function SidebarNav(): JSX.Element {
             </li>
           ))}
           {isTrial && (
-            <li>
+            <li className="upgrade-section">
+              {trialDay !== null && (
+                <span className="trial-day">Trial Day {trialDay}</span>
+              )}
               <button type="button" className="upgrade-btn" onClick={handleUpgrade}>
                 Upgrade
               </button>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1639,7 +1639,7 @@ hr {
   text-align: center;
   padding: var(--spacing-sm) var(--spacing-md);
   border: 2px solid var(--color-warning);
-  border-radius: 4px;
+  border-radius: 9999px;
   background: none;
   color: var(--color-warning);
   margin-bottom: var(--spacing-sm);
@@ -1648,6 +1648,14 @@ hr {
 .app-sidebar .upgrade-btn:hover {
   background-color: var(--color-warning);
   color: var(--color-text-inverse);
+}
+
+.app-sidebar .trial-day {
+  display: block;
+  text-align: center;
+  color: var(--color-warning);
+  font-weight: 600;
+  margin-bottom: var(--spacing-xs);
 }
 
 .app-sidebar .signout-btn {


### PR DESCRIPTION
## Summary
- show current trial day above the sidebar upgrade button
- round upgrade button corners for a pill-shaped look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0a340d5883278ce906513744c87a