### PR TITLE
Create AI todo list with tasks

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -128,7 +128,7 @@ export default function DashboardPage(): JSX.Element {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ prompt: form.description }),
+          body: JSON.stringify({ title: form.title, prompt: form.description || form.title }),
         })
       }
       setShowModal(false)

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -1,8 +1,8 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { generateAIResponse } from './ai-generate.js'
 import { requireAuth } from '../lib/auth.js'
-
-import { checkAiLimit, logAiUsage } from "./usage-utils.js"
+import { getClient } from './db-client.js'
+import { checkAiLimit, logAiUsage } from './usage-utils.js'
 export const handler = async (
   event: HandlerEvent,
   _context: HandlerContext
@@ -12,8 +12,9 @@ export const handler = async (
   }
   if (!event.body) return { statusCode: 400, body: 'Missing body' }
 
+  let userId: string
   try {
-    const { userId } = requireAuth(event)
+    ;({ userId } = requireAuth(event))
     if (!(await checkAiLimit(userId))) {
       return { statusCode: 429, body: 'AI limit reached' }
     }
@@ -24,20 +25,49 @@ export const handler = async (
 
   let data: any
   try { data = JSON.parse(event.body) } catch { return { statusCode: 400, body: 'Invalid JSON' } }
-  const { prompt } = data
+  const { prompt, title } = data
   if (!prompt || typeof prompt !== 'string') return { statusCode: 400, body: 'Invalid prompt' }
+  const listTitle = typeof title === 'string' && title.trim() ? title.trim() : prompt.trim()
 
   try {
     const content = await generateAIResponse(
       prompt,
       'Generate a JSON array of todo items. Limit to 20 items, each with a title and note field. Respond only with JSON without code fences or quotes.\nExample:\n[{"title":"Sample","note":"Details"}]'
     )
-    let todos: unknown
-    try { todos = JSON.parse(content) } catch { todos = [] }
-    return {
-      statusCode: 200,
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ todos })
+    let todosRaw: unknown
+    try { todosRaw = JSON.parse(content) } catch { todosRaw = [] }
+    const todos = Array.isArray(todosRaw) ? todosRaw : []
+
+    const client = await getClient()
+    try {
+      await client.query('BEGIN')
+      const listRes = await client.query(
+        'INSERT INTO todo_lists (user_id, title) VALUES ($1,$2) RETURNING id',
+        [userId, listTitle]
+      )
+      const listId = listRes.rows[0].id
+
+      for (const item of todos) {
+        const todoTitle = typeof (item as any).title === 'string' ? (item as any).title : null
+        if (!todoTitle) continue
+        const note = typeof (item as any).note === 'string' ? (item as any).note : null
+        await client.query(
+          'INSERT INTO todos (user_id, title, description, list_id, created_at, updated_at) VALUES ($1,$2,$3,$4,NOW(),NOW())',
+          [userId, todoTitle, note, listId]
+        )
+      }
+      await client.query('COMMIT')
+      return {
+        statusCode: 201,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: listId })
+      }
+    } catch (err) {
+      await client.query('ROLLBACK')
+      console.error(err)
+      return { statusCode: 500, body: 'Internal Server Error' }
+    } finally {
+      client.release()
     }
   } catch (err) {
     console.error(err)

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -102,7 +102,7 @@ export default function TodosPage(): JSX.Element {
       const res = await fetch('/api/ai-create-todo', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ prompt: form.description || form.title })
+        body: JSON.stringify({ title: form.title, prompt: form.description || form.title })
       })
       const json = await res.json()
       if (json?.id) {


### PR DESCRIPTION
## Summary
- Build AI todo creation endpoint that saves generated tasks and returns list id
- Send todo list title along with AI prompt when creating from the dashboard and Todos page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688daeea3e988327862688ca16cd122d