### PR TITLE
Improve admin analytics charts and totals

### DIFF
--- a/analytics.tsx
+++ b/analytics.tsx
@@ -14,12 +14,29 @@ interface AnalyticsPoint {
   aiProcesses: number
 }
 
+interface AnalyticsTotals {
+  kanbans: number
+  todoLists: number
+  todos: number
+  mindmaps: number
+  nodes: number
+  aiProcesses: number
+}
+
 export default function AnalyticsPage(): JSX.Element {
   const { user } = useUser()
   if (!isAdmin(user)) {
     return <p>Forbidden</p>
   }
   const [data, setData] = useState<AnalyticsPoint[]>([])
+  const [totals, setTotals] = useState<AnalyticsTotals>({
+    kanbans: 0,
+    todoLists: 0,
+    todos: 0,
+    mindmaps: 0,
+    nodes: 0,
+    aiProcesses: 0,
+  })
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -37,6 +54,7 @@ export default function AnalyticsPage(): JSX.Element {
       })
       .then(json => {
         setData(json.data as AnalyticsPoint[])
+        setTotals(json.totals as AnalyticsTotals)
       })
       .catch(err => {
         if (err.name !== 'AbortError') {
@@ -55,17 +73,6 @@ export default function AnalyticsPage(): JSX.Element {
     nodes: data.map(d => d.nodes),
     aiProcesses: data.map(d => d.aiProcesses),
   }
-
-  const latest =
-    data[data.length - 1] || ({
-      day: '',
-      kanbans: 0,
-      todoLists: 0,
-      todos: 0,
-      mindmaps: 0,
-      nodes: 0,
-      aiProcesses: 0,
-    } as AnalyticsPoint)
 
   const metrics: { key: keyof typeof series; label: string }[] = [
     { key: 'kanbans', label: 'Kanban Boards' },
@@ -87,8 +94,8 @@ export default function AnalyticsPage(): JSX.Element {
           {metrics.map(m => (
             <div key={m.key} className="analytic-tile">
               <h2>{m.label}</h2>
-              <p className="tile-value">{latest[m.key]}</p>
-              <Sparkline data={series[m.key]} />
+              <p className="tile-value">{totals[m.key]}</p>
+              <Sparkline data={series[m.key]} height={60} showArea />
             </div>
           ))}
         </div>

--- a/netlify/functions/analytics.ts
+++ b/netlify/functions/analytics.ts
@@ -78,8 +78,23 @@ export const handler = async (
       `,
       [startDate.toISOString(), endDate.toISOString()]
     )
+    const { rows: totalRows } = await client.query(
+      `
+      SELECT
+        (SELECT COUNT(*) FROM kanban_boards) AS "kanbans",
+        (SELECT COUNT(*) FROM todo_lists) AS "todoLists",
+        (SELECT COUNT(*) FROM todos) AS "todos",
+        (SELECT COUNT(*) FROM mindmaps) AS "mindmaps",
+        (SELECT COUNT(*) FROM nodes) AS "nodes",
+        (SELECT COUNT(*) FROM ai_usage) AS "aiProcesses"
+      `
+    )
 
-    return { statusCode: 200, headers, body: JSON.stringify({ data: rows }) }
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ data: rows, totals: totalRows[0] }),
+    }
   } catch (err) {
     console.error('analytics error', err)
     return { statusCode: 500, headers, body: JSON.stringify({ error: 'Internal Server Error' }) }

--- a/src/Sparkline.tsx
+++ b/src/Sparkline.tsx
@@ -5,6 +5,7 @@ interface SparklineProps {
   width?: number
   height?: number
   color?: string
+  showArea?: boolean
 }
 
 export default function Sparkline({
@@ -12,15 +13,17 @@ export default function Sparkline({
   width = 100,
   height = 40,
   color = '#38bdf8',
+  showArea = false,
 }: SparklineProps) {
   const max = Math.max(...data, 1)
-  const points = data
+  const linePoints = data
     .map((d, i) => {
-      const x = (i / (data.length - 1)) * width
+      const x = (i / Math.max(data.length - 1, 1)) * width
       const y = height - (d / max) * height
       return `${x},${y}`
     })
     .join(' ')
+  const areaPoints = `0,${height} ${linePoints} ${width},${height}`
 
   return (
     <svg
@@ -30,12 +33,29 @@ export default function Sparkline({
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="none"
     >
+      <line
+        x1="0"
+        y1={height}
+        x2={width}
+        y2={height}
+        stroke={color}
+        strokeWidth="1"
+        opacity="0.2"
+      />
+      {showArea && (
+        <polygon
+          fill={color}
+          fillOpacity="0.1"
+          stroke="none"
+          points={areaPoints}
+        />
+      )}
       <polyline
         fill="none"
         stroke={color}
         strokeWidth="3"
         strokeLinecap="round"
-        points={points}
+        points={linePoints}
       />
     </svg>
   )


### PR DESCRIPTION
## Summary
- show global usage totals for kanbans, todos, mindmaps, nodes and AI processes
- enhance sparkline charts with area fill and baseline for clearer trends
- analytics API aggregates totals across all users for admin view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed1c1023c8327b4c5c54d971d5d44