### PR TITLE
feat: validate openrouter responses

### DIFF
--- a/components/Kanban/AIButton.tsx
+++ b/components/Kanban/AIButton.tsx
@@ -20,20 +20,17 @@ const cardSchema = z.object({
 })
 
 const kanbanSchema = z.object({
-  New: z.array(cardSchema),
-  'In Progress': z.array(cardSchema),
-  Done: z.array(cardSchema),
-}).refine(data => {
-  const total = data.New.length + data['In Progress'].length + data.Done.length
-  return total <= 20
-}, 'Too many cards')
+  New: z.array(cardSchema).max(20),
+  'In Progress': z.array(cardSchema).length(0),
+  Done: z.array(cardSchema).length(0),
+})
 
 export function buildKanbanFromJSON(data: KanbanColumns): KanbanColumns {
   return data
 }
 
 function buildKanbanPrompt(topic: string): string {
-  return `Generate a JSON array of 20 kanban cards for ${topic}. Each should include a title and description. Group them into 3 columns: New, In Progress, Done.`
+  return `Generate a JSON array of up to 20 kanban cards for ${topic}. Each should include a title and description. Group them into 1 column: New. Cards should only go into New column. Return only valid JSON.`
 }
 
 interface AIButtonProps {

--- a/components/Mindmap/AIButton.tsx
+++ b/components/Mindmap/AIButton.tsx
@@ -11,7 +11,7 @@ export interface MindmapNode {
 const mindmapNodeSchema: z.ZodType<MindmapNode> = z.lazy(() =>
   z.object({
     title: z.string(),
-    children: z.array(mindmapNodeSchema).max(3).optional(),
+    children: z.array(mindmapNodeSchema).min(2).max(3).optional(),
   }),
 )
 

--- a/components/Todos/AIButton.tsx
+++ b/components/Todos/AIButton.tsx
@@ -14,7 +14,7 @@ export function buildTodosFromJSON(data: TodoItem[]): TodoItem[] {
 }
 
 function buildTodosPrompt(topic: string): string {
-  return `Create a JSON list of up to 20 todo items for ${topic}. Each item should have a title.`
+  return `Create a JSON list of up to 20 todo items for ${topic}. Each item should have a title. Return only valid JSON.`
 }
 
 interface AIButtonProps {


### PR DESCRIPTION
## Summary
- tighten mind map generation with child count checks and explicit JSON prompt guidance
- enforce valid JSON for todos and kanban prompts
- restrict kanban AI cards to New column only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2c95955083278b4a0347d8cdce85