### PR TITLE
Ensure AI-created todo lists link back to mindmap

### DIFF
--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -522,7 +522,7 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ linkedTodoListId: list.id })
           }).catch(() => {})
-          navigate(`/todos/${list.id}`)
+          navigate(`/todos/${list.id}`, { state: { mindmapId: list.mindmap_id } })
           setAiLoading(false)
         } catch (err) {
           console.error('AI todo create failed', err)

--- a/src/TodosCanvasPage.tsx
+++ b/src/TodosCanvasPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useLocation } from 'react-router-dom'
 import TodoCanvas from '../TodoCanvas'
 import { authFetch } from '../authFetch'
 
@@ -20,6 +20,7 @@ interface TodoList {
 
 export default function TodosCanvasPage(): JSX.Element {
   const { id } = useParams<{ id: string }>()
+  const location = useLocation()
   const [list, setList] = useState<TodoList | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -50,7 +51,7 @@ export default function TodosCanvasPage(): JSX.Element {
             list_id={id}
             listTitle={list?.title}
             listDescription={list?.description}
-            mindmapId={list?.mindmap_id || undefined}
+            mindmapId={list?.mindmap_id || (location.state as any)?.mindmapId || undefined}
           />
         )}
       </main>


### PR DESCRIPTION
## Summary
- Pass mindmap id when navigating to new todo list generated from mindmap via AI
- Allow TodosCanvasPage to accept mindmap id from navigation state so todo list links back to its mindmap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e8dd6495c8327b83a6577276e16c0