### PR TITLE
style: improve todo list creation modal

### DIFF
--- a/TodoCreateModeModal.tsx
+++ b/TodoCreateModeModal.tsx
@@ -5,65 +5,87 @@ interface Props {
   isOpen: boolean
   nodeTitle: string
   nodeDescription: string
-  onSelect: (option: 'quick' | 'ai', title: string, description: string) => void
+  onSelect: (option: 'quick' | 'ai', title: string, description: string) => Promise<void>
   onClose: () => void
 }
 
 export default function TodoCreateModeModal({ isOpen, nodeTitle, nodeDescription, onSelect, onClose }: Props) {
   const [title, setTitle] = useState(nodeTitle)
   const [description, setDescription] = useState(nodeDescription)
+  const [loading, setLoading] = useState<null | 'quick' | 'ai'>(null)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (isOpen) {
       setTitle(nodeTitle)
       setDescription(nodeDescription)
+      setError(null)
+      setLoading(null)
     }
   }, [isOpen, nodeTitle, nodeDescription])
 
   const disableAI = !title || title.trim() === ''
 
+  const handleSelect = async (option: 'quick' | 'ai') => {
+    setError(null)
+    setLoading(option)
+    try {
+      await onSelect(option, title, description)
+      onClose()
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+    } finally {
+      setLoading(null)
+    }
+  }
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} ariaLabel="Create Todo List">
-      <div className="modal-container card-modal fancy-modal" style={{ minWidth: '300px' }}>
+      <div className="bg-white p-6 rounded-lg shadow-xl max-w-md w-full" style={{ minWidth: '300px' }}>
         <h2 className="mb-4 text-lg font-semibold">Create Todo List</h2>
-        <div className="flex flex-col space-y-4 mb-4">
-          <div className="flex flex-col space-y-1">
-            <label className="text-sm font-medium">Title</label>
+        <div className="flex flex-col space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
             <input
               type="text"
-              className="w-full p-2 border rounded"
+              className="w-full px-3 py-2 border border-gray-300 rounded shadow-sm"
               value={title}
               onChange={e => setTitle(e.target.value)}
               placeholder="Title"
+              disabled={loading !== null}
             />
           </div>
-          <div className="flex flex-col space-y-1">
-            <label className="text-sm font-medium">Description</label>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
             <textarea
-              className="w-full p-2 border rounded resize-none h-24"
+              className="w-full px-3 py-2 border border-gray-300 rounded shadow-sm resize-none h-24"
               value={description}
               onChange={e => setDescription(e.target.value)}
               placeholder="Description (optional)"
+              disabled={loading !== null}
             />
           </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
         </div>
-        <div className="flex justify-between items-center mt-6 space-x-3">
+        <div className="flex justify-end space-x-3 mt-6">
           <button
-            className="bg-orange-500 text-white px-4 py-2 rounded flex items-center"
-            onClick={() => onSelect('quick', title, description)}
+            className="bg-orange-500 text-white px-4 py-2 rounded hover:bg-orange-600 disabled:opacity-50"
+            onClick={() => handleSelect('quick')}
+            disabled={loading !== null}
           >
-            📝 Quick Create
+            {loading === 'quick' ? 'Creating...' : '📝 Quick Create'}
           </button>
+            <button
+              className="bg-gradient-to-r from-purple-500 to-green-400 text-white px-4 py-2 rounded hover:opacity-90 disabled:opacity-50"
+              onClick={() => handleSelect('ai')}
+              disabled={disableAI || loading !== null}
+            >
+              {loading === 'ai' ? 'Thinking...' : '✨ Create with AI'}
+            </button>
           <button
-            className="bg-gradient-to-r from-purple-500 to-green-400 text-white px-4 py-2 rounded flex items-center"
-            onClick={() => onSelect('ai', title, description)}
-            disabled={disableAI}
-          >
-            ✨ Create with AI
-          </button>
-          <button
-            className="bg-gray-200 text-gray-700 px-4 py-2 rounded"
+            className="text-gray-600 hover:text-gray-900 px-4 py-2"
             onClick={onClose}
+            disabled={loading !== null}
           >
             Cancel
           </button>

--- a/mindmapcanvas.tsx
+++ b/mindmapcanvas.tsx
@@ -947,7 +947,6 @@ const MindmapCanvas = forwardRef<MindmapCanvasHandle, MindmapCanvasProps>(
             nodeDescription={createTodoNode.description || ''}
             onSelect={async (option, title, description) => {
               const node = createTodoNode
-              setCreateTodoNode(null)
               if (!node) return
               const updatedNode = { ...node, label: title, description }
               updateNode(updatedNode)


### PR DESCRIPTION
## Summary
- restyled Create Todo List modal with vertical input fields, clear labels, and responsive layout
- added horizontal action buttons with loading/error handling for quick or AI-powered creation
- updated mindmap canvas integration to await creation before closing the modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e940ab61c83279da8cab7264ef4f4