### PR TITLE
Center mindmap origin on load

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -531,8 +531,10 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
         setHasCentered(true)
         const { clientWidth, clientHeight } = containerRef.current
         const root = nodes.find(n => !n.parentId) ?? nodes[0]
-        const centerX = root.x
-        const centerY = root.y
+        const centerX =
+          typeof root?.x === 'number' && Number.isFinite(root.x) ? root.x : 0
+        const centerY =
+          typeof root?.y === 'number' && Number.isFinite(root.y) ? root.y : 0
         setTransform(prev => ({
           x: clientWidth / 2 - centerX * prev.k,
           y: clientHeight / 2 - centerY * prev.k,

--- a/src/MapEditorPage.tsx
+++ b/src/MapEditorPage.tsx
@@ -155,8 +155,8 @@ export default function MapEditorPage(): JSX.Element {
     if (loaded && Array.isArray(nodes) && nodes.length === 0 && !firstNodeCreated && mindmap?.id) {
       setFirstNodeCreated(true)
 
-      const rootX = 400
-      const rootY = 300
+      const rootX = 0
+      const rootY = 0
 
       const rootNode: NodePayload = {
         x: rootX,


### PR DESCRIPTION
## Summary
- Ensure auto-created root nodes start at coordinate (0,0)
- Safeguard centering logic to default to origin when node positions are missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dacb0ca708327b3638abb4c0eb3f4