### PR TITLE
feat: add openrouter ai helpers

### DIFF
--- a/components/Kanban/AIButton.tsx
+++ b/components/Kanban/AIButton.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import { z } from 'zod'
+import LoadingSpinner from '../../loadingspinner'
+import { callOpenRouterWithRetries } from '../../utils/openrouter'
+
+export interface KanbanCard {
+  title: string
+  description: string
+}
+
+export interface KanbanColumns {
+  New: KanbanCard[]
+  'In Progress': KanbanCard[]
+  Done: KanbanCard[]
+}
+
+const cardSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+})
+
+const kanbanSchema = z.object({
+  New: z.array(cardSchema),
+  'In Progress': z.array(cardSchema),
+  Done: z.array(cardSchema),
+}).refine(data => {
+  const total = data.New.length + data['In Progress'].length + data.Done.length
+  return total <= 20
+}, 'Too many cards')
+
+export function buildKanbanFromJSON(data: KanbanColumns): KanbanColumns {
+  return data
+}
+
+function buildKanbanPrompt(topic: string): string {
+  return `Generate a JSON array of 20 kanban cards for ${topic}. Each should include a title and description. Group them into 3 columns: New, In Progress, Done.`
+}
+
+interface AIButtonProps {
+  topic: string
+  onGenerate: (data: KanbanColumns) => void
+}
+
+export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Element {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    setLoading(true)
+    setError(null)
+    const prompt = buildKanbanPrompt(topic)
+    for (let i = 0; i < 3; i++) {
+      try {
+        const response = await callOpenRouterWithRetries(prompt)
+        const parsed = JSON.parse(response)
+        const validated = kanbanSchema.parse(parsed)
+        const built = buildKanbanFromJSON(validated)
+        onGenerate(built)
+        setLoading(false)
+        return
+      } catch (err) {
+        console.warn('Kanban generation failed', err)
+        if (i === 2) setError('Failed to generate kanban data')
+      }
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div>
+      <button className="btn-primary" onClick={handleClick} disabled={loading}>
+        {loading ? <LoadingSpinner size={16} /> : 'Create with AI'}
+      </button>
+      {error && <div className="error-text">{error}</div>}
+    </div>
+  )
+}

--- a/components/Mindmap/AIButton.tsx
+++ b/components/Mindmap/AIButton.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { z } from 'zod'
+import LoadingSpinner from '../../loadingspinner'
+import { callOpenRouterWithRetries } from '../../utils/openrouter'
+
+export interface MindmapNode {
+  title: string
+  children?: MindmapNode[]
+}
+
+const mindmapNodeSchema: z.ZodType<MindmapNode> = z.lazy(() =>
+  z.object({
+    title: z.string(),
+    children: z.array(mindmapNodeSchema).max(3).optional(),
+  }),
+)
+
+const mindmapSchema = z.object({
+  title: z.string(),
+  children: z.array(mindmapNodeSchema).max(8).optional(),
+})
+
+export function buildMindmapFromJSON(data: MindmapNode): MindmapNode {
+  return data
+}
+
+function buildMindmapPrompt(topic: string): string {
+  return `Create a JSON mind map about ${topic} with a central idea and up to 8 top-level nodes. Each node may have children. Return only valid JSON.`
+}
+
+interface AIButtonProps {
+  topic: string
+  onGenerate: (data: MindmapNode) => void
+}
+
+export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Element {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    setLoading(true)
+    setError(null)
+    const prompt = buildMindmapPrompt(topic)
+    for (let i = 0; i < 3; i++) {
+      try {
+        const response = await callOpenRouterWithRetries(prompt)
+        const parsed = JSON.parse(response)
+        const validated = mindmapSchema.parse(parsed)
+        const built = buildMindmapFromJSON(validated)
+        onGenerate(built)
+        setLoading(false)
+        return
+      } catch (err) {
+        console.warn('Mindmap generation failed', err)
+        if (i === 2) setError('Failed to generate mind map')
+      }
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div>
+      <button className="btn-primary" onClick={handleClick} disabled={loading}>
+        {loading ? <LoadingSpinner size={16} /> : 'Create with AI'}
+      </button>
+      {error && <div className="error-text">{error}</div>}
+    </div>
+  )
+}

--- a/components/Todos/AIButton.tsx
+++ b/components/Todos/AIButton.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { z } from 'zod'
+import LoadingSpinner from '../../loadingspinner'
+import { callOpenRouterWithRetries } from '../../utils/openrouter'
+
+export interface TodoItem {
+  title: string
+}
+
+const todosSchema = z.array(z.object({ title: z.string() })).max(20)
+
+export function buildTodosFromJSON(data: TodoItem[]): TodoItem[] {
+  return data.map(t => ({ title: t.title }))
+}
+
+function buildTodosPrompt(topic: string): string {
+  return `Create a JSON list of up to 20 todo items for ${topic}. Each item should have a title.`
+}
+
+interface AIButtonProps {
+  topic: string
+  onGenerate: (data: TodoItem[]) => void
+}
+
+export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Element {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleClick = async () => {
+    setLoading(true)
+    setError(null)
+    const prompt = buildTodosPrompt(topic)
+    for (let i = 0; i < 3; i++) {
+      try {
+        const response = await callOpenRouterWithRetries(prompt)
+        const parsed = JSON.parse(response)
+        const validated = todosSchema.parse(parsed)
+        const built = buildTodosFromJSON(validated)
+        onGenerate(built)
+        setLoading(false)
+        return
+      } catch (err) {
+        console.warn('Todo generation failed', err)
+        if (i === 2) setError('Failed to generate todos')
+      }
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div>
+      <button className="btn-primary" onClick={handleClick} disabled={loading}>
+        {loading ? <LoadingSpinner size={16} /> : 'Create with AI'}
+      </button>
+      {error && <div className="error-text">{error}</div>}
+    </div>
+  )
+}

--- a/utils/openrouter.ts
+++ b/utils/openrouter.ts
@@ -1,0 +1,33 @@
+
+export async function callOpenRouterWithRetries(prompt: string, maxRetries = 3): Promise<string> {
+  const url = 'https://openrouter.ai/api/v1/chat/completions'
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
+    'HTTP-Referer': 'https://mindxdo.netlify.app',
+    'X-Title': 'MindXdo',
+  }
+
+  const body = {
+    model: process.env.OPENROUTER_DEFAULT_MODEL,
+    messages: [{ role: 'user', content: prompt }],
+  }
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+      const data = await response.json()
+      const content = data?.choices?.[0]?.message?.content
+      if (!content) throw new Error('No content in response')
+      return content
+    } catch (error) {
+      console.warn(`❌ OpenRouter retry ${i + 1} failed:`, error)
+      if (i === maxRetries - 1) throw new Error('OpenRouter failed after 3 attempts.')
+    }
+  }
+  throw new Error('OpenRouter failed')
+}


### PR DESCRIPTION
## Summary
- add reusable OpenRouter helper with retry logic
- introduce Mindmap, Todos, and Kanban AI buttons using JSON schema validation and builder hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d29c03cb08327be882100f5f83df0