### PR TITLE
Fix AI todo creation prompt to include title and description

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -128,7 +128,7 @@ export default function DashboardPage(): JSX.Element {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ title: form.title, prompt: form.description || form.title }),
+          body: JSON.stringify({ title: form.title, description: form.description }),
         })
       }
       setShowModal(false)

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -490,13 +490,13 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
       async (node: NodeData) => {
         if (!node) return
         const title = node.label || 'Todo List'
+        const description = node.description || ''
         setAiLoading(true)
         try {
-          const prompt = [title, node.description].filter(Boolean).join('\n\n')
           const res = await authFetch('/.netlify/functions/ai-create-todo', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ title, prompt })
+            body: JSON.stringify({ title, description })
           })
           if (!res.ok) throw new Error('AI create failed')
           const list = await res.json()

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -25,18 +25,22 @@ export const handler = async (
 
   let data: any
   try { data = JSON.parse(event.body) } catch { return { statusCode: 400, body: 'Invalid JSON' } }
-  const { prompt, title } = data
+  const { title, description = '' } = data
   if (typeof title !== 'string' || !title.trim()) {
     return { statusCode: 400, body: 'Invalid title' }
   }
-  if (!prompt || typeof prompt !== 'string') {
-    return { statusCode: 400, body: 'Invalid prompt' }
-  }
   const listTitle = title.trim()
+
+  const userPrompt = [
+    `Title: ${listTitle}`,
+    description && typeof description === 'string' ? `Description: ${description.trim()}` : ''
+  ]
+    .filter(Boolean)
+    .join('\n')
 
   try {
     const content = await generateAIResponse(
-      prompt,
+      userPrompt,
       'Generate a JSON array of todo items. Limit to 20 items, each with a title and note field. Respond only with JSON without code fences or quotes.\nExample:\n[{"title":"Sample","note":"Details"}]'
     )
     let todosRaw: unknown

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -102,7 +102,7 @@ export default function TodosPage(): JSX.Element {
       const res = await fetch('/api/ai-create-todo', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: form.title, prompt: form.description || form.title })
+        body: JSON.stringify({ title: form.title, description: form.description })
       })
       const json = await res.json()
       if (json?.id) {


### PR DESCRIPTION
## Summary
- ensure mindmap AI todo creation sends both title and description
- build prompt on server for OpenRouter using provided title and description
- update other AI todo creation entry points to match new API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e816709b48327bad5d29a0406a919