### PR TITLE
feat: improve node positioning

### DIFF
--- a/components/Mindmap/layout.ts
+++ b/components/Mindmap/layout.ts
@@ -8,15 +8,19 @@ export interface LayoutNode {
 
 export function assignPositions(root: LayoutNode): void {
   const MIN_SIBLING_GAP = 100
-  const BASE_RADIUS = 200
-  const RADIUS_STEP = 75
-  const MAX_RADIUS = 350
+  const BASE_RADIUS = 150
+  const RADIUS_STEP = 30
+  const MIN_RADIUS = 80
+  const MIN_NODE_GAP = 100
+  const COLLISION_STEP = 20
 
   const byId = new Map<string, LayoutNode>()
+  const placed: LayoutNode[] = []
   const queue: Array<{ node: LayoutNode; depth: number }> = []
   root.x = 400
   root.y = 300
   byId.set(root.id, root)
+  placed.push(root)
   queue.push({ node: root, depth: 0 })
 
   while (queue.length > 0) {
@@ -25,9 +29,9 @@ export function assignPositions(root: LayoutNode): void {
     const total = children.length
     if (total === 0) continue
 
-    const baseRadius = Math.min(
-      MAX_RADIUS,
-      BASE_RADIUS + Math.max(0, depth - 1) * RADIUS_STEP
+    const baseRadius = Math.max(
+      MIN_RADIUS,
+      BASE_RADIUS - Math.max(0, depth - 1) * RADIUS_STEP
     )
     const isRoot = !node.parentId
 
@@ -62,8 +66,45 @@ export function assignPositions(root: LayoutNode): void {
       const angle = startAngle + angleStep * idx
       child.x = Math.round((node.x ?? 0) + Math.cos(angle) * radius)
       child.y = Math.round((node.y ?? 0) + Math.sin(angle) * radius)
+      resolveCollision(child, placed, node, MIN_NODE_GAP, COLLISION_STEP, MIN_RADIUS)
+      placed.push(child)
       byId.set(child.id, child)
       queue.push({ node: child, depth: depth + 1 })
     })
+  }
+}
+
+function resolveCollision(
+  node: LayoutNode,
+  others: LayoutNode[],
+  parent: LayoutNode,
+  minGap: number,
+  step: number,
+  minRadius: number
+): void {
+  const px = parent.x ?? 0
+  const py = parent.y ?? 0
+  let angle = Math.atan2((node.y ?? 0) - py, (node.x ?? 0) - px)
+  let radius = Math.sqrt(
+    Math.pow((node.x ?? 0) - px, 2) + Math.pow((node.y ?? 0) - py, 2)
+  )
+
+  let iterations = 0
+  const maxIterations = 50
+
+  while (iterations < maxIterations) {
+    const hasCollision = others.some(o => {
+      if (o === node) return false
+      const dx = (node.x ?? 0) - (o.x ?? 0)
+      const dy = (node.y ?? 0) - (o.y ?? 0)
+      return Math.sqrt(dx * dx + dy * dy) < minGap
+    })
+
+    if (!hasCollision) break
+
+    radius = Math.max(minRadius, radius - step)
+    node.x = Math.round(px + Math.cos(angle) * radius)
+    node.y = Math.round(py + Math.sin(angle) * radius)
+    iterations++
   }
 }

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -242,11 +242,16 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     )
 
     const replaceNodeId = useCallback((tempId: string, newId: string) => {
-      setNodes(prev =>
-        Array.isArray(prev)
-          ? prev.map(n => (n.id === tempId ? { ...n, id: newId } : n))
-          : prev
-      )
+      setNodes(prev => {
+        if (!Array.isArray(prev)) return prev
+        const mapped = prev.map(n => (n.id === tempId ? { ...n, id: newId } : n))
+        const root = buildLayoutTree(mapped)
+        if (root) {
+          assignPositions(root)
+          return flattenLayoutTree(root)
+        }
+        return mapped
+      })
       setEdges(prev =>
         Array.isArray(prev)
           ? prev.map(e => ({


### PR DESCRIPTION
## Summary
- tighten radial layout and add collision resolution so sub-child nodes stay clustered without overlap
- recalc node positions when temporary IDs are replaced so new nodes appear immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d919437248327b6c7ea85f6d7f07d