### PR TITLE
use netlify openrouter model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ ADMIN_PASSWORD=
 
 # AI integration (optional)
 OPENROUTER_API_KEY=your-openrouter-key
-OPENROUTER_DEFAULT_MODEL=gpt-4o-mini
+OPENROUTER_DEFAULT_MODEL=openai/gpt-4o-mini
 
 # environment mode
 NODE_ENV=production

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Set the following variables in your Netlify environment to enable AI powered fea
 
 ```
 OPENROUTER_API_KEY=your-openrouter-key
-OPENROUTER_DEFAULT_MODEL=gpt-4o-mini
+OPENROUTER_DEFAULT_MODEL=openai/gpt-4o-mini
 ```
 
 These are used by serverless functions to generate mind maps and todo lists.

--- a/netlify/functions/ai-generate.ts
+++ b/netlify/functions/ai-generate.ts
@@ -3,10 +3,14 @@ import type { ChatCompletionMessageParam } from "openai/resources/chat/completio
 
 const openai = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,
-  baseURL: "https://openrouter.ai/api/v1"
+  baseURL: "https://openrouter.ai/api/v1",
+  defaultHeaders: {
+    "HTTP-Referer": "https://mindx.do",
+    "X-Title": "MindXdo"
+  }
 })
 
-const MODEL = "openai/gpt-4o-mini"
+const MODEL = process.env.OPENROUTER_DEFAULT_MODEL ?? "openai/gpt-4o-mini"
 
 export async function generateAIResponse(prompt: string, systemPrompt?: string) {
   const messages: ChatCompletionMessageParam[] = []

--- a/openaiclient.ts
+++ b/openaiclient.ts
@@ -1,7 +1,8 @@
 import OpenAI from 'openai'
 import type { ChatCompletionCreateParams } from 'openai/resources/chat/completions'
 
-const DEFAULT_MODEL = process.env.OPENROUTER_DEFAULT_MODEL ?? 'gpt-4o-mini'
+const DEFAULT_MODEL =
+  process.env.OPENROUTER_DEFAULT_MODEL ?? 'openai/gpt-4o-mini'
 const DEFAULT_TEMPERATURE = 0.7
 const DEFAULT_MAX_TOKENS = 256
 
@@ -10,7 +11,14 @@ function getOpenAI(): OpenAI {
   if (openaiInstance) return openaiInstance
   const apiKey = process.env.OPENROUTER_API_KEY
   if (!apiKey) throw new Error('Missing OPENROUTER_API_KEY environment variable')
-  openaiInstance = new OpenAI({ apiKey })
+  openaiInstance = new OpenAI({
+    apiKey,
+    baseURL: 'https://openrouter.ai/api/v1',
+    defaultHeaders: {
+      'HTTP-Referer': 'https://mindx.do',
+      'X-Title': 'MindXdo',
+    },
+  })
   return openaiInstance
 }
 

--- a/utils/openrouter.ts
+++ b/utils/openrouter.ts
@@ -3,12 +3,12 @@ export async function callOpenRouterWithRetries(prompt: string, maxRetries = 3):
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
-    'HTTP-Referer': 'https://mindxdo.netlify.app',
+    'HTTP-Referer': 'https://mindx.do',
     'X-Title': 'MindXdo',
   }
 
   const body = {
-    model: process.env.OPENROUTER_DEFAULT_MODEL,
+    model: process.env.OPENROUTER_DEFAULT_MODEL ?? 'openai/gpt-4o-mini',
     messages: [{ role: 'user', content: prompt }],
   }
 


### PR DESCRIPTION
## Summary
- send OpenRouter requests with MindXdo headers
- default to Netlify's OPENROUTER_DEFAULT_MODEL
- document OpenRouter env vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d737017188327b179c243c70974b1