### PR TITLE
feat: add admin navigation

### DIFF
--- a/analytics.tsx
+++ b/analytics.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { authFetch } from './authFetch'
+import AdminNav from './src/AdminNav'
 
 const formatDateInput = (date: Date): string => {
   const year = date.getFullYear()
@@ -114,6 +115,7 @@ export default function AnalyticsPage(): JSX.Element {
   return (
     <div className="analytics-page">
       <h1>Analytics</h1>
+      <AdminNav />
       <div className="analytics-controls">
         <label>
           Start Date:

--- a/payments.tsx
+++ b/payments.tsx
@@ -1,3 +1,5 @@
+import AdminNav from './src/AdminNav'
+
 const paymentSchema = z.object({
   id: z.string(),
   user_id: z.string(),
@@ -82,6 +84,7 @@ const PaymentsPage: React.FC = () => {
   return (
     <div className="payments-page">
       <h1>Payments</h1>
+      <AdminNav />
       {error && <div className="error">{error}</div>}
       {loading ? (
         <div>Loading payments...</div>

--- a/src/AdminNav.tsx
+++ b/src/AdminNav.tsx
@@ -1,0 +1,26 @@
+import { NavLink } from 'react-router-dom'
+
+const adminLinks = [
+  { to: '/admin/users', label: 'Users' },
+  { to: '/admin/payments', label: 'Payments' },
+  { to: '/admin/analytics', label: 'Analytics' }
+]
+
+export default function AdminNav(): JSX.Element {
+  return (
+    <nav className="admin-nav" aria-label="Admin navigation">
+      <ul>
+        {adminLinks.map(link => (
+          <li key={link.to}>
+            <NavLink
+              to={link.to}
+              className={({ isActive }) => (isActive ? 'active' : undefined)}
+            >
+              {link.label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -2,6 +2,7 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import React, { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
 import { useUser } from './lib/UserContext'
+import { isAdmin } from './lib/isAdmin'
 import { authFetch } from '../authFetch'
 
 const mainLinks = [
@@ -18,9 +19,15 @@ const accountLinks = [
   { to: '/account', label: 'Account' },
 ]
 
+const adminLinks = [
+  { to: '/admin/users', label: 'Users' },
+  { to: '/admin/payments', label: 'Payments' },
+  { to: '/admin/analytics', label: 'Analytics' },
+]
+
 export default function SidebarNav(): JSX.Element {
   const navigate = useNavigate()
-  const { setUser } = useUser()
+  const { user, setUser } = useUser()
 
   const [open, setOpen] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth > 768 : true
@@ -140,6 +147,22 @@ export default function SidebarNav(): JSX.Element {
             </li>
           ))}
         </ul>
+        {isAdmin(user) && (
+          <ul className="admin-links">
+            {adminLinks.map(link => (
+              <li key={link.to}>
+                <NavLink
+                  to={link.to}
+                  className={({ isActive }) =>
+                    isActive ? 'active' : undefined
+                  }
+                >
+                  {link.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        )}
         <ul className="account-links">
           {accountLinks.map(link => (
             <li key={link.to}>

--- a/src/global.scss
+++ b/src/global.scss
@@ -1627,6 +1627,13 @@ hr {
   }
 }
 
+/* Sidebar admin section */
+.app-sidebar .admin-links {
+  margin-top: var(--spacing-xl);
+  padding-top: var(--spacing-md);
+  border-top: 1px solid var(--color-border);
+}
+
 /* Sidebar account section */
 .app-sidebar .account-links {
   margin-top: var(--spacing-xl);

--- a/users.tsx
+++ b/users.tsx
@@ -1,3 +1,5 @@
+import AdminNav from './src/AdminNav'
+
 export default function UsersPage(): JSX.Element {
   const [users, setUsers] = useState<User[]>([])
   const [page, setPage] = useState<number>(1)
@@ -133,6 +135,7 @@ export default function UsersPage(): JSX.Element {
   return (
     <div>
       <h1>Users</h1>
+      <AdminNav />
       <div style={{ marginBottom: 16 }}>
         <input
           type="text"


### PR DESCRIPTION
## Summary
- add AdminNav component for consistent admin navigation links
- show admin section in SidebarNav when current user is an admin
- include admin navigation on analytics, payments, and users pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ebfc2f4388327b1ada3caaefe99c3