### PR TITLE
Rename Stripe webhook and enforce POST method

### DIFF
--- a/netlify/functions/stripeWebhook.ts
+++ b/netlify/functions/stripeWebhook.ts
@@ -5,6 +5,9 @@ import { jsonResponse } from '../lib/response.js'
 import { getClient } from './db-client.js'
 
 export const handler = async (event: HandlerEvent, _context: HandlerContext) => {
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { success: false, message: 'Method Not Allowed' })
+  }
   const signature = event.headers['stripe-signature'] || event.headers['Stripe-Signature']
   if (!signature) {
     return jsonResponse(400, { success: false, message: 'Missing Stripe signature' })


### PR DESCRIPTION
## Summary
- rename Netlify webhook function to `stripeWebhook`
- ensure webhook only accepts POST requests and responds with 405 otherwise

## Testing
- `npm run compile:functions`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891424681e0832798d71dedd21caaaa