### PR TITLE
feat: enhance upgrade page marketing

### DIFF
--- a/upgrade-required.tsx
+++ b/upgrade-required.tsx
@@ -1,8 +1,18 @@
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import FaintMindmapBackground from './FaintMindmapBackground'
+import useScrollReveal from './useScrollReveal'
 
 export default function UpgradeRequired(): JSX.Element {
+  useScrollReveal()
+  const reasons = [
+    'Map your vision visually so nothing is lost',
+    'Turn ideas into actionable todos with a click',
+    'Track progress on an integrated Kanban board',
+    'Collaborate visually with your entire team',
+    'Stay organized from concept to completion',
+  ]
+
   return (
     <div className="upgrade-required">
       <section className="section text-center relative overflow-hidden">
@@ -11,33 +21,39 @@ export default function UpgradeRequired(): JSX.Element {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6 }}
-          className="form-card"
+          className="about-hero-inner"
         >
-          <h1 className="text-3xl font-bold mb-4">Upgrade Required</h1>
-          <p className="mb-8">
+          <h1 className="marketing-text-large">Upgrade Required</h1>
+          <p className="section-subtext">
             Using MindXdo allows you to build your vision map and connect the dots to your
             todo and task list to bring the map to life. Humans are visual people and using
             MindXdo allows you to visualize and create while staying organized.
           </p>
+          <ul className="text-left list-disc list-inside mt-4 mb-8">
+            {reasons.map(reason => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ul>
           <Link to="/login" className="btn">
             Back to Login
           </Link>
         </motion.div>
       </section>
 
-      <section className="section section--one-col text-center">
-        <div className="container text-center">
-          <motion.img
-            src="./assets/hero-mindmap.png"
-            alt="Vision map"
-            className="banner-image"
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.6 }}
-            transition={{ duration: 0.6 }}
-          />
+      <section className="about-section reveal">
+        <motion.img
+          src="./assets/hero-mindmap.png"
+          alt="Vision map"
+          width={400}
+          height={400}
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.6 }}
+          transition={{ duration: 0.6 }}
+        />
+        <div>
           <motion.h2
-            className="marketing-text-large mt-6"
+            className="marketing-text-large"
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
@@ -45,22 +61,26 @@ export default function UpgradeRequired(): JSX.Element {
           >
             Build Your Vision Map
           </motion.h2>
+          <p className="section-subtext">
+            Capture your ideas in a visual map that clarifies the direction for every project.
+          </p>
         </div>
       </section>
 
-      <section className="section section--one-col text-center section-bg-alt">
-        <div className="container text-center">
-          <motion.img
-            src="./assets/hero-todo.png"
-            alt="Connect todos"
-            className="banner-image"
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.6 }}
-            transition={{ duration: 0.6 }}
-          />
+      <section className="about-section reveal reverse">
+        <motion.img
+          src="./assets/hero-todo.png"
+          alt="Connect todos"
+          width={400}
+          height={400}
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.6 }}
+          transition={{ duration: 0.6 }}
+        />
+        <div>
           <motion.h2
-            className="marketing-text-large mt-6"
+            className="marketing-text-large"
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
@@ -68,22 +88,26 @@ export default function UpgradeRequired(): JSX.Element {
           >
             Connect Todos to Bring Ideas to Life
           </motion.h2>
+          <p className="section-subtext">
+            Send map branches directly to your todo list so inspiration becomes action.
+          </p>
         </div>
       </section>
 
-      <section className="section section--one-col text-center">
-        <div className="container text-center">
-          <motion.img
-            src="./assets/hero-collaboration.png"
-            alt="Stay organized"
-            className="banner-image"
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true, amount: 0.6 }}
-            transition={{ duration: 0.6 }}
-          />
+      <section className="about-section reveal">
+        <motion.img
+          src="./assets/hero-collaboration.png"
+          alt="Stay organized"
+          width={400}
+          height={400}
+          initial={{ opacity: 0, y: 30 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, amount: 0.6 }}
+          transition={{ duration: 0.6 }}
+        />
+        <div>
           <motion.h2
-            className="marketing-text-large mt-6"
+            className="marketing-text-large"
             initial={{ opacity: 0 }}
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
@@ -91,6 +115,9 @@ export default function UpgradeRequired(): JSX.Element {
           >
             Stay Organized and Visual
           </motion.h2>
+          <p className="section-subtext">
+            Track work on Kanban lanes while your vision map keeps everyone aligned.
+          </p>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- Add fancy hero with top five reasons to combine mind maps, todos and Kanban
- Alternate marketing sections with images and copy for vision map, todos and organization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d5cbea5448327a79c6b607f0c58c4