### PR TITLE
Enable cascading deletion for nodes

### DIFF
--- a/migrations/048_cascade_delete_nodes.sql
+++ b/migrations/048_cascade_delete_nodes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE nodes DROP CONSTRAINT IF EXISTS nodes_parent_id_fkey;
+ALTER TABLE nodes ADD CONSTRAINT nodes_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES nodes(id) ON DELETE CASCADE;

--- a/runmigrations.ts
+++ b/runmigrations.ts
@@ -101,7 +101,7 @@ export async function runMigrations(): Promise<void> {
       CREATE TABLE IF NOT EXISTS nodes (
         id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
         mindmap_id  UUID NOT NULL REFERENCES mindmaps(id),
-        parent_id   UUID REFERENCES nodes(id),
+        parent_id   UUID REFERENCES nodes(id) ON DELETE CASCADE,
         x           DOUBLE PRECISION DEFAULT 0,
         y           DOUBLE PRECISION DEFAULT 0,
         label       TEXT,


### PR DESCRIPTION
## Summary
- cascade delete child nodes by default
- update migration to drop and recreate parent_id foreign key with `ON DELETE CASCADE`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688dadd9f6948327a4808cbbd4805da1