### PR TITLE
feat: use radial fan layout for ai mindmap

### DIFF
--- a/components/Mindmap/AIButton.tsx
+++ b/components/Mindmap/AIButton.tsx
@@ -72,19 +72,68 @@ function validateMindmapTree(root: any): asserts root is MindmapNode {
 }
 
 function assignPositions(root: MindmapNode): void {
+  type Direction = 'tr' | 'br' | 'bl' | 'tl'
+  const directionAngles: Record<Direction, number> = {
+    tr: -Math.PI / 4,
+    br: Math.PI / 4,
+    bl: (3 * Math.PI) / 4,
+    tl: (-3 * Math.PI) / 4,
+  }
+  const MIN_SIBLING_GAP = 100
+  const BASE_DISTANCE = 200
+  const DISTANCE_STEP = 150
+
+  const byId = new Map<string, MindmapNode>()
+  const getDirection = (node: MindmapNode): Direction => {
+    if (!node.parentId) return 'tr'
+    const parent = byId.get(node.parentId)
+    if (!parent) return 'tr'
+    const dx = (node.x ?? 0) - (parent.x ?? 0)
+    const dy = (node.y ?? 0) - (parent.y ?? 0)
+    if (dx >= 0 && dy <= 0) return 'tr'
+    if (dx >= 0 && dy > 0) return 'br'
+    if (dx < 0 && dy > 0) return 'bl'
+    return 'tl'
+  }
+
   const queue: Array<{ node: MindmapNode; depth: number }> = []
   root.x = 400
   root.y = 300
+  byId.set(root.id, root)
   queue.push({ node: root, depth: 0 })
+
   while (queue.length > 0) {
     const { node, depth } = queue.shift()!
     const children = Array.isArray(node.children) ? node.children : []
-    const angleStep = children.length > 0 ? (2 * Math.PI) / children.length : 0
+    const total = children.length
+    if (total === 0) continue
+
+    const baseRadius = BASE_DISTANCE + depth * DISTANCE_STEP
+    const isRoot = !node.parentId
+    const baseArc = isRoot ? Math.PI * 2 : Math.PI
+    let arc = baseArc
+    let angleStep = arc / total
+
+    const minAngleForGap = 2 * Math.asin(MIN_SIBLING_GAP / (2 * baseRadius))
+    if (angleStep < minAngleForGap) {
+      const maxArc = isRoot ? Math.PI * 2 : (Math.PI * 3) / 2
+      arc = Math.min(maxArc, minAngleForGap * total)
+      angleStep = arc / total
+    }
+
+    const radius = Math.max(
+      baseRadius,
+      MIN_SIBLING_GAP / (2 * Math.sin(angleStep / 2))
+    )
+
+    const centerAngle = isRoot ? 0 : directionAngles[getDirection(node)]
+    const startAngle = centerAngle - arc / 2
+
     children.forEach((child, idx) => {
-      const angle = idx * angleStep
-      const distance = 200 + depth * 40
-      child.x = Math.round((node.x ?? 0) + Math.cos(angle) * distance)
-      child.y = Math.round((node.y ?? 0) + Math.sin(angle) * distance)
+      const angle = startAngle + angleStep * (idx + 0.5)
+      child.x = Math.round((node.x ?? 0) + Math.cos(angle) * radius)
+      child.y = Math.round((node.y ?? 0) + Math.sin(angle) * radius)
+      byId.set(child.id, child)
       queue.push({ node: child, depth: depth + 1 })
     })
   }

--- a/netlify/functions/mindmaps.ts
+++ b/netlify/functions/mindmaps.ts
@@ -205,6 +205,28 @@ export async function createMindmapFromNodes(
         roots.push(node)
       }
     }
+    type Direction = 'tr' | 'br' | 'bl' | 'tl'
+    const directionAngles: Record<Direction, number> = {
+      tr: -Math.PI / 4,
+      br: Math.PI / 4,
+      bl: (3 * Math.PI) / 4,
+      tl: (-3 * Math.PI) / 4,
+    }
+    const MIN_SIBLING_GAP = 100
+    const BASE_DISTANCE = 200
+    const DISTANCE_STEP = 150
+
+    const getDirection = (node: TmpNode): Direction => {
+      if (!node.parentId) return 'tr'
+      const parent = byId.get(node.parentId)
+      if (!parent) return 'tr'
+      const dx = (node.x ?? 0) - (parent.x ?? 0)
+      const dy = (node.y ?? 0) - (parent.y ?? 0)
+      if (dx >= 0 && dy <= 0) return 'tr'
+      if (dx >= 0 && dy > 0) return 'br'
+      if (dx < 0 && dy > 0) return 'bl'
+      return 'tl'
+    }
 
     const queue: Array<{ node: TmpNode; depth: number }> = []
     roots.forEach(root => {
@@ -216,12 +238,34 @@ export async function createMindmapFromNodes(
     while (queue.length > 0) {
       const { node, depth } = queue.shift()!
       const children = node.children
-      const angleStep = children.length > 0 ? (2 * Math.PI) / children.length : 0
+      const total = children.length
+      if (total === 0) continue
+
+      const baseRadius = BASE_DISTANCE + depth * DISTANCE_STEP
+      const isRoot = !node.parentId
+      const baseArc = isRoot ? Math.PI * 2 : Math.PI
+      let arc = baseArc
+      let angleStep = arc / total
+
+      const minAngleForGap = 2 * Math.asin(MIN_SIBLING_GAP / (2 * baseRadius))
+      if (angleStep < minAngleForGap) {
+        const maxArc = isRoot ? Math.PI * 2 : (Math.PI * 3) / 2
+        arc = Math.min(maxArc, minAngleForGap * total)
+        angleStep = arc / total
+      }
+
+      const radius = Math.max(
+        baseRadius,
+        MIN_SIBLING_GAP / (2 * Math.sin(angleStep / 2))
+      )
+
+      const centerAngle = isRoot ? 0 : directionAngles[getDirection(node)]
+      const startAngle = centerAngle - arc / 2
+
       children.forEach((child, idx) => {
-        const angle = idx * angleStep
-        const distance = 200 + depth * 40
-        child.x = Math.round((node.x ?? 0) + Math.cos(angle) * distance)
-        child.y = Math.round((node.y ?? 0) + Math.sin(angle) * distance)
+        const angle = startAngle + angleStep * (idx + 0.5)
+        child.x = Math.round((node.x ?? 0) + Math.cos(angle) * radius)
+        child.y = Math.round((node.y ?? 0) + Math.sin(angle) * radius)
         queue.push({ node: child, depth: depth + 1 })
       })
     }


### PR DESCRIPTION
## Summary
- position AI-generated nodes in radial fans around their parent
- apply same radial layout when creating mindmaps on the server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d88704b68832780e9ebe6f4d30776