### PR TITLE
Simplify mindmap node layout

### DIFF
--- a/components/Mindmap/layout.ts
+++ b/components/Mindmap/layout.ts
@@ -21,12 +21,9 @@ export function assignPositions(root: LayoutNode): void {
   const RADIUS_STEP = 100
   const SUBNODE_ARC = Math.PI / 2 // 90° fan for sub-nodes
 
-  // Center of the canvas
-  const CENTER_X = 400
-  const CENTER_Y = 300
-
-  root.x = CENTER_X
-  root.y = CENTER_Y
+  // place root at the origin – the canvas can translate it later
+  root.x = 0
+  root.y = 0
   root.angle = 0
 
   const queue: Array<{ node: LayoutNode; depth: number }> = [
@@ -45,8 +42,8 @@ export function assignPositions(root: LayoutNode): void {
       children.forEach((child, idx) => {
         const angle = angleStep * idx
         child.angle = angle
-        child.x = Math.round(CENTER_X + Math.cos(angle) * ROOT_RADIUS)
-        child.y = Math.round(CENTER_Y + Math.sin(angle) * ROOT_RADIUS)
+        child.x = Math.round(Math.cos(angle) * ROOT_RADIUS)
+        child.y = Math.round(Math.sin(angle) * ROOT_RADIUS)
         queue.push({ node: child, depth: depth + 1 })
       })
       continue

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -132,7 +132,14 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
     const containerRef = useRef<HTMLDivElement | null>(null)
 
     useEffect(() => {
-      setNodes(safePropNodes)
+      setNodes(() => {
+        const root = buildLayoutTree(safePropNodes)
+        if (root) {
+          assignPositions(root)
+          return flattenLayoutTree(root)
+        }
+        return safePropNodes
+      })
     }, [propNodes])
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Simplify radial layout function for mindmap nodes
- Recompute node positions on load so nodes fan out from the center

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688da0f205348327984b245236489504