### PR TITLE
style: make homepage get started button blue

### DIFF
--- a/homepage.tsx
+++ b/homepage.tsx
@@ -104,7 +104,7 @@ const Homepage: React.FC = (): JSX.Element => {
           <p>
             Mindmaps connect todos to boards, turning ideas into executed vision.
           </p>
-          <Link to="/purchase" className="btn">
+          <Link to="/purchase" className="btn btn-blue">
             Get Started
           </Link>
         </motion.div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -281,6 +281,17 @@ $spacers: (
   }
 }
 
+.btn-blue {
+  background-color: blue;
+  border-color: blue;
+  color: var(--color-text-inverse);
+  &:hover {
+    background-color: darkblue;
+    border-color: darkblue;
+    color: var(--color-text-inverse);
+  }
+}
+
 @keyframes fade-in {
   from { opacity: 0; }
   to { opacity: 1; }


### PR DESCRIPTION
## Summary
- add `.btn-blue` style for blue background and hover
- apply blue styling to homepage Get Started link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895438066d48327a356e261a3d96494