### PR TITLE
Expand todo list widths

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -2545,7 +2545,7 @@ hr {
 }
 
 .todo-list {
-  width: min(600px, 80%);
+  width: min(700px, 80%);
   margin: 0 auto;
   display: flex;
   flex-direction: column;
@@ -2616,6 +2616,7 @@ hr {
 }
 
 .todo-item {
+  width: min(700px, 80%);
   display: flex;
   align-items: center;
   padding: 1rem;
@@ -3828,7 +3829,7 @@ hr {
 }
 
 .todo-block {
-  width: min(600px, 80%);
+  width: min(700px, 80%);
   margin: 0 auto 0.5rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- widen todo list container and items by 100px
- increase todo block width for each task

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed14b75e08327bc97dd5a6d84ae6f