### PR TITLE
Add client-side create limits for mindmaps, todos, and boards

### DIFF
--- a/dashboard.tsx
+++ b/dashboard.tsx
@@ -6,6 +6,7 @@ import LoadingSkeleton from './loadingskeleton'
 import FaintMindmapBackground from './FaintMindmapBackground'
 import MindmapArm from './MindmapArm'
 import Sparkline from './src/Sparkline'
+import { checkLimit } from './src/lib/checkLimit'
 
 interface MapItem {
   id: string
@@ -78,6 +79,9 @@ export default function DashboardPage(): JSX.Element {
 
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
+    const resource = createType === 'map' ? 'mindmap' : 'todo'
+    const ok = await checkLimit(resource)
+    if (!ok) return
     try {
       if (createType === 'map') {
         await fetch('/.netlify/functions/mindmaps', {
@@ -107,6 +111,9 @@ export default function DashboardPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
+    const resource = createType === 'map' ? 'mindmap' : 'todo'
+    const ok = await checkLimit(resource)
+    if (!ok) return
     try {
       if (createType === 'map') {
         await fetch('/.netlify/functions/ai-create-mindmap', {

--- a/src/DashboardPage.tsx
+++ b/src/DashboardPage.tsx
@@ -16,6 +16,7 @@ import {
   validateBoards,
   validateNodes,
 } from './apiValidators'
+import { checkLimit } from './lib/checkLimit'
 
 interface TodoItem {
   id: string
@@ -123,6 +124,9 @@ export default function DashboardPage(): JSX.Element {
 
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
+    const resource = createType === 'map' ? 'mindmap' : createType === 'todo' ? 'todo' : 'board'
+    const ok = await checkLimit(resource)
+    if (!ok) return
     try {
       if (createType === 'map') {
         const res = await fetch('/.netlify/functions/mindmaps', {
@@ -173,6 +177,9 @@ export default function DashboardPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
+    const resource = createType === 'map' ? 'mindmap' : createType === 'todo' ? 'todo' : 'board'
+    const ok = await checkLimit(resource)
+    if (!ok) return
     if (aiUsage >= aiLimit) {
       alert('AI automation limit reached')
       return

--- a/src/KanbanBoardsPage.tsx
+++ b/src/KanbanBoardsPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
+import { checkLimit } from './lib/checkLimit'
 
 interface BoardItem {
   id: string
@@ -53,6 +54,8 @@ export default function KanbanBoardsPage(): JSX.Element {
 
   const handleSave = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
+    const ok = await checkLimit('board')
+    if (!ok) return
     try {
       const res = await authFetch('/.netlify/functions/kanban-boards', {
         method: 'POST',
@@ -81,6 +84,8 @@ export default function KanbanBoardsPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
+    const ok = await checkLimit('board')
+    if (!ok) return
     setAiLoading(true)
     try {
       const res = await fetch('/api/ai-create-board', {

--- a/src/MindmapsPage.tsx
+++ b/src/MindmapsPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import LoadingSkeleton from '../loadingskeleton'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
+import { checkLimit } from './lib/checkLimit'
 
 interface MapItem {
   id: string
@@ -63,6 +64,8 @@ export default function MindmapsPage(): JSX.Element {
 
   const handleCreate = async (e: FormEvent): Promise<void> => {
     e.preventDefault()
+    const ok = await checkLimit('mindmap')
+    if (!ok) return
     try {
       const res = await fetch('/.netlify/functions/mindmaps', {
         method: 'POST',
@@ -86,6 +89,8 @@ export default function MindmapsPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
+    const ok = await checkLimit('mindmap')
+    if (!ok) return
     setAiLoading(true)
     try {
       const res = await fetch('/api/ai-create-mindmap', {

--- a/src/TodosPage.tsx
+++ b/src/TodosPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import FaintMindmapBackground from '../FaintMindmapBackground'
 import MindmapArm from '../MindmapArm'
 import LoadingSkeleton from '../loadingskeleton'
+import { checkLimit } from './lib/checkLimit'
 
 interface TodoItem {
   id: string
@@ -53,6 +54,8 @@ export default function TodosPage(): JSX.Element {
     e.preventDefault()
     const title = form.title.trim()
     if (!title) return
+    const ok = await checkLimit('todo')
+    if (!ok) return
     const res = await fetch('/.netlify/functions/todo-lists', {
       method: 'POST',
       credentials: 'include',
@@ -97,6 +100,8 @@ export default function TodosPage(): JSX.Element {
   }
 
   const handleAiCreate = async (): Promise<void> => {
+    const ok = await checkLimit('todo')
+    if (!ok) return
     setAiLoading(true)
     try {
       const res = await fetch('/api/ai-create-todo', {

--- a/src/lib/checkLimit.ts
+++ b/src/lib/checkLimit.ts
@@ -1,0 +1,49 @@
+import { LIMIT_MINDMAPS, LIMIT_TODO_LISTS, LIMIT_KANBAN_BOARDS, LIMIT_MINDMAPS_TRIAL, LIMIT_TODO_LISTS_TRIAL, LIMIT_KANBAN_BOARDS_TRIAL } from '../constants'
+
+export type ResourceType = 'mindmap' | 'todo' | 'board'
+
+export async function checkLimit(resource: ResourceType): Promise<boolean> {
+  try {
+    const [usageRes, statusRes] = await Promise.all([
+      fetch('/.netlify/functions/usage', { credentials: 'include' }),
+      fetch('/.netlify/functions/user-status', { credentials: 'include' })
+    ])
+    if (!usageRes.ok || !statusRes.ok) return true
+
+    const usage = await usageRes.json()
+    const statusJson = await statusRes.json()
+    const isTrial = statusJson?.data?.subscription_status === 'trialing'
+
+    let count = 0
+    let limit = 0
+    let label = ''
+
+    switch (resource) {
+      case 'mindmap':
+        count = usage.mindmaps ?? 0
+        limit = isTrial ? LIMIT_MINDMAPS_TRIAL : LIMIT_MINDMAPS
+        label = 'Mindmap'
+        break
+      case 'todo':
+        count = usage.todoLists ?? 0
+        limit = isTrial ? LIMIT_TODO_LISTS_TRIAL : LIMIT_TODO_LISTS
+        label = 'Todo list'
+        break
+      case 'board':
+        count = usage.boards ?? 0
+        limit = isTrial ? LIMIT_KANBAN_BOARDS_TRIAL : LIMIT_KANBAN_BOARDS
+        label = 'Kanban board'
+        break
+    }
+
+    if (count >= limit) {
+      alert(`${label} limit reached`)
+      return false
+    }
+
+    return true
+  } catch {
+    return true
+  }
+}
+


### PR DESCRIPTION
## Summary
- add shared `checkLimit` helper to fetch usage & user status
- use limit checks before creating mindmaps, todo lists, kanban boards, and AI variants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ed89a535c8327b63a5ba37d5405c2