### PR TITLE
Raise AI automation limits to 100 with trial cap

### DIFF
--- a/account.tsx
+++ b/account.tsx
@@ -22,6 +22,7 @@ export default function AccountPage(): JSX.Element {
     boards: 0,
     aiUsage: 0,
   })
+  const [aiLimit, setAiLimit] = useState(LIMIT_AI_MONTHLY)
   const [msg, setMsg] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -38,6 +39,7 @@ export default function AccountPage(): JSX.Element {
             boards: Number(data.boards) || 0,
             aiUsage: Number(data.aiUsage) || 0,
           })
+          setAiLimit(Number(data.aiLimit) || LIMIT_AI_MONTHLY)
         }
       })
       .catch(() => {})
@@ -105,7 +107,7 @@ export default function AccountPage(): JSX.Element {
             <tr>
               <td className="metric-label">AI Automations</td>
               <td className="metric-value">
-                {usage.aiUsage}/{LIMIT_AI_MONTHLY} this month
+                {usage.aiUsage}/{aiLimit} this month
               </td>
             </tr>
           </tbody>

--- a/components/Kanban/AIButton.tsx
+++ b/components/Kanban/AIButton.tsx
@@ -40,9 +40,9 @@ export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Elem
 
     setLoading(true)
     try {
-      const usage = await getMonthlyUsage(user.id, 'kanban')
-      if (usage >= 25) {
-        alert("You’ve reached your 25 AI kanban creations this month.")
+      const { usage, limit } = await getMonthlyUsage(user.id, 'kanban')
+      if (usage >= limit) {
+        alert(`You’ve reached your ${limit} AI kanban creations this month.`)
         return
       }
 

--- a/components/Mindmap/AIButton.tsx
+++ b/components/Mindmap/AIButton.tsx
@@ -143,9 +143,9 @@ export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Elem
 
     setLoading(true)
     try {
-      const usage = await getMonthlyUsage(user.id, 'mindmap')
-      if (usage >= 25) {
-        alert("You've hit your monthly AI limit for mindmaps.")
+      const { usage, limit } = await getMonthlyUsage(user.id, 'mindmap')
+      if (usage >= limit) {
+        alert(`You've hit your monthly AI limit of ${limit} mindmaps.`)
         return
       }
 

--- a/components/Todos/AIButton.tsx
+++ b/components/Todos/AIButton.tsx
@@ -29,9 +29,9 @@ export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Elem
 
     setLoading(true)
     try {
-      const usage = await getMonthlyUsage(user.id, 'todo')
-      if (usage >= 25) {
-        alert("You’ve reached your 25 AI todo list creations this month.")
+      const { usage, limit } = await getMonthlyUsage(user.id, 'todo')
+      if (usage >= limit) {
+        alert(`You’ve reached your ${limit} AI todo list creations this month.`)
         return
       }
 

--- a/lib/ai/usage.ts
+++ b/lib/ai/usage.ts
@@ -1,4 +1,5 @@
 import { authFetch } from '../../authFetch'
+import { LIMIT_AI_MONTHLY } from '../../src/constants'
 
 export async function trackAIUsage(userId: string, type: 'mindmap' | 'todo' | 'kanban') {
   await authFetch('/.netlify/functions/ai-usage', {
@@ -14,7 +15,11 @@ export async function getMonthlyUsage(userId: string, type: 'mindmap' | 'todo' |
     method: 'GET',
     credentials: 'include',
   })
-  if (!res.ok) return 0
+  if (!res.ok)
+    return { usage: 0, limit: LIMIT_AI_MONTHLY }
   const data = await res.json()
-  return Number(data.usage) || 0
+  return {
+    usage: Number(data.usage) || 0,
+    limit: Number(data.aiLimit) || LIMIT_AI_MONTHLY,
+  }
 }

--- a/netlify/functions/ai-usage.ts
+++ b/netlify/functions/ai-usage.ts
@@ -1,6 +1,7 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { requireAuth } from '../lib/auth.js'
 import { trackAIUsage, getMonthlyUsage } from '../lib/ai/usage.js'
+import { getAiLimit } from './usage-utils.js'
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   let userId: string
@@ -27,10 +28,11 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
 
   if (event.httpMethod === 'GET') {
     const usage = await getMonthlyUsage(userId, typeParam)
+    const { limit } = await getAiLimit(userId)
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ usage }),
+      body: JSON.stringify({ usage, aiLimit: limit }),
     }
   }
 

--- a/netlify/functions/limits.ts
+++ b/netlify/functions/limits.ts
@@ -1,8 +1,11 @@
 export const LIMIT_MINDMAPS = 10
 export const LIMIT_TODO_LISTS = 100
 export const LIMIT_KANBAN_BOARDS = 10
-// Expose a monthly limit of 25 AI automations but keep a
-// server-side buffer of 5 extra attempts.
-export const LIMIT_AI_MONTHLY = 25
+// Expose a monthly limit of 100 AI automations but keep a
+// server-side buffer of 5 extra attempts. Trial users are
+// restricted to 10 automations during the trial period.
+export const LIMIT_AI_MONTHLY = 100
+export const LIMIT_AI_TRIAL = 10
 export const AI_BUFFER = 5
 export const TOTAL_AI_LIMIT = LIMIT_AI_MONTHLY + AI_BUFFER
+export const TOTAL_AI_TRIAL_LIMIT = LIMIT_AI_TRIAL + AI_BUFFER

--- a/netlify/functions/usage.ts
+++ b/netlify/functions/usage.ts
@@ -1,7 +1,7 @@
 import type { HandlerEvent, HandlerContext } from '@netlify/functions'
 import { getClient } from './db-client.js'
 import { requireAuth } from '../lib/auth.js'
-import { TOTAL_AI_LIMIT } from './limits.js'
+import { getAiLimit } from './usage-utils.js'
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
   if (event.httpMethod !== 'GET') {
@@ -26,6 +26,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
       [userId]
     )
     const r = rows[0]
+    const { limit } = await getAiLimit(userId)
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -34,7 +35,7 @@ export const handler = async (event: HandlerEvent, _context: HandlerContext) => 
         todoLists: Number(r.todo_lists),
         boards: Number(r.boards),
         aiUsage: Number(r.ai_usage),
-        aiLimit: TOTAL_AI_LIMIT
+        aiLimit: limit
       })
     }
   } catch (err) {

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -47,6 +47,7 @@ export default function DashboardPage(): JSX.Element {
   const [form, setForm] = useState({ title: '', description: '' })
   const [aiLoading, setAiLoading] = useState(false)
   const [aiUsage, setAiUsage] = useState(0)
+  const [aiLimit, setAiLimit] = useState(LIMIT_AI_MONTHLY)
   const [cardsDoneToday, setCardsDoneToday] = useState(0)
   const [cardsDoneWeek, setCardsDoneWeek] = useState(0)
   const navigate = useNavigate()
@@ -90,6 +91,7 @@ export default function DashboardPage(): JSX.Element {
       const usageRes = await authFetch('/.netlify/functions/usage', { credentials: 'include' })
       const usageJson = usageRes.ok ? await usageRes.json() : { aiUsage: 0 }
       setAiUsage(Number(usageJson.aiUsage) || 0)
+      setAiLimit(Number(usageJson.aiLimit) || LIMIT_AI_MONTHLY)
 
       setMaps(Array.isArray(mapsList) ? mapsList : [])
       setTodoLists(Array.isArray(lists) ? lists : [])
@@ -159,7 +161,7 @@ export default function DashboardPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
-    if (aiUsage >= LIMIT_AI_MONTHLY) {
+    if (aiUsage >= aiLimit) {
       alert('AI automation limit reached')
       return
     }

--- a/src/PurchasePage.tsx
+++ b/src/PurchasePage.tsx
@@ -62,7 +62,7 @@ export default function PurchasePage() {
           <div>Kanban Boards</div>
           <div className="feature-limit">10</div>
           <div>AI Automations</div>
-          <div className="feature-limit">25 per month</div>
+          <div className="feature-limit">100 per month</div>
         </div>
         <p className="mb-xs">+ Coming soon team members</p>
         <p className="text-muted">Upgrades available in app</p>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,9 +1,12 @@
 export const LIMIT_MINDMAPS = 10
 export const LIMIT_TODO_LISTS = 100
 export const LIMIT_KANBAN_BOARDS = 10
-// Users can run 25 AI automations per month but we allow a
-// hidden buffer of 5 additional attempts.
-export const LIMIT_AI_MONTHLY = 25
+// Users can run 100 AI automations per month but we allow a
+// hidden buffer of 5 additional attempts. Trial users are
+// limited to 10 automations during the trial period.
+export const LIMIT_AI_MONTHLY = 100
+export const LIMIT_AI_TRIAL = 10
 export const AI_BUFFER = 5
 // Total attempts allowed before blocking
 export const TOTAL_AI_LIMIT = LIMIT_AI_MONTHLY + AI_BUFFER
+export const TOTAL_AI_TRIAL_LIMIT = LIMIT_AI_TRIAL + AI_BUFFER


### PR DESCRIPTION
## Summary
- Bump AI automation quota to 100 per month and add 10-action trial cap
- Server utilities compute limits by subscription status and expose to clients
- UI now displays and enforces dynamic AI limits

## Testing
- `npm test`
- `npm run compile:functions`


------
https://chatgpt.com/codex/tasks/task_e_688e7b6fb2c88327874573cf305c7f7c