### PR TITLE
Use user email for todo comment authors

### DIFF
--- a/TodoCommentsModal.tsx
+++ b/TodoCommentsModal.tsx
@@ -12,7 +12,7 @@ interface Props {
   todo: TodoItem | null
   onClose: () => void
   onAdd: (comment: TodoComment) => void
-  currentUser?: { name: string }
+  currentUser?: { email: string }
 }
 
 export default function TodoCommentsModal({ todo, onClose, onAdd, currentUser }: Props) {
@@ -111,7 +111,7 @@ export default function TodoCommentsModal({ todo, onClose, onAdd, currentUser }:
         <h2 className="mb-2 text-lg font-semibold">Comments for "{todo.title}"</h2>
         <div className="comment-feed" ref={feedRef}>
           {comments.map((c, i) => {
-            const isMine = c.author === currentUser?.name
+            const isMine = c.author === currentUser?.email
             const name = isMine ? 'Me' : c.author || 'Anon'
 
             return (

--- a/netlify/functions/todo-comments.ts
+++ b/netlify/functions/todo-comments.ts
@@ -55,7 +55,7 @@ export const handler: Handler = async (event) => {
       }
       console.debug('Fetching comments for todoId:', todoId, 'userId:', userId)
       const res = await client.query(
-        `SELECT c.id, c.comment, c.created_at, u.name AS author
+        `SELECT c.id, c.comment, c.created_at, u.email AS author
          FROM todo_comments c
          JOIN users u ON c.user_id = u.id
          WHERE c.todo_id = $1
@@ -114,9 +114,9 @@ export const handler: Handler = async (event) => {
          RETURNING id, comment, created_at`,
         [todoId, userId, commentText]
       )
-      const nameRes = await client.query('SELECT name FROM users WHERE id=$1', [userId])
+      const emailRes = await client.query('SELECT email FROM users WHERE id=$1', [userId])
       const inserted = insert.rows[0]
-      const response = { ...inserted, author: nameRes.rows[0]?.name || 'You' }
+      const response = { ...inserted, author: emailRes.rows[0]?.email || 'You' }
       return { statusCode: 201, headers, body: JSON.stringify(response) }
     }
 


### PR DESCRIPTION
## Summary
- fix todo comments query to select user email instead of nonexistent name
- show current user match by email in todo comment modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0d7caa8083279988f57198604c09