### PR TITLE
Ensure AI-created Kanban boards include core columns

### DIFF
--- a/KanbanCard.tsx
+++ b/KanbanCard.tsx
@@ -1,7 +1,7 @@
 export default function KanbanCard({ title }: { title?: string }) {
   return (
     <div className="kanban-card">
-      {title || 'New Card'}
+      <div className="kanban-title">{title || 'New Card'}</div>
     </div>
   )
 }

--- a/netlify/functions/ai-create-board.ts
+++ b/netlify/functions/ai-create-board.ts
@@ -42,6 +42,14 @@ export const handler = async (
     )
     const boardId = res.rows[0].id
 
+    const coreCols = ['New', 'In-Progress', 'Review', 'Done']
+    for (let i = 0; i < coreCols.length; i++) {
+      await client.query(
+        'INSERT INTO kanban_columns (board_id, title, position) VALUES ($1,$2,$3)',
+        [boardId, coreCols[i], i]
+      )
+    }
+
     if (prompt && typeof prompt === 'string' && prompt.trim()) {
       try {
         const aiText = await generateAIResponse(

--- a/src/global.scss
+++ b/src/global.scss
@@ -2613,6 +2613,13 @@ hr {
   transition: background-color 0.2s ease;
 }
 
+.kanban-card .kanban-title {
+  font-size: 14px;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
 .kanban-card.past-due {
   background-color: #ffe5e5;
 }


### PR DESCRIPTION
## Summary
- ensure AI-created Kanban boards automatically add New, In-Progress, Review, and Done columns
- wrap Kanban card titles and reduce title text to 14px for better readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688db5fca2b883279cca7d5fb0f7a733