### PR TITLE
style: enhance admin tables and analytics layout

### DIFF
--- a/analytics.tsx
+++ b/analytics.tsx
@@ -56,6 +56,26 @@ export default function AnalyticsPage(): JSX.Element {
     aiProcesses: data.map(d => d.aiProcesses),
   }
 
+  const latest =
+    data[data.length - 1] || ({
+      day: '',
+      kanbans: 0,
+      todoLists: 0,
+      todos: 0,
+      mindmaps: 0,
+      nodes: 0,
+      aiProcesses: 0,
+    } as AnalyticsPoint)
+
+  const metrics: { key: keyof typeof series; label: string }[] = [
+    { key: 'kanbans', label: 'Kanban Boards' },
+    { key: 'todoLists', label: 'Todo Lists' },
+    { key: 'todos', label: 'Todos' },
+    { key: 'mindmaps', label: 'Mindmaps' },
+    { key: 'nodes', label: 'Nodes' },
+    { key: 'aiProcesses', label: 'AI Processes' },
+  ]
+
   return (
     <div className="analytics-page">
       <AdminNav />
@@ -64,30 +84,13 @@ export default function AnalyticsPage(): JSX.Element {
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {!loading && !error && (
         <div className="analytics-grid">
-          <div>
-            <h2>Kanban Boards</h2>
-            <Sparkline data={series.kanbans} />
-          </div>
-          <div>
-            <h2>Todo Lists</h2>
-            <Sparkline data={series.todoLists} />
-          </div>
-          <div>
-            <h2>Todos</h2>
-            <Sparkline data={series.todos} />
-          </div>
-          <div>
-            <h2>Mindmaps</h2>
-            <Sparkline data={series.mindmaps} />
-          </div>
-          <div>
-            <h2>Nodes</h2>
-            <Sparkline data={series.nodes} />
-          </div>
-          <div>
-            <h2>AI Processes</h2>
-            <Sparkline data={series.aiProcesses} />
-          </div>
+          {metrics.map(m => (
+            <div key={m.key} className="analytic-tile">
+              <h2>{m.label}</h2>
+              <p className="tile-value">{latest[m.key]}</p>
+              <Sparkline data={series[m.key]} />
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -4035,3 +4035,59 @@ hr {
     margin: 0;
   }
 }
+
+/* Admin Users Table */
+.users-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.users-table th,
+.users-table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+}
+
+.users-table thead {
+  background: var(--color-primary-light);
+  color: #333;
+}
+
+.users-table tbody tr:nth-child(even) {
+  background: #fff7e6;
+}
+
+/* Analytics page */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+@media (min-width: 700px) {
+  .analytics-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.analytic-tile {
+  background: #fff;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.analytic-tile h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.tile-value {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin: 0 0 1rem;
+}


### PR DESCRIPTION
## Summary
- polish admin users table with spacing and soft alternating row colors
- revamp analytics page with tiled metrics and a responsive two-column grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ecd7693588327aa60b4465fa822f4