### PR TITLE
Ensure sign-out fully clears session

### DIFF
--- a/src/SidebarNav.tsx
+++ b/src/SidebarNav.tsx
@@ -39,8 +39,9 @@ export default function SidebarNav(): JSX.Element {
   const handleSignOut = () => {
     document.cookie = 'token=; Max-Age=0; path=/'
     document.cookie = 'session=; Max-Age=0; path=/'
+    sessionStorage.clear()
     setUser(null)
-    navigate('/login')
+    navigate('/login', { replace: true })
   }
 
   const handleUpgrade = async () => {

--- a/src/header.tsx
+++ b/src/header.tsx
@@ -219,8 +219,11 @@ const Header = (): JSX.Element => {
                     onClick={() => {
                       document.cookie = 'token=; Max-Age=0; path=/'
                       document.cookie = 'session=; Max-Age=0; path=/'
+                      sessionStorage.clear()
                       setUser(null)
-                      handleNavSelect('/login')
+                      setProfileMenuOpen(false)
+                      setMenuOpen(false)
+                      navigate('/login', { replace: true })
                     }}
                   >
                     Sign Out


### PR DESCRIPTION
## Summary
- Clear session storage and cookies on sign out
- Replace browser history and reset UI state when signing out

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed3da2f98832789cb6fd80ae3dd25