### PR TITLE
Revamp todo creation modal

### DIFF
--- a/TodoCreateModeModal.tsx
+++ b/TodoCreateModeModal.tsx
@@ -1,37 +1,59 @@
+import { useState, useEffect } from 'react'
 import Modal from './modal'
 
 interface Props {
   isOpen: boolean
   nodeTitle: string
   nodeDescription: string
-  onSelect: (option: 'quick' | 'ai') => void
+  onSelect: (option: 'quick' | 'ai', title: string, description: string) => void
   onClose: () => void
 }
 
 export default function TodoCreateModeModal({ isOpen, nodeTitle, nodeDescription, onSelect, onClose }: Props) {
-  const disableAI = !nodeTitle || nodeTitle.trim() === ''
+  const [title, setTitle] = useState(nodeTitle)
+  const [description, setDescription] = useState(nodeDescription)
+
+  useEffect(() => {
+    if (isOpen) {
+      setTitle(nodeTitle)
+      setDescription(nodeDescription)
+    }
+  }, [isOpen, nodeTitle, nodeDescription])
+
+  const disableAI = !title || title.trim() === ''
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} ariaLabel="Create Todo List">
-      <div className="modal-container card-modal" style={{ minWidth: '300px' }}>
+      <div className="modal-container card-modal fancy-modal" style={{ minWidth: '300px' }}>
         <h2 className="mb-2 text-lg font-semibold">Create Todo List</h2>
-        {nodeTitle && <p className="text-sm mb-1">{nodeTitle}</p>}
-        {nodeDescription && (
-          <p className="text-xs text-gray-500 mb-2">{nodeDescription}</p>
-        )}
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <input
+            type="text"
+            className="input"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Title"
+          />
+          <textarea
+            className="textarea"
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder="Description (optional)"
+          />
+        </div>
+        <div className="flex flex-col gap-4 mt-4">
           <button
             className="btn-primary"
-            onClick={() => onSelect('quick')}
+            onClick={() => onSelect('quick', title, description)}
           >
             📝 Quick Create
           </button>
           <button
-            className="btn-primary"
-            onClick={() => onSelect('ai')}
+            className="btn-ai"
+            onClick={() => onSelect('ai', title, description)}
             disabled={disableAI}
           >
-            ✨ Create with AI
+            Create with AI
           </button>
           <button className="btn-cancel" onClick={onClose}>
             Cancel

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -927,14 +927,16 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
             isOpen={!!createTodoNode}
             nodeTitle={createTodoNode.label || ''}
             nodeDescription={createTodoNode.description || ''}
-            onSelect={async option => {
+            onSelect={async (option, title, description) => {
               const node = createTodoNode
               setCreateTodoNode(null)
               if (!node) return
+              const updatedNode = { ...node, label: title, description }
+              updateNode(updatedNode)
               if (option === 'quick') {
-                await handleTodoClick(node)
+                await handleTodoClick(updatedNode)
               } else {
-                await handleTodoCreateAI(node)
+                await handleTodoCreateAI(updatedNode)
               }
             }}
             onClose={() => setCreateTodoNode(null)}

--- a/src/global.scss
+++ b/src/global.scss
@@ -2272,6 +2272,32 @@ hr {
   background-color: var(--color-warning);
 }
 
+.btn-ai {
+  position: relative;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  cursor: pointer;
+  background: linear-gradient(90deg, #a855f7, #22c55e);
+  background-size: 200% 200%;
+  animation: gradient-flow 4s ease infinite;
+}
+
+.btn-ai::after {
+  content: '\2728';
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  animation: sparkle 1.5s ease-in-out infinite;
+}
+
+.fancy-modal {
+  background: linear-gradient(135deg, #ffffff 0%, #f3e8ff 100%);
+}
+
 .empty-map-message {
   display: flex;
   flex-direction: column;
@@ -2337,6 +2363,17 @@ hr {
 @keyframes draw-border {
   from { transform: scale(0); }
   to { transform: scale(1); }
+}
+
+@keyframes gradient-flow {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@keyframes sparkle {
+  0%, 100% { opacity: 1; transform: translateY(-50%) scale(1); }
+  50% { opacity: 0.5; transform: translateY(-50%) scale(1.3); }
 }
 
 .form-actions {


### PR DESCRIPTION
## Summary
- add editable fields and improved layout for todo creation modal
- style "Create with AI" button with purple-to-green gradient and sparkle
- pass updated node text into todo creation logic

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8033a3dc8327bf0e9e7694a9aefb