### PR TITLE
Link AI-created todos to originating mindmap

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -496,7 +496,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
           const res = await authFetch('/.netlify/functions/ai-create-todo', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ title, description })
+            body: JSON.stringify({ title, description, nodeId: node.id })
           })
           if (!res.ok) throw new Error('AI create failed')
           const list = await res.json()


### PR DESCRIPTION
## Summary
- include nodeId when creating todo list with AI from mindmap
- allow AI todo creation endpoint to associate lists with nodes and return mindmap id

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e875c7d70832787daf57e2d734857