### PR TITLE
Fix admin users listing and style admin navigation

### DIFF
--- a/analytics.tsx
+++ b/analytics.tsx
@@ -58,8 +58,8 @@ export default function AnalyticsPage(): JSX.Element {
 
   return (
     <div className="analytics-page">
-      <h1>Analytics</h1>
       <AdminNav />
+      <h1>Analytics</h1>
       {loading && <p>Loading analytics...</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {!loading && !error && (

--- a/payments.tsx
+++ b/payments.tsx
@@ -101,8 +101,8 @@ const PaymentsPage: React.FC = () => {
 
   return (
     <div className="payments-page">
-      <h1>Payments</h1>
       <AdminNav />
+      <h1>Payments</h1>
       {error && <div className="error">{error}</div>}
       {loading ? (
         <div>Loading payments...</div>

--- a/src/AdminNav.tsx
+++ b/src/AdminNav.tsx
@@ -9,12 +9,14 @@ const adminLinks = [
 export default function AdminNav(): JSX.Element {
   return (
     <nav className="admin-nav" aria-label="Admin navigation">
-      <ul>
+      <ul className="admin-nav-list">
         {adminLinks.map(link => (
           <li key={link.to}>
             <NavLink
               to={link.to}
-              className={({ isActive }) => (isActive ? 'active' : undefined)}
+              className={({ isActive }) =>
+                `admin-nav-link${isActive ? ' admin-nav-link-active' : ''}`
+              }
             >
               {link.label}
             </NavLink>

--- a/src/global.scss
+++ b/src/global.scss
@@ -392,6 +392,34 @@ hr {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
+/* Admin navigation */
+.admin-nav {
+  margin-bottom: var(--spacing-md);
+}
+
+.admin-nav-list {
+  display: flex;
+  gap: var(--spacing-lg);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.admin-nav-link {
+  color: var(--color-text);
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: 4px;
+  transition: background-color var(--transition-duration) var(--transition-ease),
+    color var(--transition-duration) var(--transition-ease);
+  font-weight: 500;
+}
+
+.admin-nav-link:hover,
+.admin-nav-link-active {
+  background-color: rgba(255, 255, 255, 0.2);
+  color: var(--color-bg);
+}
+
 .layout-menu-button {
   display: none;
 }

--- a/users.tsx
+++ b/users.tsx
@@ -2,13 +2,13 @@ import { useEffect, useState } from 'react'
 import AdminNav from './src/AdminNav'
 import { useUser } from './src/lib/UserContext'
 import { isAdmin } from './src/lib/isAdmin'
+import { authFetch } from './authFetch'
 
 interface User {
   id: string
   name: string | null
   email: string
   role: string
-  status: string | null
   created_at: string
 }
 
@@ -24,8 +24,7 @@ export default function UsersPage(): JSX.Element {
   useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
-    fetch('/api/users?skip=0&limit=100', {
-      credentials: 'include',
+    authFetch('/api/users?skip=0&limit=100', {
       signal: controller.signal,
     })
       .then(res => {
@@ -33,7 +32,8 @@ export default function UsersPage(): JSX.Element {
         return res.json()
       })
       .then(json => {
-        setUsers(json.data as User[])
+        const data = Array.isArray(json.data) ? (json.data as User[]) : []
+        setUsers(data)
       })
       .catch(err => {
         if (err.name !== 'AbortError') {
@@ -46,8 +46,8 @@ export default function UsersPage(): JSX.Element {
 
   return (
     <div className="admin-users-page">
-      <h1>Users</h1>
       <AdminNav />
+      <h1>Users</h1>
       {loading && <p>Loading users...</p>}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {!loading && !error && (
@@ -57,7 +57,6 @@ export default function UsersPage(): JSX.Element {
               <th>Name</th>
               <th>Email</th>
               <th>Role</th>
-              <th>Status</th>
               <th>Date Joined</th>
             </tr>
           </thead>
@@ -68,13 +67,12 @@ export default function UsersPage(): JSX.Element {
                   <td>{u.name || ''}</td>
                   <td>{u.email}</td>
                   <td>{u.role}</td>
-                  <td>{u.status || ''}</td>
                   <td>{new Date(u.created_at).toLocaleDateString()}</td>
                 </tr>
               ))
             ) : (
               <tr>
-                <td colSpan={5}>No users found.</td>
+                <td colSpan={4}>No users found.</td>
               </tr>
             )}
           </tbody>


### PR DESCRIPTION
## Summary
- fetch user list with auth and render as table on admin Users page
- add styled admin navigation and place across top of admin pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ec6d39e8c832794e5e13c7ee993ab