### PR TITLE
Refactor AI mindmap generation

### DIFF
--- a/netlify/functions/ai-create-mindmap.ts
+++ b/netlify/functions/ai-create-mindmap.ts
@@ -3,7 +3,8 @@ import { generateAIResponse } from './ai-generate.js'
 import { createMindmapFromNodes } from './mindmaps.js'
 import { requireAuth } from '../lib/auth.js'
 import { checkAiLimit, logAiUsage } from "./usage-utils.js"
-import { aiMindmapNodesSchema } from './validationschemas.js'
+import { aiMindmapTreeSchema } from './validationschemas.js'
+import { randomUUID } from 'crypto'
 
 export const handler = async (
   event: HandlerEvent,
@@ -33,19 +34,71 @@ export const handler = async (
   if (typeof title !== 'string' || !title.trim()) return { statusCode: 400, body: 'Invalid title' }
   if (!description) return { statusCode: 400, body: 'Missing description' }
 
-  const prompt = `Generate a mindmap as JSON from: "${description}". Limit to 40 nodes or fewer and include one root node with child and sub nodes. Each node should have fields id (uuid), title, and parentId (uuid or null). Return only valid JSON.\nExample:\n[{"id":"uuid","title":"Root","parentId":null},{"id":"uuid","title":"Child","parentId":"root-uuid"}]`
+  const systemPrompt =
+    'You are an AI that generates useful and structured mindmaps with a core concept and branching child nodes.'
+  const userPrompt = `Create a JSON structure for a mind map.
 
-  let nodes: any[] = []
+Topic:
+- Title: "${title}"
+- Description: "${description}"
+
+Instructions:
+- Use the title and description as the root node (core concept).
+- Add up to 8 child nodes, each with a title and description.
+- Each child may contain 2–3 subnodes.
+- Nest nodes using "children" arrays.
+- Each node should only include: title, description, and children.
+
+Example:
+{
+  "title": "Core Concept",
+  "description": "Overview of the concept",
+  "children": [
+    {
+      "title": "Child Node",
+      "description": "Details about this aspect",
+      "children": [
+        {
+          "title": "Subnode",
+          "description": "Further explanation"
+        }
+      ]
+    }
+  ]
+}
+
+Return only valid JSON.`
+
+  type TreeNode = { title: string; description?: string; children?: TreeNode[] }
+
+  let flatNodes: Array<{ id: string; title: string; description?: string; parentId: string | null }> = []
+
   try {
-    const content = await generateAIResponse(prompt)
-    nodes = aiMindmapNodesSchema.parse(JSON.parse(content))
+    const content = await generateAIResponse(userPrompt, systemPrompt)
+    const tree = aiMindmapTreeSchema.parse(JSON.parse(content)) as TreeNode
+    tree.title = title
+    tree.description = description
+
+    const traverse = (node: TreeNode, parentId: string | null) => {
+      const id = randomUUID()
+      flatNodes.push({ id, title: node.title, description: node.description, parentId })
+      for (const child of node.children || []) {
+        traverse(child, id)
+      }
+    }
+
+    traverse(tree, null)
   } catch (err) {
     console.error('AI parse failed:', err)
-    nodes = []
+  }
+
+  if (flatNodes.length === 0) {
+    const id = randomUUID()
+    flatNodes.push({ id, title, description, parentId: null })
   }
 
   try {
-    const mindmapId = await createMindmapFromNodes(userId, title, description, nodes)
+    const mindmapId = await createMindmapFromNodes(userId, title, description, flatNodes)
     return {
       statusCode: 200,
       body: JSON.stringify({ mindmapId })

--- a/netlify/functions/validationschemas.ts
+++ b/netlify/functions/validationschemas.ts
@@ -12,10 +12,10 @@ export const mapInputSchema = z.object({
   }),
 })
 
-export const aiMindmapNodeSchema = z.object({
-  id: z.string().uuid().optional(),
-  title: z.string(),
-  parentId: z.string().uuid().nullable().optional()
-})
-
-export const aiMindmapNodesSchema = z.array(aiMindmapNodeSchema)
+export const aiMindmapTreeSchema: z.ZodType<any> = z.lazy(() =>
+  z.object({
+    title: z.string(),
+    description: z.string().optional().default(''),
+    children: z.array(aiMindmapTreeSchema).optional().default([]),
+  })
+)

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -158,23 +158,23 @@ export default function MapEditorPage(): JSX.Element {
       const rootX = 400
       const rootY = 300
 
-      const generalNode: NodePayload = {
+      const rootNode: NodePayload = {
         x: rootX,
         y: rootY,
-        label: 'General',
-        description: '',
+        label: mindmap.title,
+        description: mindmap.description || '',
         parentId: null,
         mindmapId: mindmap.id,
         linkedTodoListId: null,
       }
 
-      console.log('[MapEditorPage] auto root node payload', generalNode)
+      console.log('[MapEditorPage] auto root node payload', rootNode)
 
       fetch('/.netlify/functions/nodes', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(generalNode)
+        body: JSON.stringify(rootNode)
       })
         .then(async res => {
           if (!res.ok) throw new Error(`Failed: ${res.status}`)
@@ -184,7 +184,7 @@ export default function MapEditorPage(): JSX.Element {
           // Immediately show the new root node so the canvas is not empty
           const id = typeof data?.id === 'string' ? data.id : undefined
           if (id) {
-            setNodes([{ ...generalNode, id }])
+            setNodes([{ ...rootNode, id }])
           } else {
             // Fallback: refetch nodes if response is unexpected
             setReloadFlag(p => p + 1)


### PR DESCRIPTION
## Summary
- prompt AI with topic title and description to build nested mindmap JSON
- parse and flatten mindmap tree into nodes with UUIDs, then batch insert with layout coords
- use map title as fallback root node when no AI data is returned
- clarify prompt to describe core concept with branching child nodes and include an example JSON structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d6c7766ec8327b28a67af5dadc2d0