### PR TITLE
Center mindmap root node on initial render

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -5,7 +5,8 @@ import {
   useCallback,
   useImperativeHandle,
   useMemo,
-  useEffect
+  useEffect,
+  useLayoutEffect
 } from 'react'
 import { motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
@@ -521,23 +522,24 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       [pan, addNode, updateNode, removeNode]
     )
 
-    useEffect(() => {
+    useLayoutEffect(() => {
+      const container = containerRef.current
       if (
         Array.isArray(nodes) &&
         nodes.length > 0 &&
         !hasCentered &&
-        containerRef.current
+        container
       ) {
-        setHasCentered(true)
-        const { clientWidth, clientHeight } = containerRef.current
+        const { clientWidth, clientHeight } = container
         const root = nodes.find(n => !n.parentId) ?? nodes[0]
-        const centerX = root.x
-        const centerY = root.y
+        const centerX = root.x ?? 0
+        const centerY = root.y ?? 0
         setTransform(prev => ({
           x: clientWidth / 2 - centerX * prev.k,
           y: clientHeight / 2 - centerY * prev.k,
           k: prev.k,
         }))
+        setHasCentered(true)
       }
     }, [nodes, hasCentered, transform.k])
 


### PR DESCRIPTION
## Summary
- Center the mindmap's root node on initial render using `useLayoutEffect`
- Calculate container dimensions before paint and adjust transform accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688da74cf06483278bf2b298da2f5e09