### PR TITLE
feat: add red delete icon to todo items

### DIFF
--- a/nodetodolist.tsx
+++ b/nodetodolist.tsx
@@ -225,8 +225,19 @@ const NodeTodoList: FC<NodeTodoListProps> = ({ nodeId }) => {
                   >
                     Edit
                   </button>
-                  <button onClick={() => handleDeleteTodo(todo.id)} disabled={isDeleting}>
-                    {isDeleting ? 'Deleting...' : 'Delete'}
+                  <button
+                    onClick={() => handleDeleteTodo(todo.id)}
+                    disabled={isDeleting}
+                    aria-label="Delete todo"
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      color: 'red',
+                      fontWeight: 'bold',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {isDeleting ? '…' : '✕'}
                   </button>
                 </>
               )}

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -202,7 +202,7 @@ export default function TodosPage(): JSX.Element {
                     <ul className="todo-items">
                       {list.todos.map(t => (
                         <li key={t.id} className="todo-item">
-                          {t.title}{' '}
+                          <span style={{ flexGrow: 1 }}>{t.title}</span>
                           <a
                             href="#"
                             className="tile-link delete-link"
@@ -210,8 +210,10 @@ export default function TodosPage(): JSX.Element {
                               e.preventDefault()
                               handleDeleteTodo(t.id)
                             }}
+                            aria-label="Delete todo"
+                            style={{ fontWeight: 'bold' }}
                           >
-                            Delete
+                            &times;
                           </a>
                         </li>
                       ))}

--- a/todoid.tsx
+++ b/todoid.tsx
@@ -227,8 +227,19 @@ export default function TodoPage({ mindmapId }: TodoPageProps) {
                   >
                     Edit
                   </button>
-                  <button onClick={() => handleTodoDelete(todo.id)} style={{ marginLeft: '8px' }}>
-                    Delete
+                  <button
+                    onClick={() => handleTodoDelete(todo.id)}
+                    style={{
+                      marginLeft: '8px',
+                      background: 'none',
+                      border: 'none',
+                      color: 'red',
+                      fontWeight: 'bold',
+                      cursor: 'pointer',
+                    }}
+                    aria-label="Delete todo"
+                  >
+                    ✕
                   </button>
                 </>
               )}


### PR DESCRIPTION
## Summary
- add red ✕ button to delete todos in NodeTodoList and todo pages
- align delete controls to the far right of each todo item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ec65a69b0832782b2a6676a3044dd