### PR TITLE
refactor: streamline node addition

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -28,7 +28,6 @@ const RADIUS_STEP = 75
 const MAX_RADIUS = 350
 // Minimum spacing between sibling nodes to avoid label overlap
 const MIN_SIBLING_GAP = 100
-const FADE_DURATION = 300
 
 const estimateLabelWidth = (label: string | undefined | null): number => {
   if (!label) return 0
@@ -117,8 +116,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
 
     const [nodes, setNodes] = useState<NodeData[]>(() => safePropNodes)
     const [edges, setEdges] = useState<EdgeData[]>(() => safePropEdges)
-    const [isFading, setIsFading] = useState(false)
-    const layoutTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    // Track fade state removed to simplify node addition experience
 
     const safeNodes = Array.isArray(nodes) ? nodes : []
     const safeEdges = Array.isArray(edges) ? edges : []
@@ -146,13 +144,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     }, [initialTransform])
     const svgRef = useRef<SVGSVGElement | null>(null)
     const containerRef = useRef<HTMLDivElement | null>(null)
-
-    useEffect(() => {
-      return () => {
-        if (layoutTimeoutRef.current) clearTimeout(layoutTimeoutRef.current)
-      }
-    }, [])
-
 
     useEffect(() => {
       setNodes(safePropNodes)
@@ -226,31 +217,26 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const addNode = useCallback(
       (node: NodeData) => {
         console.log('[MindmapCanvas] addNode', node)
-        setIsFading(true)
-        if (layoutTimeoutRef.current) clearTimeout(layoutTimeoutRef.current)
-        layoutTimeoutRef.current = setTimeout(() => {
-          setNodes(prev => {
-            const updated = [...prev, node]
-            const root = buildLayoutTree(updated)
-            if (root) {
-              assignPositions(root)
-              return flattenLayoutTree(root)
-            }
-            return updated
-          })
-          if (
-            node.parentId &&
-            !safeEdges.some(e => e.from === node.parentId && e.to === node.id)
-          ) {
-            const edgeId =
-              typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-                ? crypto.randomUUID()
-                : Math.random().toString(36).slice(2)
-            const edge: EdgeData = { id: edgeId, from: node.parentId, to: node.id }
-            setEdges(prev => [...prev, edge])
+        setNodes(prev => {
+          const updated = [...prev, node]
+          const root = buildLayoutTree(updated)
+          if (root) {
+            assignPositions(root)
+            return flattenLayoutTree(root)
           }
-          setIsFading(false)
-        }, FADE_DURATION)
+          return updated
+        })
+        if (
+          node.parentId &&
+          !safeEdges.some(e => e.from === node.parentId && e.to === node.id)
+        ) {
+          const edgeId =
+            typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+              ? crypto.randomUUID()
+              : Math.random().toString(36).slice(2)
+          const edge: EdgeData = { id: edgeId, from: node.parentId, to: node.id }
+          setEdges(prev => [...prev, edge])
+        }
       },
       [safeEdges]
     )
@@ -801,14 +787,12 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
               x: transform.x,
               y: transform.y,
               scale: transform.k,
-              opacity: isFading ? 0 : 1,
             }}
             initial={false}
             transition={{
               type: 'spring',
               stiffness: 100,
               damping: 20,
-              opacity: { duration: FADE_DURATION / 1000 },
             }}
             style={{ originX: 0, originY: 0 }}
           >


### PR DESCRIPTION
## Summary
- remove fade-out timeout when adding mind map nodes
- recompute layout instantly and retain edges
- simplify canvas animation for smoother updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d96ba39ac83278388f42837089bde