### PR TITLE
feat: improve mindmap node spacing

### DIFF
--- a/components/Mindmap/layout.ts
+++ b/components/Mindmap/layout.ts
@@ -11,8 +11,9 @@ export function assignPositions(root: LayoutNode): void {
   const BASE_RADIUS = 150
   const RADIUS_STEP = 30
   const MIN_RADIUS = 80
-  const MIN_NODE_GAP = 100
-  const COLLISION_STEP = 20
+  const MIN_NODE_GAP = 70
+  const COLLISION_STEP = 50
+  const SUBNODE_SPACING = 70
 
   const byId = new Map<string, LayoutNode>()
   const placed: LayoutNode[] = []
@@ -29,44 +30,54 @@ export function assignPositions(root: LayoutNode): void {
     const total = children.length
     if (total === 0) continue
 
-    const baseRadius = Math.max(
-      MIN_RADIUS,
-      BASE_RADIUS - Math.max(0, depth - 1) * RADIUS_STEP
-    )
-    const isRoot = !node.parentId
+    if (depth === 0) {
+      const baseRadius = Math.max(
+        MIN_RADIUS,
+        BASE_RADIUS - Math.max(0, depth - 1) * RADIUS_STEP
+      )
 
-    const parentAngle = isRoot
-      ? 0
-      : (() => {
-          const parent = node.parentId ? byId.get(node.parentId) : null
-          if (!parent) return 0
-          return Math.atan2((node.y ?? 0) - (parent.y ?? 0), (node.x ?? 0) - (parent.x ?? 0))
-        })()
+      const parentAngle = 0
+      let arc = Math.PI * 2
+      let angleStep = total > 1 ? arc / (total - 1) : 0
 
-    let arc = isRoot ? Math.PI * 2 : Math.PI / 2
-    let angleStep = total > 1 ? arc / (total - 1) : 0
+      const minAngleForGap = 2 * Math.asin(MIN_SIBLING_GAP / (2 * baseRadius))
+      if (total > 1 && angleStep < minAngleForGap) {
+        const maxArc = Math.PI * 2
+        arc = Math.min(maxArc, minAngleForGap * (total - 1))
+        angleStep = arc / (total - 1)
+      }
 
-    const minAngleForGap = 2 * Math.asin(MIN_SIBLING_GAP / (2 * baseRadius))
-    if (total > 1 && angleStep < minAngleForGap) {
-      const maxArc = isRoot ? Math.PI * 2 : Math.PI
-      arc = Math.min(maxArc, minAngleForGap * (total - 1))
-      angleStep = arc / (total - 1)
+      const radius = Math.max(
+        baseRadius,
+        total > 1
+          ? MIN_SIBLING_GAP / (2 * Math.sin(angleStep / 2))
+          : baseRadius
+      )
+
+      const startAngle = total > 1 ? parentAngle - arc / 2 : parentAngle
+
+      children.forEach((child, idx) => {
+        const angle = startAngle + angleStep * idx
+        child.x = Math.round((node.x ?? 0) + Math.cos(angle) * radius)
+        child.y = Math.round((node.y ?? 0) + Math.sin(angle) * radius)
+        resolveCollision(child, placed, MIN_NODE_GAP, COLLISION_STEP)
+        placed.push(child)
+        byId.set(child.id, child)
+        queue.push({ node: child, depth: depth + 1 })
+      })
+      continue
     }
 
-    const radius = Math.max(
-      baseRadius,
-      total > 1
-        ? MIN_SIBLING_GAP / (2 * Math.sin(angleStep / 2))
-        : baseRadius
-    )
-
-    const startAngle = total > 1 ? parentAngle - arc / 2 : parentAngle
+    const parent = node.parentId ? byId.get(node.parentId) : null
+    const angle = parent
+      ? Math.atan2((node.y ?? 0) - (parent.y ?? 0), (node.x ?? 0) - (parent.x ?? 0))
+      : 0
 
     children.forEach((child, idx) => {
-      const angle = startAngle + angleStep * idx
-      child.x = Math.round((node.x ?? 0) + Math.cos(angle) * radius)
-      child.y = Math.round((node.y ?? 0) + Math.sin(angle) * radius)
-      resolveCollision(child, placed, node, MIN_NODE_GAP, COLLISION_STEP, MIN_RADIUS)
+      const distance = SUBNODE_SPACING * (idx + 1)
+      child.x = Math.round((node.x ?? 0) + Math.cos(angle) * distance)
+      child.y = Math.round((node.y ?? 0) + Math.sin(angle) * distance)
+      resolveCollision(child, placed, MIN_NODE_GAP, COLLISION_STEP)
       placed.push(child)
       byId.set(child.id, child)
       queue.push({ node: child, depth: depth + 1 })
@@ -77,20 +88,22 @@ export function assignPositions(root: LayoutNode): void {
 function resolveCollision(
   node: LayoutNode,
   others: LayoutNode[],
-  parent: LayoutNode,
   minGap: number,
-  step: number,
-  minRadius: number
+  step: number
 ): void {
-  const px = parent.x ?? 0
-  const py = parent.y ?? 0
-  let angle = Math.atan2((node.y ?? 0) - py, (node.x ?? 0) - px)
-  let radius = Math.sqrt(
-    Math.pow((node.x ?? 0) - px, 2) + Math.pow((node.y ?? 0) - py, 2)
-  )
-
   let iterations = 0
   const maxIterations = 50
+  const directions: Array<[number, number]> = [
+    [step, 0],
+    [0, step],
+    [-step, 0],
+    [0, -step],
+    [step, step],
+    [-step, step],
+    [step, -step],
+    [-step, -step],
+  ]
+  let dirIndex = 0
 
   while (iterations < maxIterations) {
     const hasCollision = others.some(o => {
@@ -102,9 +115,10 @@ function resolveCollision(
 
     if (!hasCollision) break
 
-    radius = Math.max(minRadius, radius - step)
-    node.x = Math.round(px + Math.cos(angle) * radius)
-    node.y = Math.round(py + Math.sin(angle) * radius)
+    const [dx, dy] = directions[dirIndex]
+    node.x = (node.x ?? 0) + dx
+    node.y = (node.y ?? 0) + dy
+    dirIndex = (dirIndex + 1) % directions.length
     iterations++
   }
 }


### PR DESCRIPTION
## Summary
- ensure sub-child nodes align with their parent's direction and are spaced roughly 70px apart
- incrementally offset new nodes by 50px to avoid collisions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d955c82a08327befe713006efbe8f