### PR TITLE
Refine AI todo prompts for focused planning

### DIFF
--- a/components/Todos/AIButton.tsx
+++ b/components/Todos/AIButton.tsx
@@ -8,16 +8,18 @@ export interface TodoItem {
   title: string
 }
 
-function buildTodosPrompt(topic: string): string {
-  return `Create a JSON array of up to 20 todo items related to "${topic}". Each item should include a title. Return only valid JSON without code fences or quotes.`
+function buildTodosPrompt(title: string, description = ''): string {
+  const desc = description.trim()
+  return `Create a JSON array of up to 20 actionable todo items that form a plan to accomplish "${title}".${desc ? ` Use the description "${desc}" to guide and refine the tasks.` : ''} Each item should include a title. Return only valid JSON without code fences or extra text.`
 }
 
 interface AIButtonProps {
-  topic: string
+  title: string
+  description?: string
   onGenerate: (data: TodoItem[]) => void
 }
 
-export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Element {
+export default function AIButton({ title, description = '', onGenerate }: AIButtonProps): JSX.Element {
   const [loading, setLoading] = useState(false)
   const { user } = useUser()
 
@@ -35,7 +37,7 @@ export default function AIButton({ topic, onGenerate }: AIButtonProps): JSX.Elem
         return
       }
 
-      const prompt = buildTodosPrompt(topic)
+      const prompt = buildTodosPrompt(title, description)
       const response = await callOpenRouterWithRetries(prompt)
       if (!response) {
         alert('AI failed to generate a todo list after 3 attempts.')

--- a/netlify/functions/ai-create-todo.ts
+++ b/netlify/functions/ai-create-todo.ts
@@ -41,7 +41,7 @@ export const handler = async (
   try {
     const content = await generateAIResponse(
       userPrompt,
-      'Generate a JSON array of todo items. Limit to 20 items, each with a title and note field. Respond only with JSON without code fences or quotes.\nExample:\n[{"title":"Sample","note":"Details"}]'
+      'Generate a JSON array of todo items that form a plan to accomplish the provided title. Use the description to refine and guide the tasks. Limit to 20 items, each with a title and note field. Respond only with JSON without code fences or quotes.\nExample:\n[{"title":"Sample","note":"Details"}]'
     )
     let todosRaw: unknown
     try { todosRaw = JSON.parse(content) } catch { todosRaw = [] }


### PR DESCRIPTION
## Summary
- Build todo-generation prompts around a list's title with optional description guidance
- Instruct AI service to create plan-oriented todos using provided description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e9aa2a1148327ab92ca6049cd0211